### PR TITLE
docs(dashboard): mcp integration

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,6 +88,8 @@ The dashboard is the central management surface. It serves three distinct roles 
 
 - *Notification scheduler:* Polls every 5 minutes and fires notifications based on system state transitions: deployment readiness or failure, node online/offline status changes, capacity warnings (when usage exceeds 80% of available capacity), and a weekly usage report (sent Monday mornings with deployment counts, node counts, API call volumes, and top models).
 
+**MCP server:** The dashboard exposes a [Model Context Protocol](https://modelcontextprotocol.io) endpoint at `/mcp`, allowing AI assistants (Claude, Cursor, Windsurf) to manage deployments, applications, API keys, and other resources via natural language. The MCP server dynamically generates its tool list from oRPC procedures at startup — any procedure not explicitly excluded is automatically available as an MCP tool. Security-sensitive operations (credential management, SSO configuration, organization deletion, instance admin) are excluded. Authentication uses the same API keys as the REST API. The endpoint can be disabled with `MCP_ENABLED=false`.
+
 Auth is handled by Better Auth with plugins for 2FA (TOTP), passkeys (WebAuthn), SSO (OIDC/SAML), API keys, and multi-tenant organizations. Five roles control access: owner, admin, member, labeler, and viewer.
 
 ### Gateway

--- a/packages/xinity-ai-dashboard/README.md
+++ b/packages/xinity-ai-dashboard/README.md
@@ -53,6 +53,25 @@ Docs and component list: https://shadcn-svelte.com/
 - `src/params`: custom route param matchers
 - `static`: static assets served as-is
 
+## MCP Server
+
+The dashboard exposes a [Model Context Protocol](https://modelcontextprotocol.io) endpoint at `/mcp`, enabling AI assistants to manage resources through natural language. It is enabled by default and can be disabled with `MCP_ENABLED=false`.
+
+Configure your MCP client to connect:
+
+```json
+{
+  "mcpServers": {
+    "xinity-ai": {
+      "url": "https://your-dashboard/mcp",
+      "headers": { "Authorization": "Bearer sk_..." }
+    }
+  }
+}
+```
+
+See the in-app documentation at `/docs/access-methods` for detailed setup instructions per client (Claude Desktop, Cursor, Windsurf, Claude Code CLI).
+
 ## Testing
 
 ```bash

--- a/packages/xinity-ai-dashboard/README.md
+++ b/packages/xinity-ai-dashboard/README.md
@@ -70,7 +70,7 @@ Configure your MCP client to connect:
 }
 ```
 
-See the in-app documentation at `/docs/access-methods` for detailed setup instructions per client (Claude Desktop, Cursor, Windsurf, Claude Code CLI).
+See the in-app documentation at `/docs/access-methods` for detailed setup instructions per client (Claude Desktop, Cursor, Windsurf, Claude Code CLI). For implementation details, see the [MCP developer guide](docs/mcp.md).
 
 ## Testing
 
@@ -102,7 +102,7 @@ The dashboard tests require a running application and its dependencies. Before r
    bun run preview
    ```
 
-The tests expect the dashboard at `http://localhost:5173`. On first run, the test setup automatically creates test users and organizations via the API.
+The tests expect the dashboard at `http://localhost:5173`. On first run, the test setup automatically creates test users and organizations via the API. See [tests/TEST_PLAN.md](tests/TEST_PLAN.md) for the full test plan.
 
 ## License
 

--- a/packages/xinity-ai-dashboard/docs/mcp.md
+++ b/packages/xinity-ai-dashboard/docs/mcp.md
@@ -1,0 +1,78 @@
+# MCP Server - Developer Guide
+
+The dashboard exposes a [Model Context Protocol](https://modelcontextprotocol.io) endpoint at `/mcp` that lets AI assistants call management operations via natural language. This document covers how it works and how to extend it.
+
+## How tools are generated
+
+`src/lib/server/mcp.ts` exports a `buildToolList()` function that recursively walks the oRPC router at module load time. Every procedure in the router becomes an MCP tool unless explicitly excluded. The tool list is built once and reused for all requests.
+
+Each tool gets:
+- **name**: the procedure's path segments joined with underscores (e.g. `apiKey_create`)
+- **description**: from the procedure's `.route({ summary })` or `.route({ description })`, falling back to the path
+- **inputSchema**: the procedure's Zod input schema converted to JSON Schema via `toJSONSchema()`
+
+Because the tool list is derived automatically, adding a new oRPC procedure makes it available via MCP with no extra work.
+
+## Excluding a procedure from MCP
+
+Chain `.meta({ mcp: false })` on the procedure definition:
+
+```typescript
+export const myProcedure = withOrganization
+  .meta({ mcp: false })
+  .route({ method: "POST", path: "/my-thing", summary: "Do something" })
+  .input(z.object({ ... }))
+  .handler(async ({ input, context }) => {
+    // ...
+  });
+```
+
+The `ProcedureMeta` type is defined in `src/lib/server/orpc/root.ts`:
+
+```typescript
+export type ProcedureMeta = {
+  /** Set to `false` to exclude this procedure from the MCP server endpoint. Defaults to included. */
+  mcp?: boolean;
+};
+```
+
+### When to exclude
+
+Exclude procedures that:
+- **Manage credentials** (passwords, passkeys, dashboard API keys) - these should only be changed through the UI or regular api with proper session context
+- **Are destructive and irreversible** (e.g. organization deletion)
+- **Require multi-step UI flows** (onboarding, SSO provider setup)
+- **Are dev-only** (e.g. adding example data)
+- **Require instance admin privileges** - these operate outside the normal org-scoped RBAC model
+
+## Authentication
+
+The endpoint at `src/routes/mcp/+server.ts` accepts API keys via two headers (checked in order):
+
+1. `Authorization: Bearer sk_...`
+2. `x-api-key: sk_...`
+
+When a tool is called, `callMcpTool()` creates a synthetic `Request` with the API key in the `x-api-key` header and passes it through the full oRPC middleware chain (`withAuth` -> `withOrganization` -> `requirePermission`). This means MCP tool calls go through the same authentication and RBAC enforcement as regular API requests.
+
+The `withOrganization` middleware resolves the organization from the API key's metadata, since MCP sessions don't have an active organization set in the browser session.
+
+## Schema mapping
+
+Zod schemas are converted to JSON Schema using the `toJSONSchema()` function from the `zod` package. One notable override:
+
+- `z.date()` is mapped to `{ type: "string", format: "date-time" }` so MCP clients know to pass ISO 8601 strings (e.g. `"2025-01-15T00:00:00Z"`) rather than getting an opaque `{}` schema.
+
+If a procedure has no input schema, it defaults to `{ type: "object", properties: {} }`.
+
+## Disabling the endpoint
+
+Set `MCP_ENABLED=false` in the environment. The variable is defined in `src/lib/server/env-schema.ts` and defaults to `true`. When disabled, the `/mcp` endpoint returns 404.
+
+## Key files
+
+| File | Role |
+|------|------|
+| `src/lib/server/mcp.ts` | Tool registry (`buildToolList`) and execution (`callMcpTool`) |
+| `src/routes/mcp/+server.ts` | HTTP endpoint, JSON-RPC message handling, authentication |
+| `src/lib/server/orpc/root.ts` | `ProcedureMeta` type, shared middleware chain |
+| `src/lib/server/env-schema.ts` | `MCP_ENABLED` environment variable definition |

--- a/packages/xinity-ai-dashboard/e2e/api/mcp.test.ts
+++ b/packages/xinity-ai-dashboard/e2e/api/mcp.test.ts
@@ -1,0 +1,171 @@
+import { describe, test, expect, beforeAll } from "bun:test";
+import { existsSync, readFileSync } from "fs";
+import { ensureE2EReady } from "../guard";
+import { getSetupState } from "./api-helpers";
+import { BASE_URL, STORAGE_STATE, type StorageState } from "../utils/test-data";
+
+const MCP_URL = `${BASE_URL}/mcp`;
+
+// ─── Helpers ────────────────────────────────────────────────────────
+
+function jsonRpc(method: string, params?: Record<string, unknown>, id: number = 1) {
+  return { jsonrpc: "2.0", id, method, params };
+}
+
+async function mcpFetch(body: unknown, apiKey?: string): Promise<Response> {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
+  return fetch(MCP_URL, { method: "POST", headers, body: JSON.stringify(body) });
+}
+
+async function mcpJson(body: unknown, apiKey?: string): Promise<Record<string, unknown>> {
+  const res = await mcpFetch(body, apiKey);
+  return (await res.json()) as Record<string, unknown>;
+}
+
+/** Create a dashboard API key for the given user session cookies. */
+async function createDashboardApiKey(cookies: string, orgId: string, name: string): Promise<string> {
+  const res = await fetch(`${BASE_URL}/api/account/dashboard-api-keys`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Origin: BASE_URL,
+      Cookie: cookies,
+    },
+    body: JSON.stringify({ name, organizationId: orgId }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Failed to create dashboard API key: ${res.status} ${body}`);
+  }
+
+  const data = (await res.json()) as { key: string };
+  return data.key;
+}
+
+// ─── Known excluded tool names (procedures with meta({ mcp: false })) ───
+
+const EXCLUDED_TOOLS = [
+  "account_changePassword",
+  "account_listPasskeys",
+  "account_deletePasskey",
+  "account_listDashboardApiKeys",
+  "account_createDashboardApiKey",
+  "account_deleteDashboardApiKey",
+  "sso_registerOidc",
+  "sso_registerSaml",
+  "sso_deleteProvider",
+  "organization_deleteOrganization",
+  "onboarding_setupOnboarding",
+  "onboarding_cli",
+  "instanceAdmin_listUsers",
+  "instanceAdmin_banUser",
+  "instanceAdmin_unbanUser",
+  "instanceAdmin_addUserToOrganization",
+  "instanceAdmin_removeUserFromOrganization",
+  "instanceAdmin_updateUserRole",
+  "instanceAdmin_listOrganizations",
+  "instanceAdmin_getOrganizationMembers",
+  "instanceAdmin_setSsoSelfManage",
+  "apiCall_addExampleCalls",
+];
+
+// ─── Setup ──────────────────────────────────────────────────────────
+
+let ownerApiKey: string;
+let viewerApiKey: string;
+let toolNames: string[];
+
+beforeAll(async () => {
+  await ensureE2EReady();
+
+  const state = await getSetupState();
+
+  // Owner API key from setup
+  ownerApiKey = state.ownerApiKey;
+  if (!ownerApiKey) {
+    // Recovery mode: create one via session cookies
+    const ownerState = JSON.parse(readFileSync(STORAGE_STATE.owner, "utf-8")) as StorageState;
+    const ownerCookies = ownerState.cookies.map((c) => `${c.name}=${c.value}`).join("; ");
+    ownerApiKey = await createDashboardApiKey(ownerCookies, state.orgId, "MCP Test Owner Key");
+  }
+
+  // Viewer API key: always create fresh
+  if (!existsSync(STORAGE_STATE.viewer)) {
+    throw new Error(`Viewer storage state not found at ${STORAGE_STATE.viewer}. Run setup first.`);
+  }
+  const viewerState = JSON.parse(readFileSync(STORAGE_STATE.viewer, "utf-8")) as StorageState;
+  const viewerCookies = viewerState.cookies.map((c) => `${c.name}=${c.value}`).join("; ");
+  viewerApiKey = await createDashboardApiKey(viewerCookies, state.orgId, "MCP Test Viewer Key");
+
+  // Pre-fetch the tool list once for visibility tests
+  const res = await mcpJson(jsonRpc("tools/list"), ownerApiKey);
+  const result = res.result as { tools: Array<{ name: string }> };
+  toolNames = result.tools.map((t) => t.name);
+});
+
+// ─── Tests ──────────────────────────────────────────────────────────
+
+describe("MCP tool visibility", () => {
+  test("tools/list does not contain excluded procedures", () => {
+    for (const excluded of EXCLUDED_TOOLS) {
+      expect(toolNames).not.toContain(excluded);
+    }
+  });
+
+  test("tools/list contains expected included tools", () => {
+    expect(toolNames).toContain("apiKey_list");
+    expect(toolNames).toContain("apiKey_create");
+    expect(toolNames).toContain("deployment_list");
+    expect(toolNames).toContain("application_list");
+    expect(toolNames).toContain("health");
+  });
+
+  test("tools/call with excluded tool name returns unknown tool error", async () => {
+    const res = await mcpJson(
+      jsonRpc("tools/call", { name: "account_changePassword", arguments: {} }),
+      ownerApiKey,
+    );
+    const result = res.result as { content: Array<{ text: string }>; isError: boolean };
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Unknown tool");
+  });
+});
+
+describe("MCP permission enforcement", () => {
+  test("owner can call apiKey_list via MCP", async () => {
+    const res = await mcpJson(
+      jsonRpc("tools/call", { name: "apiKey_list", arguments: {} }),
+      ownerApiKey,
+    );
+    expect(res.error).toBeUndefined();
+    const result = res.result as { content: Array<{ text: string }>; isError?: boolean };
+    expect(result.isError).toBeFalsy();
+    // Result should be parseable JSON (array of API keys)
+    const parsed = JSON.parse(result.content[0].text);
+    expect(Array.isArray(parsed)).toBe(true);
+  });
+
+  test("viewer cannot call apiKey_create via MCP", async () => {
+    const res = await mcpJson(
+      jsonRpc("tools/call", {
+        name: "apiKey_create",
+        arguments: { name: "Should Fail Key", enabled: true },
+      }),
+      viewerApiKey,
+    );
+    const result = res.result as { content: Array<{ text: string }>; isError?: boolean };
+    expect(result.isError).toBe(true);
+  });
+
+  test("request without API key returns unauthorized error", async () => {
+    const res = await mcpJson(
+      jsonRpc("tools/call", { name: "apiKey_list", arguments: {} }),
+      // no API key
+    );
+    const error = res.error as { code: number; message: string };
+    expect(error.code).toBe(-32001);
+    expect(error.message).toContain("Unauthorized");
+  });
+});

--- a/packages/xinity-ai-dashboard/example.env
+++ b/packages/xinity-ai-dashboard/example.env
@@ -16,3 +16,5 @@ S3_ACCESS_KEY_ID=xinity
 S3_SECRET_ACCESS_KEY=xinity-secret
 S3_BUCKET=xinity-media
 S3_REGION=us-east-1
+# Model Context Protocol endpoint at /mcp (true by default)
+MCP_ENABLED=true

--- a/packages/xinity-ai-dashboard/package.json
+++ b/packages/xinity-ai-dashboard/package.json
@@ -3,9 +3,9 @@
 	"private": true,
 	"type": "module",
 	"scripts": {
-		"dev": "bun --bun vite dev | pino-pretty",
+		"dev": "bun --bun vite dev --port 5173 | pino-pretty",
 		"build": "bun --bun vite build",
-		"preview": "bun --bun vite preview",
+		"preview": "bun --bun vite preview --port 5173 | pino-pretty",
 		"prepare": "svelte-kit sync || echo ''",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"test": "bun test --timeout 60000",

--- a/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/account.procedure.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/account.procedure.ts
@@ -5,7 +5,7 @@ import { rootLogger } from "$lib/server/logging";
 import { getDB } from "$lib/server/db";
 import { memberT, sql } from "common-db";
 
-const log = rootLogger.child({ name: "auth.procedure" });
+const log = rootLogger.child({ name: "account.procedure" });
 const tags = ["Auth"];
 
 const changePassword = rootOs
@@ -127,7 +127,7 @@ const deleteDashboardApiKey = rootOs
     }
   });
 
-export const authRouter = rootOs.prefix("/auth").router({
+export const authRouter = rootOs.prefix("/account").router({
   changePassword,
   listPasskeys,
   deletePasskey,

--- a/packages/xinity-ai-dashboard/src/lib/server/orpc/router.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/orpc/router.ts
@@ -2,7 +2,7 @@ import { os } from "@orpc/server";
 import { apiCallRouter } from "./procedures/api-call.procedure";
 import { apiKeyRouter } from "./procedures/api-key.procedure";
 import { applicationRouter } from "./procedures/application.procedure";
-import { authRouter } from "./procedures/auth.procedure";
+import { authRouter } from "./procedures/account.procedure";
 import { deploymentRouter } from "./procedures/deployment.procedure";
 import { devRouter } from "./procedures/dev.procedure";
 import { organizationRouter } from "./procedures/organization.procedure";
@@ -27,7 +27,7 @@ export const router = {
   apiKey: apiKeyRouter,
   application: applicationRouter,
   apiCall: apiCallRouter,
-  auth: authRouter,
+  account: authRouter,
   organization: organizationRouter,
   user: userRouter,
   deployment: deploymentRouter,

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/settings/DashboardApiKeyManagement.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/settings/DashboardApiKeyManagement.svelte
@@ -30,7 +30,7 @@
 
   async function loadApiKeys() {
     isLoading = true;
-    const [error, data] = await orpc.auth.listDashboardApiKeys({});
+    const [error, data] = await orpc.account.listDashboardApiKeys({});
     isLoading = false;
     if (error) {
       loadError = error.message;
@@ -79,7 +79,7 @@
     }
 
     isCreating = true;
-    const [error, data] = await orpc.auth.createDashboardApiKey({
+    const [error, data] = await orpc.account.createDashboardApiKey({
       name: newKeyName,
       organizationId: newKeyOrgId,
     });
@@ -107,7 +107,7 @@
     apiKeyToDelete = null;
     deleteDialogOpen = false;
 
-    const [error] = await orpc.auth.deleteDashboardApiKey({ id });
+    const [error] = await orpc.account.deleteDashboardApiKey({ id });
     if (error) {
       browserLogger.error(error, "Error deleting API key");
       toastState.add("Error deleting API key", "error");

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/settings/PasskeyManagement.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/settings/PasskeyManagement.svelte
@@ -24,7 +24,7 @@
 
   async function loadPasskeys() {
     isLoading = true;
-    const [error, data] = await orpc.auth.listPasskeys({});
+    const [error, data] = await orpc.account.listPasskeys({});
     isLoading = false;
     if (error) {
       loadError = error.message;
@@ -60,7 +60,7 @@
     confirmDelete = null;
     deleteDialogOpen = false;
 
-    const [error] = await orpc.auth.deletePasskey({ id });
+    const [error] = await orpc.account.deletePasskey({ id });
     if (error) {
       browserLogger.error(error, "Error deleting passkey");
       toastState.add("Error deleting passkey", "error");

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/settings/PasswordChange.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/settings/PasswordChange.svelte
@@ -22,7 +22,7 @@
     }
 
     isSubmitting = true;
-    const [error] = await orpc.auth.changePassword({
+    const [error] = await orpc.account.changePassword({
       currentPassword,
       newPassword,
     });

--- a/packages/xinity-ai-dashboard/tests/TEST_PLAN.md
+++ b/packages/xinity-ai-dashboard/tests/TEST_PLAN.md
@@ -106,7 +106,44 @@ error-handler.test.ts
 
 ---
 
-## 5. E2E Smoke Tests (With Real App)
+## 5. MCP Endpoint
+
+### 5.1 Tool Visibility (API - No Mocking)
+
+Verify that `tools/list` returns only procedures that are not excluded via `meta({ mcp: false })`. Uses a direct HTTP POST to `/mcp` with JSON-RPC.
+
+```
+e2e/api/mcp.test.ts (tool visibility)
+├── tools/list does not contain any excluded procedure names
+│   (auth_changePassword, auth_listPasskeys, auth_deletePasskey,
+│    auth_listDashboardApiKeys, auth_createDashboardApiKey, auth_deleteDashboardApiKey,
+│    sso_registerOidc, sso_registerSaml, sso_deleteProvider,
+│    organization_deleteOrganization, onboarding_setupOnboarding, onboarding_cli,
+│    instanceAdmin_listUsers, instanceAdmin_banUser, instanceAdmin_unbanUser,
+│    instanceAdmin_addUserToOrganization, instanceAdmin_removeUserFromOrganization,
+│    instanceAdmin_updateUserRole, instanceAdmin_listOrganizations,
+│    instanceAdmin_getOrganizationMembers, instanceAdmin_setSsoSelfManage,
+│    apiCall_addExampleCalls)
+├── tools/list contains expected included tools (e.g. apiKey_list, deployment_list)
+└── tools/call with an excluded tool name returns "Unknown tool" error
+```
+
+### 5.2 Permission Enforcement via MCP (API - Requires Setup)
+
+Verify that the oRPC permission middleware runs correctly when tools are called through the MCP endpoint. Requires dashboard API keys for both owner and viewer roles.
+
+The owner API key is already created by global-setup. A viewer dashboard API key needs to be created in `beforeAll` via the auth API using viewer session cookies.
+
+```
+e2e/api/mcp.test.ts (permissions)
+├── owner can call apiKey_list via MCP (returns tool result)
+├── viewer cannot call apiKey_create via MCP (returns permission error in tool result)
+└── request without API key returns JSON-RPC error -32001 (Unauthorized)
+```
+
+---
+
+## 6. E2E Smoke Tests (With Real App)
 
 Minimal set of critical paths using Playwright or similar.
 
@@ -127,11 +164,13 @@ e2e/
 | Permission State | 3 | No |
 | oRPC Permission Middleware | 4 | No (mocked) |
 | oRPC Business Logic | 4 | Yes |
+| MCP Tool Visibility | 3 | Yes |
+| MCP Permission Enforcement | 3 | Yes |
 | UI Sidebar | 3 | No |
 | UI API Keys Page | 3 | No |
 | Error Handling | 3 | No |
 | E2E Smoke | 3 | Yes |
-| **Total** | **28** | **7 with DB** |
+| **Total** | **34** | **13 with DB** |
 
 ---
 
@@ -176,5 +215,6 @@ mock.module("$lib/state/permissions.svelte", () => ({
 
 1. **Role Permissions** - Ensures role definitions are correct
 2. **oRPC Permission Middleware** - Ensures API is protected
-3. **UI Permission Gating** - Ensures users see correct UI
-4. **E2E Smoke Tests** - Ensures critical paths work end-to-end
+3. **MCP Endpoint** - Ensures excluded tools are hidden and permissions enforced via MCP
+4. **UI Permission Gating** - Ensures users see correct UI
+5. **E2E Smoke Tests** - Ensures critical paths work end-to-end

--- a/packages/xinity-ai-dashboard/tests/TEST_PLAN.md
+++ b/packages/xinity-ai-dashboard/tests/TEST_PLAN.md
@@ -115,8 +115,8 @@ Verify that `tools/list` returns only procedures that are not excluded via `meta
 ```
 e2e/api/mcp.test.ts (tool visibility)
 ├── tools/list does not contain any excluded procedure names
-│   (auth_changePassword, auth_listPasskeys, auth_deletePasskey,
-│    auth_listDashboardApiKeys, auth_createDashboardApiKey, auth_deleteDashboardApiKey,
+│   (account_changePassword, account_listPasskeys, account_deletePasskey,
+│    account_listDashboardApiKeys, account_createDashboardApiKey, account_deleteDashboardApiKey,
 │    sso_registerOidc, sso_registerSaml, sso_deleteProvider,
 │    organization_deleteOrganization, onboarding_setupOnboarding, onboarding_cli,
 │    instanceAdmin_listUsers, instanceAdmin_banUser, instanceAdmin_unbanUser,


### PR DESCRIPTION
## Description

This PR introduces some additional documentation for the MCP integration in the dashboard.  
At the same time, it also introduces tests for the mcp endpoints, mostly to ensure its security follows the same schema and specification as the rest of the api.  
Along the way, it also became apparent that there was a name clash in the route of a set of api methods that made them unavailable via the /api. Specifically the /auth related procedures.  
This is now fixed by renaming the path to /account. 
This would be a breaking change, if it had been reachable by anyone via the api paths so far. Since that was not the case, we will move on with it as a non-breaking change.

## Type of change

Bug fix + Docs

## Testing

New tests were introduced.

## Checklist

- [x] Tests pass locally (`bun test`), or no testable code was changed
- [x] New or changed behavior is covered by tests, or this change does not require tests
- [x] Documentation is updated, or no user-facing behavior or configuration was changed
- [x] There are no breaking changes, or they are marked with `!` in the commit type and described above
- [x] No security-sensitive changes (authentication, credentials, input handling), or they have been reviewed
- [x] No new dependencies were added, or they have been reviewed for license and maintenance status