### PR TITLE
fix(dashboard): fixed org activation flow

### DIFF
--- a/packages/xinity-ai-dashboard/src/lib/server/auth-server.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/auth-server.ts
@@ -169,7 +169,9 @@ export const auth = betterAuth({
     after: sendWelcomeNotification,
   },
   trustedOrigins: serverEnv.NODE_ENV === "development" ? ["*"] : [
+    serverEnv.ORIGIN,
     "*.google.com",
+    ...(serverEnv.TRUSTED_ORIGINS?.split(",").map(s => s.trim()).filter(Boolean) ?? []),
   ],
 
   plugins: [

--- a/packages/xinity-ai-dashboard/src/lib/server/env-schema.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/env-schema.ts
@@ -27,4 +27,5 @@ export const dashboardEnvSchema = z.object({
   S3_REGION: z.string().default("us-east-1").describe("S3 region").meta(expert()),
   MCP_ENABLED: z.stringbool().default(true).describe("Enable the /mcp Model Context Protocol endpoint"),
   LICENSE_KEY: z.string().optional().describe("License key for unlocking paid features (Ed25519-signed token)").meta(secret()),
+  TRUSTED_ORIGINS: z.string().optional().describe("Comma-separated additional trusted origins for CSRF validation behind reverse proxies").meta(expert()),
 });

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/+layout.server.ts
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/+layout.server.ts
@@ -30,7 +30,7 @@ export const load: LayoutServerLoad = async ({ request, url, cookies }) => {
   }
 
   // Auto-activate the first organization if user has orgs but none is active
-  if (!session.session.activeOrganizationId) {
+  if (!session.session.activeOrganizationId && !url.searchParams.has('_orgActivated')) {
     let autoActivated = false;
     try {
       const organizations = await auth.api.listOrganizations({
@@ -48,10 +48,24 @@ export const load: LayoutServerLoad = async ({ request, url, cookies }) => {
       log.warn({ err }, "Failed to auto-activate organization");
     }
     if (autoActivated) {
-      // Clear the stale session cookie cache and redirect so the next
-      // request reads the updated session from the DB.
-      cookies.delete('better-auth.session_data', { path: '/' });
-      redirect(302, url.pathname + url.search);
+      // Clear the stale session cookie cache so the next request does a DB lookup.
+      // Better Auth prefixes cookie names with __Secure- when baseURL is HTTPS.
+      const prefix = serverEnv.ORIGIN.startsWith("https://") ? "__Secure-" : "";
+      const cacheCookieName = `${prefix}better-auth.session_data`;
+      cookies.delete(cacheCookieName, { path: '/' });
+      // Also delete any chunked variants (e.g. .0, .1, …)
+      const cookieHeader = request.headers.get("cookie") ?? "";
+      for (const part of cookieHeader.split(";")) {
+        const name = part.trim().split("=")[0];
+        if (name && name.startsWith(cacheCookieName + ".")) {
+          cookies.delete(name, { path: '/' });
+        }
+      }
+
+      // Redirect with a guard param to prevent loops
+      const redirectUrl = new URL(url);
+      redirectUrl.searchParams.set('_orgActivated', '1');
+      redirect(302, redirectUrl.pathname + redirectUrl.search);
     }
   }
 


### PR DESCRIPTION
## Description

This PR fixes a simple issue that was recently found.
When signing into the dashboard, by default no organization is active, even if the user in question does have a organization. Therefore there is a auto org activation flow built into the dashboard.  
This activation flow had two problems: 
- It needs to delete a cookie that handles the user session. Thats because to activate the organization, the session needs to be refreshed. When the dashboard was running under https, this cookie has a different name. We missed this in the flow so far, and corrected it in this PR.
- The flow reloads the page, to immediately get a fresh session, reset the cookie, and show the correct UI state right away. The problem was that when due to the previous issue the cookie could not be deleted, this reload would be triggered over and over again. When running behind a reverse proxy, this resulted in a too many redirects error, blocking the page entirely until the 5m cookie expiration time ran out, at which point it would work until the next sign in.

As a related improvement, trustedOrigins was improved by making the ORIGIN of the dashboard itself explicitly part of it by default, and making it possible to specify extra origins.

## Type of change

Bug fix

## Testing

Testing this would require significant additional infrastructure during test runs (a reverse proxy, running with https during tests), which we will avoid for this edge case.

## Checklist

- [x] Tests pass locally (`bun test`), or no testable code was changed
- [ ] New or changed behavior is covered by tests, or this change does not require tests
- [x] Documentation is updated, or no user-facing behavior or configuration was changed
- [x] There are no breaking changes, or they are marked with `!` in the commit type and described above
- [ ] No security-sensitive changes (authentication, credentials, input handling), or they have been reviewed
- [x] No new dependencies were added, or they have been reviewed for license and maintenance status