### PR TITLE
Fix/daemon state log decluttering

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <p align="center">
   <a href="https://github.com/xinity-ai/xinity-ai/actions/workflows/tests.yml"><img src="https://github.com/xinity-ai/xinity-ai/actions/workflows/tests.yml/badge.svg" alt="CI" /></a>
   <a href="#licensing"><img src="https://img.shields.io/badge/license-Apache%202.0%20%2F%20ELv2-blue" alt="License" /></a>
-  <a href="https://discord.gg/7f66jBpaYR"><img src="https://img.shields.io/badge/Discord-Join%20Us-5865F2?logo=discord&logoColor=white" alt="Discord" /></a>
+  <a href="https://get.xinity.ai/discord"><img src="https://img.shields.io/badge/Discord-Join%20Us-5865F2?logo=discord&logoColor=white" alt="Discord" /></a>
   <a href="https://github.com/xinity-ai/xinity-ai/stargazers"><img src="https://img.shields.io/github/stars/xinity-ai/xinity-ai?style=social" alt="GitHub Stars" /></a>
   <br/>
   <img src="https://img.shields.io/badge/🇪🇺_Made_in_Europe-blue" alt="Made in Europe" />

--- a/packages/xinity-ai-daemon/src/modules/db-sync.ts
+++ b/packages/xinity-ai-daemon/src/modules/db-sync.ts
@@ -18,6 +18,8 @@ export { groupInstallationsByDriver };
 
 const log = rootLogger.child({ name: "db-sync" });
 
+let previousInstallationsSnapshot: string | null = null;
+
 export function dbSync(){
   return createWorkflowCoordinator({
     periodMs: env.SYNC_INTERVAL_MS,
@@ -74,7 +76,7 @@ function syncUnsupportedDriver$(
  * Non-ollama drivers are explicitly no-ops for now.
  */
 function sync(): Observable<void> {
-  log.info("Performing sync");
+  log.debug("Performing sync");
 
   return defer(() => from(getNodeId())).pipe(
     switchMap((nodeID) =>
@@ -93,10 +95,12 @@ function sync(): Observable<void> {
           buckets.push({ driver, installations: [] });
         }
       }
-      log.info(
-        { models: installations.map(({ driver, model, estCapacity }) => ({ driver, model, estCapacity })) },
-        "Current installations"
-      );
+      const models = installations.map(({ driver, model, estCapacity }) => ({ driver, model, estCapacity }));
+      const snapshot = JSON.stringify(models);
+      if (snapshot !== previousInstallationsSnapshot) {
+        previousInstallationsSnapshot = snapshot;
+        log.info({ models }, "Installations changed");
+      }
       return from(buckets).pipe(
         mergeMap(({ driver, installations: driverInstallations }) => {
           if (driver === "ollama") {


### PR DESCRIPTION
## Description

This pull request fixes an issue we noticed where low importance logs clutter up the logs of the xinity ai daemon. 
The main change is that the frequently ocurring "synch" log is now demoted to debug status, and can be easily hidden, and the detailed list of available installations is just shown initially or when they change.

Aside that it also updates an outdated discord link in the readme

## Type of change

Bug fix

## Testing

No tests are impacted

## Checklist

- [x] Tests pass locally (`bun test`), or no testable code was changed
- [x] New or changed behavior is covered by tests, or this change does not require tests
- [x] Documentation is updated, or no user-facing behavior or configuration was changed
- [x] There are no breaking changes, or they are marked with `!` in the commit type and described above
- [x] No security-sensitive changes (authentication, credentials, input handling), or they have been reviewed
- [x] No new dependencies were added, or they have been reviewed for license and maintenance status