### PR TITLE
fix(dashboard): set up homepage with streamed queries / faster load

### DIFF
--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/+page.server.ts
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/+page.server.ts
@@ -5,12 +5,15 @@ import {
   usageEventT, usageSummaryT, NIL_APP_UUID, invitationT,
 } from "common-db";
 import type { PageServerLoad } from "./$types";
+import type { ChecklistData, KeyMetrics, ChartsData, TablesData } from "./dashboard.types";
 import { rootLogger } from "$lib/server/logging";
 
 const log = rootLogger.child({ name: "dashboard-home" });
 
+type DB = ReturnType<typeof getDB>;
+
 /** Roll up usageEvent rows older than 30 days into usageSummary, then delete them. */
-async function rollupUsageEvents(db: ReturnType<typeof getDB>, orgId: string) {
+async function rollupUsageEvents(db: DB, orgId: string) {
   await db.execute(sql`
     INSERT INTO "call_data"."usage_summary"
       ("date", "organization_id", "application_id", "api_key_id", "model",
@@ -40,65 +43,40 @@ async function rollupUsageEvents(db: ReturnType<typeof getDB>, orgId: string) {
   ));
 }
 
-export const load: PageServerLoad = async ({ parent }) => {
-  const { user, session } = await parent();
-  const userId = user.id;
-  const activeOrgId = session.activeOrganizationId;
-
-  if (!activeOrgId) {
-    return {
-      noOrg: true,
-      ...emptyData(),
-    };
-  }
-
-  const db = getDB();
-
-  // Fire-and-forget rollup of old usage events
-  rollupUsageEvents(db, activeOrgId).catch(err => log.error({ err }, "Rollup error"));
-
-  // Run all independent queries in parallel
+async function loadKeyMetrics(db: DB, orgId: string, userId: string): Promise<KeyMetrics> {
   const [
     [eventTotalsResult],
     [summaryTotalsResult],
     [todayResult],
     [tokenAvgResult],
-    recentModels,
-    [ratingsResult],
-    [trainingDataResult],
-    trendData,
-    topAppsRaw,
-    [avgDurationResult],
-    recentActivitiesResult,
+    [responseDataResult],
   ] = await Promise.all([
-    // Usage totals from usageEvent (recent, last 30 days)
+    // Usage totals + avg duration from usageEvent, same table and filter
     db.select({
       totalCalls: sql<number>`COUNT(*)::int`,
       loggedCalls: sql<number>`COUNT(*) FILTER (WHERE ${usageEventT.logged})::int`,
+      avgDuration: sql<number | null>`AVG(${usageEventT.duration})`,
     })
       .from(usageEventT)
-      .where(eq(usageEventT.organizationId, activeOrgId)),
+      .where(eq(usageEventT.organizationId, orgId)),
 
-    // Usage totals from usageSummary (older, rolled up)
     db.select({
       totalCalls: sql<number>`COALESCE(SUM(${usageSummaryT.totalCalls}), 0)::int`,
       loggedCalls: sql<number>`COALESCE(SUM(${usageSummaryT.loggedCalls}), 0)::int`,
     })
       .from(usageSummaryT)
-      .where(eq(usageSummaryT.organizationId, activeOrgId)),
+      .where(eq(usageSummaryT.organizationId, orgId)),
 
-    // Today's usage
     db.select({
       totalCalls: sql<number>`COUNT(*)::int`,
       loggedCalls: sql<number>`COUNT(*) FILTER (WHERE ${usageEventT.logged})::int`,
     })
       .from(usageEventT)
       .where(and(
-        eq(usageEventT.organizationId, activeOrgId),
+        eq(usageEventT.organizationId, orgId),
         sql`DATE(${usageEventT.createdAt}) = CURRENT_DATE`,
       )),
 
-    // Mean tokens per call: last 1m, 10m, 1h (split by input/output)
     db.select({
       avgInput1m: sql<number | null>`AVG(${usageEventT.inputTokens}) FILTER (WHERE ${usageEventT.createdAt} > NOW() - INTERVAL '1 minute')`,
       avgOutput1m: sql<number | null>`AVG(${usageEventT.outputTokens}) FILTER (WHERE ${usageEventT.createdAt} > NOW() - INTERVAL '1 minute')`,
@@ -109,104 +87,94 @@ export const load: PageServerLoad = async ({ parent }) => {
     })
       .from(usageEventT)
       .where(and(
-        eq(usageEventT.organizationId, activeOrgId),
+        eq(usageEventT.organizationId, orgId),
         sql`${usageEventT.createdAt} > NOW() - INTERVAL '1 hour'`,
       )),
 
+    // Ratings + training data from apiCallResponse, same table and filter
     db.select({
-        name: modelDeploymentT.name,
-        status: sql<string>`'deployed'`,
-      })
-      .from(modelDeploymentT)
-      .where(sql`
-        ${modelDeploymentT.organizationId} = ${activeOrgId} 
-      AND 
-        ${modelDeploymentT.deletedAt} IS NULL
-      `)
-      .orderBy(sql`${modelDeploymentT.createdAt} DESC`)
-      .limit(3),
-
-    db.select({
-        liked: sql<number>`COUNT(CASE WHEN ${apiCallResponseT.response} = true THEN 1 END)::int`,
-        disliked: sql<number>`COUNT(CASE WHEN ${apiCallResponseT.response} = false THEN 1 END)::int`,
-        unrated: sql<number>`COUNT(CASE WHEN ${apiCallResponseT.response} IS NULL THEN 1 END)::int`,
-      })
+      liked: sql<number>`COUNT(CASE WHEN ${apiCallResponseT.response} = true THEN 1 END)::int`,
+      disliked: sql<number>`COUNT(CASE WHEN ${apiCallResponseT.response} = false THEN 1 END)::int`,
+      unrated: sql<number>`COUNT(CASE WHEN ${apiCallResponseT.response} IS NULL THEN 1 END)::int`,
+      total: sql<number>`COUNT(*)::int`,
+      edited: sql<number>`COUNT(CASE WHEN ${apiCallResponseT.outputEdit} IS NOT NULL THEN 1 END)::int`,
+      rated: sql<number>`COUNT(CASE WHEN ${apiCallResponseT.response} IS NOT NULL THEN 1 END)::int`,
+    })
       .from(apiCallResponseT)
       .where(sql`${apiCallResponseT.userId} = ${userId}`),
+  ]);
 
-    db.select({
-        total: sql<number>`COUNT(*)::int`,
-        edited: sql<number>`COUNT(CASE WHEN ${apiCallResponseT.outputEdit} IS NOT NULL THEN 1 END)::int`,
-        rated: sql<number>`COUNT(CASE WHEN ${apiCallResponseT.response} IS NOT NULL THEN 1 END)::int`,
-      })
-      .from(apiCallResponseT)
-      .where(sql`${apiCallResponseT.userId} = ${userId}`),
+  const totalCalls = (eventTotalsResult?.totalCalls || 0) + (summaryTotalsResult?.totalCalls || 0);
+  const loggedCalls = (eventTotalsResult?.loggedCalls || 0) + (summaryTotalsResult?.loggedCalls || 0);
+  const avgDuration = eventTotalsResult?.avgDuration ?? null;
+  const avgResponseTime = avgDuration ? Number((avgDuration / 1000).toFixed(1)) : 0;
+  const totalRated = (responseDataResult?.liked || 0) + (responseDataResult?.disliked || 0);
+  const approvalRate = totalRated === 0 ? 0 : Number((((responseDataResult?.liked || 0) / totalRated) * 100).toFixed(1));
+  const totalDatapoints = responseDataResult?.total || 0;
+  const editedCount = responseDataResult?.edited || 0;
+  const ratedCount = responseDataResult?.rated || 0;
 
-    // 30-day trend from usageEvent (calls + tokens per day)
+  return {
+    apiCallStats: {
+      totalCalls,
+      loggedCalls,
+      todayCalls: todayResult?.totalCalls || 0,
+      todayLoggedCalls: todayResult?.loggedCalls || 0,
+      approvalRate,
+      avgResponseTime,
+    },
+    tokenStats: {
+      avgInput1m: tokenAvgResult?.avgInput1m != null ? Math.round(tokenAvgResult.avgInput1m) : null,
+      avgOutput1m: tokenAvgResult?.avgOutput1m != null ? Math.round(tokenAvgResult.avgOutput1m) : null,
+      avgInput10m: tokenAvgResult?.avgInput10m != null ? Math.round(tokenAvgResult.avgInput10m) : null,
+      avgOutput10m: tokenAvgResult?.avgOutput10m != null ? Math.round(tokenAvgResult.avgOutput10m) : null,
+      avgInput1h: tokenAvgResult?.avgInput1h != null ? Math.round(tokenAvgResult.avgInput1h) : null,
+      avgOutput1h: tokenAvgResult?.avgOutput1h != null ? Math.round(tokenAvgResult.avgOutput1h) : null,
+    },
+    responseRatings: {
+      liked: responseDataResult?.liked || 0,
+      disliked: responseDataResult?.disliked || 0,
+      unrated: responseDataResult?.unrated || 0,
+    },
+    trainingData: {
+      datapoints: totalDatapoints,
+      edited: totalDatapoints > 0 ? Math.round((editedCount / totalDatapoints) * 100) : 0,
+      rated: totalDatapoints > 0 ? Math.round((ratedCount / totalDatapoints) * 100) : 0,
+    },
+  };
+}
+
+async function loadCharts(db: DB, orgId: string): Promise<ChartsData> {
+  const [trendData, topAppsRaw] = await Promise.all([
     db.select({
-        date: sql<string>`DATE(${usageEventT.createdAt})`,
-        totalCalls: sql<number>`COUNT(*)::int`,
-        loggedCalls: sql<number>`COUNT(*) FILTER (WHERE ${usageEventT.logged})::int`,
-        inputTokens: sql<number>`COALESCE(SUM(${usageEventT.inputTokens}), 0)::int`,
-        outputTokens: sql<number>`COALESCE(SUM(${usageEventT.outputTokens}), 0)::int`,
-      })
+      date: sql<string>`DATE(${usageEventT.createdAt})`,
+      totalCalls: sql<number>`COUNT(*)::int`,
+      loggedCalls: sql<number>`COUNT(*) FILTER (WHERE ${usageEventT.logged})::int`,
+      inputTokens: sql<number>`COALESCE(SUM(${usageEventT.inputTokens}), 0)::int`,
+      outputTokens: sql<number>`COALESCE(SUM(${usageEventT.outputTokens}), 0)::int`,
+    })
       .from(usageEventT)
       .where(and(
-        eq(usageEventT.organizationId, activeOrgId),
+        eq(usageEventT.organizationId, orgId),
         sql`DATE(${usageEventT.createdAt}) >= CURRENT_DATE - INTERVAL '29 days'`,
       ))
       .groupBy(sql`DATE(${usageEventT.createdAt})`)
       .orderBy(sql`DATE(${usageEventT.createdAt}) ASC`),
 
-    // Top applications by usage (last 30 days)
     db.select({
-        applicationId: usageEventT.applicationId,
-        totalCalls: sql<number>`COUNT(*)::int`,
-        totalTokens: sql<number>`COALESCE(SUM(${usageEventT.inputTokens} + ${usageEventT.outputTokens}), 0)::int`,
-      })
+      applicationId: usageEventT.applicationId,
+      totalCalls: sql<number>`COUNT(*)::int`,
+      totalTokens: sql<number>`COALESCE(SUM(${usageEventT.inputTokens} + ${usageEventT.outputTokens}), 0)::int`,
+    })
       .from(usageEventT)
       .where(and(
-        eq(usageEventT.organizationId, activeOrgId),
+        eq(usageEventT.organizationId, orgId),
         sql`${usageEventT.createdAt} >= CURRENT_DATE - INTERVAL '29 days'`,
       ))
       .groupBy(usageEventT.applicationId)
       .orderBy(sql`COUNT(*) DESC`)
       .limit(5),
-
-    // Average response duration from all usage events
-    db.select({ avg: sql<number>`AVG(${usageEventT.duration})` })
-      .from(usageEventT)
-      .where(eq(usageEventT.organizationId, activeOrgId)),
-
-    // Recent activities from usage events (all calls, not just logged)
-    db.select({
-        model: usageEventT.model,
-        timestamp: usageEventT.createdAt,
-        inputTokens: usageEventT.inputTokens,
-        outputTokens: usageEventT.outputTokens,
-        duration: usageEventT.duration,
-        logged: usageEventT.logged,
-      })
-      .from(usageEventT)
-      .where(eq(usageEventT.organizationId, activeOrgId))
-      .orderBy(sql`${usageEventT.createdAt} DESC`)
-      .limit(5),
   ]);
-
-  // Combine event + summary totals
-  const totalCalls = (eventTotalsResult?.totalCalls || 0) + (summaryTotalsResult?.totalCalls || 0);
-  const loggedCalls = (eventTotalsResult?.loggedCalls || 0) + (summaryTotalsResult?.loggedCalls || 0);
-  const todayCalls = todayResult?.totalCalls || 0;
-  const todayLoggedCalls = todayResult?.loggedCalls || 0;
-
-  const avgDuration = avgDurationResult?.avg ?? null;
-  const avgResponseTime = avgDuration ? Number((avgDuration / 1000).toFixed(1)) : 0;
-  const totalRated = (ratingsResult?.liked || 0) + (ratingsResult?.disliked || 0);
-  const approvalRate = totalRated === 0 ? 0 : Number((((ratingsResult?.liked || 0) / totalRated) * 100).toFixed(1));
-
-  const totalDatapoints = trainingDataResult?.total || 0;
-  const editedCount = trainingDataResult?.edited || 0;
-  const ratedCount = trainingDataResult?.rated || 0;
 
   // Fill in missing days with zeros for the 30-day trend
   const trendMap = new Map(trendData.map(d => [d.date, d]));
@@ -235,13 +203,86 @@ export const load: PageServerLoad = async ({ parent }) => {
     appNameMap = new Map(apps.map(a => [a.id, a.name]));
   }
 
-  const topApplications = topAppsRaw.map(a => ({
-    name: (a.applicationId == null || a.applicationId === NIL_APP_UUID) ? 'Uncategorized' : (appNameMap.get(a.applicationId) ?? 'Unknown'),
-    totalCalls: a.totalCalls,
-    totalTokens: a.totalTokens,
-  }));
+  return {
+    usageTrend,
+    topApplications: topAppsRaw.map(a => ({
+      name: (a.applicationId == null || a.applicationId === NIL_APP_UUID) ? 'Uncategorized' : (appNameMap.get(a.applicationId) ?? 'Unknown'),
+      totalCalls: a.totalCalls,
+      totalTokens: a.totalTokens,
+    })),
+  };
+}
 
-  // Checklist completion queries (all LIMIT 1 existence checks)
+async function loadTables(db: DB, orgId: string): Promise<TablesData> {
+  const [recentActivitiesResult, recentModels] = await Promise.all([
+    db.select({
+      model: usageEventT.model,
+      timestamp: usageEventT.createdAt,
+      inputTokens: usageEventT.inputTokens,
+      outputTokens: usageEventT.outputTokens,
+      duration: usageEventT.duration,
+      logged: usageEventT.logged,
+    })
+      .from(usageEventT)
+      .where(eq(usageEventT.organizationId, orgId))
+      .orderBy(sql`${usageEventT.createdAt} DESC`)
+      .limit(5),
+
+    db.select({
+      name: modelDeploymentT.name,
+      status: sql<string>`'deployed'`,
+    })
+      .from(modelDeploymentT)
+      .where(sql`
+        ${modelDeploymentT.organizationId} = ${orgId}
+      AND
+        ${modelDeploymentT.deletedAt} IS NULL
+      `)
+      .orderBy(sql`${modelDeploymentT.createdAt} DESC`)
+      .limit(3),
+  ]);
+
+  return {
+    recentActivities: recentActivitiesResult.map(a => ({
+      model: a.model,
+      timestamp: a.timestamp.toISOString(),
+      inputTokens: a.inputTokens,
+      outputTokens: a.outputTokens,
+      duration: a.duration,
+      logged: a.logged,
+    })),
+    recentModels: recentModels.map(m => ({ name: m.name, status: m.status })),
+  };
+}
+
+export const load: PageServerLoad = async ({ parent }) => {
+  const { user, session } = await parent();
+  const userId = user.id;
+  const activeOrgId = session.activeOrganizationId;
+
+  if (!activeOrgId) {
+    return {
+      noOrg: true,
+      ...emptyData(),
+    };
+  }
+
+  const db = getDB();
+
+  // Fire-and-forget rollup of old usage events
+  void rollupUsageEvents(db, activeOrgId)
+    .catch(err => log.error({ err }, "Usage info rollup error"));
+
+  // Stream all data. Page renders immediately, sections fill in as queries resolve.
+  return {
+    checklist: loadChecklist(db, activeOrgId),
+    keyMetrics: loadKeyMetrics(db, activeOrgId, userId),
+    charts: loadCharts(db, activeOrgId),
+    tables: loadTables(db, activeOrgId),
+  };
+};
+
+async function loadChecklist(db: DB, orgId: string): Promise<ChecklistData> {
   const [
     checkDeployment,
     checkApiCall,
@@ -253,124 +294,90 @@ export const load: PageServerLoad = async ({ parent }) => {
       .from(modelDeploymentT)
       .where(
         sql`
-          ${modelDeploymentT.organizationId} = ${activeOrgId}
+          ${modelDeploymentT.organizationId} = ${orgId}
         AND
           ${modelDeploymentT.deletedAt} IS NULL
         `,
-       )
+      )
       .limit(1),
 
     db.select({ id: usageEventT.id })
       .from(usageEventT)
-      .where(eq(usageEventT.organizationId, activeOrgId))
+      .where(eq(usageEventT.organizationId, orgId))
       .limit(1),
 
     db.select({ id: apiCallResponseT.apiCallId })
       .from(apiCallResponseT)
       .innerJoin(apiCallT, eq(apiCallT.id, apiCallResponseT.apiCallId))
-      .where(eq(apiCallT.organizationId, activeOrgId))
+      .where(eq(apiCallT.organizationId, orgId))
       .limit(1),
 
     db.select({ id: invitationT.id })
       .from(invitationT)
-      .where(eq(invitationT.organizationId, activeOrgId))
+      .where(eq(invitationT.organizationId, orgId))
       .limit(1),
 
     db.select({ id: aiApplicationT.id })
       .from(aiApplicationT)
       .where(and(
-        eq(aiApplicationT.organizationId, activeOrgId),
+        eq(aiApplicationT.organizationId, orgId),
         isNull(aiApplicationT.deletedAt),
       ))
       .limit(1),
   ]);
 
   return {
-    apiCallStats: { totalCalls, loggedCalls, todayCalls, todayLoggedCalls, approvalRate, avgResponseTime },
-    tokenStats: {
-      avgInput1m: tokenAvgResult?.avgInput1m != null ? Math.round(tokenAvgResult.avgInput1m) : null,
-      avgOutput1m: tokenAvgResult?.avgOutput1m != null ? Math.round(tokenAvgResult.avgOutput1m) : null,
-      avgInput10m: tokenAvgResult?.avgInput10m != null ? Math.round(tokenAvgResult.avgInput10m) : null,
-      avgOutput10m: tokenAvgResult?.avgOutput10m != null ? Math.round(tokenAvgResult.avgOutput10m) : null,
-      avgInput1h: tokenAvgResult?.avgInput1h != null ? Math.round(tokenAvgResult.avgInput1h) : null,
-      avgOutput1h: tokenAvgResult?.avgOutput1h != null ? Math.round(tokenAvgResult.avgOutput1h) : null,
-    },
-    recentModels: recentModels.map(m => ({ name: m.name, status: m.status })),
-    topApplications,
-    responseRatings: {
-      liked: ratingsResult?.liked || 0,
-      disliked: ratingsResult?.disliked || 0,
-      unrated: ratingsResult?.unrated || 0,
-    },
-    trainingData: {
-      datapoints: totalDatapoints,
-      edited: totalDatapoints > 0 ? Math.round((editedCount / totalDatapoints) * 100) : 0,
-      rated: totalDatapoints > 0 ? Math.round((ratedCount / totalDatapoints) * 100) : 0,
-    },
-    recentActivities: recentActivitiesResult.map(a => ({
-      model: a.model,
-      timestamp: a.timestamp.toISOString(),
-      inputTokens: a.inputTokens,
-      outputTokens: a.outputTokens,
-      duration: a.duration,
-      logged: a.logged,
-    })),
-    usageTrend,
-    checklist: {
-      hasOrganization: true,
-      hasDeployment: checkDeployment.length > 0,
-      hasApiCall: checkApiCall.length > 0,
-      hasLabeledCall: checkLabeledCall.length > 0,
-      hasInvitation: checkInvitation.length > 0,
-      hasApplication: checkApplication.length > 0,
-    },
+    hasOrganization: true,
+    hasDeployment: checkDeployment.length > 0,
+    hasApiCall: checkApiCall.length > 0,
+    hasLabeledCall: checkLabeledCall.length > 0,
+    hasInvitation: checkInvitation.length > 0,
+    hasApplication: checkApplication.length > 0,
   };
-};
+}
 
 function emptyData() {
   return {
-    apiCallStats: {
-      totalCalls: 0,
-      loggedCalls: 0,
-      todayCalls: 0,
-      todayLoggedCalls: 0,
-      approvalRate: 0,
-      avgResponseTime: 0,
-    },
-    tokenStats: {
-      avgInput1m: null as number | null,
-      avgOutput1m: null as number | null,
-      avgInput10m: null as number | null,
-      avgOutput10m: null as number | null,
-      avgInput1h: null as number | null,
-      avgOutput1h: null as number | null,
-    },
-    recentModels: [],
-    topApplications: [],
-    responseRatings: {
-      liked: 0,
-      disliked: 0,
-      unrated: 0,
-    },
-    trainingData: {
-      datapoints: 0,
-      edited: 0,
-      rated: 0,
-    },
-    recentActivities: [] as Array<{ model: string; timestamp: string; inputTokens: number; outputTokens: number; duration: number | null; logged: boolean }>,
-    usageTrend: Array.from({ length: 30 }, () => ({
-      totalCalls: 0,
-      loggedCalls: 0,
-      inputTokens: 0,
-      outputTokens: 0,
-    })),
-    checklist: {
+    checklist: Promise.resolve<ChecklistData>({
       hasOrganization: false,
       hasDeployment: false,
       hasApiCall: false,
       hasLabeledCall: false,
       hasInvitation: false,
       hasApplication: false,
-    },
-  }
+    }),
+    keyMetrics: Promise.resolve<KeyMetrics>({
+      apiCallStats: {
+        totalCalls: 0,
+        loggedCalls: 0,
+        todayCalls: 0,
+        todayLoggedCalls: 0,
+        approvalRate: 0,
+        avgResponseTime: 0,
+      },
+      tokenStats: {
+        avgInput1m: null,
+        avgOutput1m: null,
+        avgInput10m: null,
+        avgOutput10m: null,
+        avgInput1h: null,
+        avgOutput1h: null,
+      },
+      responseRatings: { liked: 0, disliked: 0, unrated: 0 },
+      trainingData: { datapoints: 0, edited: 0, rated: 0 },
+    }),
+    charts: Promise.resolve<ChartsData>({
+      usageTrend: Array.from({ length: 30 }, () => ({
+        totalCalls: 0,
+        loggedCalls: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+      })),
+      topApplications: [],
+    }),
+    tables: Promise.resolve<TablesData>({
+      recentActivities: [],
+      recentModels: [],
+    }),
+  };
 }

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/+page.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/+page.svelte
@@ -4,46 +4,27 @@
   import GettingStartedChecklist from "./GettingStartedChecklist.svelte";
 
   export let data;
-
-  // Extract only dashboard data, excluding user
-  const {
-    noOrg,
-    checklist,
-    apiCallStats,
-    tokenStats,
-    recentModels,
-    topApplications,
-    responseRatings,
-    trainingData,
-    recentActivities,
-    usageTrend,
-  } = data;
 </script>
 
 <svelte:head>
   <title>Xinity Dashboard</title>
 </svelte:head>
 
-{#if noOrg}
+{#if data.noOrg}
   <OnboardingFlow />
 {/if}
 
 {#if !data.displaySettings?.gettingStartedDismissed}
   <GettingStartedChecklist
-    {checklist}
+    checklist={data.checklist}
     displaySettings={data.displaySettings}
   />
 {/if}
 
-{#if !noOrg}
+{#if !data.noOrg}
   <Dashboard
-    {apiCallStats}
-    {tokenStats}
-    {recentModels}
-    {topApplications}
-    {responseRatings}
-    {trainingData}
-    {recentActivities}
-    {usageTrend}
+    keyMetrics={data.keyMetrics}
+    charts={data.charts}
+    tables={data.tables}
   />
 {/if}

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/Dashboard.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/Dashboard.svelte
@@ -1,73 +1,23 @@
 <script lang="ts">
   import Chart from "$lib/components/Chart.svelte";
   import type { ChartConfiguration } from "chart.js";
+  import type { KeyMetrics, ChartsData, TablesData } from "./dashboard.types";
 
-  // Props from server
-  export let apiCallStats = {
-    totalCalls: 0,
-    loggedCalls: 0,
-    todayCalls: 0,
-    todayLoggedCalls: 0,
-    approvalRate: 0,
-    avgResponseTime: 0,
-  };
+  export let keyMetrics: Promise<KeyMetrics>;
+  export let charts: Promise<ChartsData>;
+  export let tables: Promise<TablesData>;
 
-  export let tokenStats: {
-    avgInput1m: number | null;
-    avgOutput1m: number | null;
-    avgInput10m: number | null;
-    avgOutput10m: number | null;
-    avgInput1h: number | null;
-    avgOutput1h: number | null;
-  } = { avgInput1m: null, avgOutput1m: null, avgInput10m: null, avgOutput10m: null, avgInput1h: null, avgOutput1h: null };
-
-  export let recentModels: Array<{ name: string; status: string }> = [];
-
-  export let topApplications: Array<{ name: string; totalCalls: number; totalTokens: number }> = [];
-
-  export let responseRatings = {
-    liked: 0,
-    disliked: 0,
-    unrated: 0,
-  };
-
-  export let trainingData = {
-    datapoints: 0,
-    edited: 0,
-    rated: 0,
-  };
-
-  export let recentActivities: Array<{
-    model: string;
-    timestamp: string;
-    inputTokens: number;
-    outputTokens: number;
-    duration: number | null;
-    logged: boolean;
-  }> = [];
-
-  export let usageTrend: Array<{
-    totalCalls: number;
-    loggedCalls: number;
-    inputTokens: number;
-    outputTokens: number;
-  }> = [];
-
-  // Calculate dates for the chart
   function getLast30Days() {
     const dates = [];
     const today = new Date();
-
     for (let i = 29; i >= 0; i--) {
       const date = new Date(today);
       date.setDate(today.getDate() - i);
       dates.push(date.getDate() + "/" + (date.getMonth() + 1));
     }
-
     return dates;
   }
 
-  // Format date for display
   function formatDate(dateString: string) {
     const date = new Date(dateString);
     return date.toLocaleString();
@@ -89,404 +39,411 @@
     if (ms == null) return "\u2014";
     return (ms / 1000).toFixed(1) + "s";
   }
-
-  $: loggedPercent = apiCallStats.totalCalls > 0
-    ? Math.round((apiCallStats.loggedCalls / apiCallStats.totalCalls) * 100)
-    : 0;
 </script>
 
 <div class="p-6 compact:p-3">
   <h1 class="text-3xl font-bold mb-6 compact:mb-3">Xinity Summary</h1>
 
-  <!-- Key metrics -->
-  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 compact:gap-2 mb-6 compact:mb-3">
-    <div class="bg-white rounded-lg shadow p-5 compact:p-3">
-      <p class="text-sm text-gray-500 mb-1">Total API Calls</p>
-      <p class="text-2xl font-bold">{apiCallStats.totalCalls}</p>
-      <p class="text-xs text-green-600 mt-2">
-        +{apiCallStats.todayCalls} today &middot; {loggedPercent}% logged
-      </p>
-    </div>
-
-    <div class="bg-white rounded-lg shadow p-5 compact:p-3">
-      <p class="text-sm text-gray-500 mb-1">Avg Tokens / Call</p>
-      <div class="mt-1 space-y-1">
-        <div>
-          <p class="text-xs text-gray-400 mb-0.5">Input</p>
-          <div class="flex items-baseline gap-3">
-            <div>
-              <span class="text-xl font-bold">{formatTokenAvg(tokenStats.avgInput1h)}</span>
-              <span class="text-xs text-gray-400 ml-0.5">1h</span>
-            </div>
-            <div>
-              <span class="text-base font-semibold text-gray-600">{formatTokenAvg(tokenStats.avgInput10m)}</span>
-              <span class="text-xs text-gray-400 ml-0.5">10m</span>
-            </div>
-            <div>
-              <span class="text-base font-semibold text-gray-600">{formatTokenAvg(tokenStats.avgInput1m)}</span>
-              <span class="text-xs text-gray-400 ml-0.5">1m</span>
-            </div>
-          </div>
+  <!-- Key metrics cards -->
+  {#await keyMetrics}
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 compact:gap-2 mb-6 compact:mb-3">
+      {#each Array(4) as _}
+        <div class="bg-white rounded-lg shadow p-5 compact:p-3 animate-pulse">
+          <div class="h-4 bg-gray-200 rounded w-24 mb-2"></div>
+          <div class="h-8 bg-gray-200 rounded w-16 mb-2"></div>
+          <div class="h-3 bg-gray-100 rounded w-32 mt-2"></div>
         </div>
-        <div>
-          <p class="text-xs text-gray-400 mb-0.5">Output</p>
-          <div class="flex items-baseline gap-3">
-            <div>
-              <span class="text-xl font-bold">{formatTokenAvg(tokenStats.avgOutput1h)}</span>
-              <span class="text-xs text-gray-400 ml-0.5">1h</span>
-            </div>
-            <div>
-              <span class="text-base font-semibold text-gray-600">{formatTokenAvg(tokenStats.avgOutput10m)}</span>
-              <span class="text-xs text-gray-400 ml-0.5">10m</span>
-            </div>
-            <div>
-              <span class="text-base font-semibold text-gray-600">{formatTokenAvg(tokenStats.avgOutput1m)}</span>
-              <span class="text-xs text-gray-400 ml-0.5">1m</span>
-            </div>
-          </div>
-        </div>
-      </div>
+      {/each}
     </div>
-
-    <div class="bg-white rounded-lg shadow p-5 compact:p-3">
-      <p class="text-sm text-gray-500 mb-1">Approval Rate</p>
-      <p class="text-2xl font-bold">{apiCallStats.approvalRate}%</p>
-      <p class="text-xs text-gray-400 mt-2">
-        Avg response: {apiCallStats.avgResponseTime}s
-      </p>
-    </div>
-
-    <div class="bg-white rounded-lg shadow p-5 compact:p-3">
-      <p class="text-sm text-gray-500 mb-1">Training Datapoints</p>
-      <p class="text-2xl font-bold">{trainingData.datapoints}</p>
-      <p class="text-xs text-xinity-magenta mt-2">
-        {trainingData.edited}% edited, {trainingData.rated}% rated
-      </p>
-    </div>
-  </div>
-
-  <!-- Main dashboard content -->
-  <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 compact:gap-3">
-    <!-- Usage Trend Chart -->
-    <div class="bg-white rounded-lg shadow p-5 compact:p-3 lg:col-span-2">
-      <h2 class="text-lg font-medium mb-4 compact:mb-2">Usage Trend (30 days)</h2>
-      <div class="h-80">
-        <Chart
-          className="size-full"
-          config={{
-            type: "line",
-            data: {
-              labels: getLast30Days(),
-              datasets: [
-                {
-                  label: "Total Calls",
-                  data: usageTrend.map(d => d.totalCalls),
-                  backgroundColor: "rgba(160, 32, 240, 0.2)",
-                  borderColor: "rgba(160, 32, 240, 1)",
-                  borderWidth: 2,
-                  tension: 0.3,
-                  pointRadius: 3,
-                  pointBackgroundColor: "rgba(160, 32, 240, 1)",
-                  yAxisID: "y",
-                },
-                {
-                  label: "Logged Calls",
-                  data: usageTrend.map(d => d.loggedCalls),
-                  backgroundColor: "rgba(160, 32, 240, 0.05)",
-                  borderColor: "rgba(160, 32, 240, 0.4)",
-                  borderWidth: 2,
-                  borderDash: [5, 5],
-                  tension: 0.3,
-                  pointRadius: 2,
-                  pointBackgroundColor: "rgba(160, 32, 240, 0.4)",
-                  yAxisID: "y",
-                },
-                {
-                  label: "Input Tokens",
-                  data: usageTrend.map(d => d.inputTokens),
-                  backgroundColor: "rgba(214, 51, 132, 0.1)",
-                  borderColor: "rgba(214, 51, 132, 0.8)",
-                  borderWidth: 2,
-                  tension: 0.3,
-                  pointRadius: 2,
-                  pointBackgroundColor: "rgba(214, 51, 132, 0.8)",
-                  yAxisID: "y1",
-                },
-                {
-                  label: "Output Tokens",
-                  data: usageTrend.map(d => d.outputTokens),
-                  backgroundColor: "rgba(232, 96, 74, 0.1)",
-                  borderColor: "rgba(232, 96, 74, 0.8)",
-                  borderWidth: 2,
-                  tension: 0.3,
-                  pointRadius: 2,
-                  pointBackgroundColor: "rgba(232, 96, 74, 0.8)",
-                  yAxisID: "y1",
-                },
-              ],
-            },
-            options: {
-              responsive: true,
-              maintainAspectRatio: false,
-              interaction: {
-                mode: "index",
-                intersect: false,
-              },
-              scales: {
-                y: {
-                  type: "linear",
-                  position: "left",
-                  beginAtZero: true,
-                  title: {
-                    display: true,
-                    text: "Calls",
-                  },
-                  border: {
-                    display: false,
-                  },
-                },
-                y1: {
-                  type: "linear",
-                  position: "right",
-                  beginAtZero: true,
-                  title: {
-                    display: true,
-                    text: "Tokens",
-                  },
-                  grid: {
-                    drawOnChartArea: false,
-                  },
-                },
-                x: {
-                  grid: {
-                    display: false,
-                  },
-                },
-              },
-              plugins: {
-                legend: {
-                  display: true,
-                  position: "bottom",
-                },
-              },
-            },
-          }}
-        />
+  {:then { apiCallStats, tokenStats, trainingData }}
+    {@const loggedPercent = apiCallStats.totalCalls > 0
+      ? Math.round((apiCallStats.loggedCalls / apiCallStats.totalCalls) * 100)
+      : 0}
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 compact:gap-2 mb-6 compact:mb-3">
+      <div class="bg-white rounded-lg shadow p-5 compact:p-3">
+        <p class="text-sm text-gray-500 mb-1">Total API Calls</p>
+        <p class="text-2xl font-bold">{apiCallStats.totalCalls}</p>
+        <p class="text-xs text-green-600 mt-2">
+          +{apiCallStats.todayCalls} today &middot; {loggedPercent}% logged
+        </p>
       </div>
-    </div>
 
-    <!-- Response Rating Chart -->
-    <div class="bg-white rounded-lg shadow p-5 compact:p-3">
-      <h2 class="text-lg font-medium mb-4 compact:mb-2">Response Ratings</h2>
-      <div class="h-80">
-        <Chart
-          className="size-full"
-          config={{
-            type: "doughnut",
-            data: {
-              labels: ["Liked", "Disliked", "Unrated"],
-              datasets: [
-                {
-                  data: [
-                    responseRatings.liked,
-                    responseRatings.disliked,
-                    responseRatings.unrated,
-                  ],
-                  backgroundColor: [
-                    "rgba(160, 32, 240, 0.6)",
-                    "rgba(232, 96, 74, 0.6)",
-                    "rgba(209, 213, 219, 0.6)",
-                  ],
-                  borderColor: [
-                    "rgba(160, 32, 240, 1)",
-                    "rgba(232, 96, 74, 1)",
-                    "rgba(209, 213, 219, 1)",
-                  ],
-                  borderWidth: 1,
-                },
-              ],
-            },
-            options: {
-              responsive: true,
-              maintainAspectRatio: false,
-              cutout: "60%",
-              plugins: {
-                legend: {
-                  position: "bottom",
-                },
-              },
-            },
-          } satisfies ChartConfiguration<"doughnut"> as ChartConfiguration}
-        />
-      </div>
-    </div>
-
-    <!-- Application Usage Chart -->
-    <div class="bg-white rounded-lg shadow p-5 compact:p-3">
-      <h2 class="text-lg font-medium mb-4 compact:mb-2">Application Usage</h2>
-      <div class="h-80">
-        <Chart
-          className="size-full"
-          config={{
-            type: "bar",
-            data: {
-              labels: topApplications.map((app) => app.name),
-              datasets: [
-                {
-                  label: "Calls (30 days)",
-                  data: topApplications.map((app) => app.totalCalls),
-                  backgroundColor: "rgba(160, 32, 240, 0.6)",
-                  borderColor: "rgba(160, 32, 240, 1)",
-                  borderWidth: 1,
-                  borderRadius: 4,
-                },
-              ],
-            },
-            options: {
-              responsive: true,
-              maintainAspectRatio: false,
-              scales: {
-                y: {
-                  beginAtZero: true,
-                  border: {
-                    display: false,
-                  },
-                },
-                x: {
-                  grid: {
-                    display: false,
-                  },
-                },
-              },
-            },
-          }}
-        />
-      </div>
-    </div>
-
-    <!-- Recent Activities -->
-    <div class="bg-white rounded-lg shadow p-5 compact:p-3 lg:col-span-2">
-      <div class="flex justify-between items-center mb-4">
-        <h2 class="text-lg font-medium">Recent Activities</h2>
-        <a href="/data" class="text-sm text-xinity-magenta hover:text-xinity-pink"
-          >View All</a
-        >
-      </div>
-      <div class="overflow-x-auto">
-        <table class="min-w-full divide-y divide-gray-200">
-          <thead class="bg-gray-50">
-            <tr>
-              <th
-                scope="col"
-                class="px-6 py-3 compact:py-1.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
-                >Model</th
-              >
-              <th
-                scope="col"
-                class="px-6 py-3 compact:py-1.5 text-right text-xs font-medium text-gray-500 uppercase tracking-wider"
-                >Input Tokens</th
-              >
-              <th
-                scope="col"
-                class="px-6 py-3 compact:py-1.5 text-right text-xs font-medium text-gray-500 uppercase tracking-wider"
-                >Output Tokens</th
-              >
-              <th
-                scope="col"
-                class="px-6 py-3 compact:py-1.5 text-right text-xs font-medium text-gray-500 uppercase tracking-wider"
-                >Duration</th
-              >
-              <th
-                scope="col"
-                class="px-6 py-3 compact:py-1.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
-                >Time</th
-              >
-              <th
-                scope="col"
-                class="px-6 py-3 compact:py-1.5 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"
-                >Logged</th
-              >
-            </tr>
-          </thead>
-          <tbody class="bg-white divide-y divide-gray-200">
-            {#each recentActivities as activity}
-              <tr>
-                <td class="px-6 py-4 compact:py-2 whitespace-nowrap">
-                  <div class="text-sm font-medium text-gray-900">
-                    {activity.model}
-                  </div>
-                </td>
-                <td class="px-6 py-4 compact:py-2 whitespace-nowrap text-right">
-                  <div class="text-sm text-gray-500">
-                    {formatTokens(activity.inputTokens)}
-                  </div>
-                </td>
-                <td class="px-6 py-4 compact:py-2 whitespace-nowrap text-right">
-                  <div class="text-sm text-gray-500">
-                    {formatTokens(activity.outputTokens)}
-                  </div>
-                </td>
-                <td class="px-6 py-4 compact:py-2 whitespace-nowrap text-right">
-                  <div class="text-sm text-gray-500">
-                    {formatDuration(activity.duration)}
-                  </div>
-                </td>
-                <td class="px-6 py-4 compact:py-2 whitespace-nowrap">
-                  <div class="text-sm text-gray-500">
-                    {formatDate(activity.timestamp)}
-                  </div>
-                </td>
-                <td class="px-6 py-4 compact:py-2 whitespace-nowrap text-center">
-                  {#if activity.logged}
-                    <span class="inline-block h-2 w-2 rounded-full bg-green-500" title="Logged"></span>
-                  {:else}
-                    <span class="inline-block h-2 w-2 rounded-full bg-gray-300" title="Not logged"></span>
-                  {/if}
-                </td>
-              </tr>
-            {/each}
-          </tbody>
-        </table>
-      </div>
-    </div>
-
-    <!-- Deployed Models -->
-    <div class="bg-white rounded-lg shadow p-5 compact:p-3">
-      <div class="flex justify-between items-center mb-4">
-        <h2 class="text-lg font-medium">Deployed Models</h2>
-        <a href="/modelhub" class="text-sm text-xinity-magenta hover:text-xinity-pink"
-          >View All</a
-        >
-      </div>
-      <div class="space-y-3 compact:space-y-1">
-        {#each recentModels as model}
-          <div
-            class="flex items-center justify-between p-3 compact:p-2 border rounded-lg hover:bg-gray-50"
-          >
-            <div class="flex items-center">
-              <div class="ml-3">
-                <p class="text-sm font-medium text-gray-900">{model.name}</p>
-                <div class="flex items-center mt-1">
-                  <span class="h-2 w-2 rounded-full bg-green-500 mr-1.5"></span>
-                  <p class="text-xs text-gray-500 capitalize">{model.status}</p>
-                </div>
+      <div class="bg-white rounded-lg shadow p-5 compact:p-3">
+        <p class="text-sm text-gray-500 mb-1">Avg Tokens / Call</p>
+        <div class="mt-1 space-y-1">
+          <div>
+            <p class="text-xs text-gray-400 mb-0.5">Input</p>
+            <div class="flex items-baseline gap-3">
+              <div>
+                <span class="text-xl font-bold">{formatTokenAvg(tokenStats.avgInput1h)}</span>
+                <span class="text-xs text-gray-400 ml-0.5">1h</span>
+              </div>
+              <div>
+                <span class="text-base font-semibold text-gray-600">{formatTokenAvg(tokenStats.avgInput10m)}</span>
+                <span class="text-xs text-gray-400 ml-0.5">10m</span>
+              </div>
+              <div>
+                <span class="text-base font-semibold text-gray-600">{formatTokenAvg(tokenStats.avgInput1m)}</span>
+                <span class="text-xs text-gray-400 ml-0.5">1m</span>
               </div>
             </div>
-            <a
-              href="/modelhub"
-              class="text-sm text-xinity-magenta hover:text-xinity-pink">Details</a
-            >
           </div>
-        {/each}
+          <div>
+            <p class="text-xs text-gray-400 mb-0.5">Output</p>
+            <div class="flex items-baseline gap-3">
+              <div>
+                <span class="text-xl font-bold">{formatTokenAvg(tokenStats.avgOutput1h)}</span>
+                <span class="text-xs text-gray-400 ml-0.5">1h</span>
+              </div>
+              <div>
+                <span class="text-base font-semibold text-gray-600">{formatTokenAvg(tokenStats.avgOutput10m)}</span>
+                <span class="text-xs text-gray-400 ml-0.5">10m</span>
+              </div>
+              <div>
+                <span class="text-base font-semibold text-gray-600">{formatTokenAvg(tokenStats.avgOutput1m)}</span>
+                <span class="text-xs text-gray-400 ml-0.5">1m</span>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
-      <div class="mt-4 text-center">
-        <a
-          href="/training"
-          class="inline-flex items-center px-4 py-2 border border-xinity-purple text-sm font-medium rounded-md text-xinity-magenta bg-white hover:bg-xinity-magenta/10"
-        >
-          Train New Model
-        </a>
+
+      <div class="bg-white rounded-lg shadow p-5 compact:p-3">
+        <p class="text-sm text-gray-500 mb-1">Approval Rate</p>
+        <p class="text-2xl font-bold">{apiCallStats.approvalRate}%</p>
+        <p class="text-xs text-gray-400 mt-2">
+          Avg response: {apiCallStats.avgResponseTime}s
+        </p>
+      </div>
+
+      <div class="bg-white rounded-lg shadow p-5 compact:p-3">
+        <p class="text-sm text-gray-500 mb-1">Training Datapoints</p>
+        <p class="text-2xl font-bold">{trainingData.datapoints}</p>
+        <p class="text-xs text-xinity-magenta mt-2">
+          {trainingData.edited}% edited, {trainingData.rated}% rated
+        </p>
       </div>
     </div>
+  {/await}
+
+  <!-- Main dashboard content (3-column grid) -->
+  <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 compact:gap-3">
+    <!-- Usage Trend Chart (col-span-2) -->
+    {#await charts}
+      <div class="bg-white rounded-lg shadow p-5 compact:p-3 lg:col-span-2 animate-pulse">
+        <div class="h-5 bg-gray-200 rounded w-48 mb-4"></div>
+        <div class="h-80 bg-gray-100 rounded"></div>
+      </div>
+    {:then { usageTrend }}
+      <div class="bg-white rounded-lg shadow p-5 compact:p-3 lg:col-span-2">
+        <h2 class="text-lg font-medium mb-4 compact:mb-2">Usage Trend (30 days)</h2>
+        <div class="h-80">
+          <Chart
+            className="size-full"
+            config={{
+              type: "line",
+              data: {
+                labels: getLast30Days(),
+                datasets: [
+                  {
+                    label: "Total Calls",
+                    data: usageTrend.map(d => d.totalCalls),
+                    backgroundColor: "rgba(160, 32, 240, 0.2)",
+                    borderColor: "rgba(160, 32, 240, 1)",
+                    borderWidth: 2,
+                    tension: 0.3,
+                    pointRadius: 3,
+                    pointBackgroundColor: "rgba(160, 32, 240, 1)",
+                    yAxisID: "y",
+                  },
+                  {
+                    label: "Logged Calls",
+                    data: usageTrend.map(d => d.loggedCalls),
+                    backgroundColor: "rgba(160, 32, 240, 0.05)",
+                    borderColor: "rgba(160, 32, 240, 0.4)",
+                    borderWidth: 2,
+                    borderDash: [5, 5],
+                    tension: 0.3,
+                    pointRadius: 2,
+                    pointBackgroundColor: "rgba(160, 32, 240, 0.4)",
+                    yAxisID: "y",
+                  },
+                  {
+                    label: "Input Tokens",
+                    data: usageTrend.map(d => d.inputTokens),
+                    backgroundColor: "rgba(214, 51, 132, 0.1)",
+                    borderColor: "rgba(214, 51, 132, 0.8)",
+                    borderWidth: 2,
+                    tension: 0.3,
+                    pointRadius: 2,
+                    pointBackgroundColor: "rgba(214, 51, 132, 0.8)",
+                    yAxisID: "y1",
+                  },
+                  {
+                    label: "Output Tokens",
+                    data: usageTrend.map(d => d.outputTokens),
+                    backgroundColor: "rgba(232, 96, 74, 0.1)",
+                    borderColor: "rgba(232, 96, 74, 0.8)",
+                    borderWidth: 2,
+                    tension: 0.3,
+                    pointRadius: 2,
+                    pointBackgroundColor: "rgba(232, 96, 74, 0.8)",
+                    yAxisID: "y1",
+                  },
+                ],
+              },
+              options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                interaction: {
+                  mode: "index",
+                  intersect: false,
+                },
+                scales: {
+                  y: {
+                    type: "linear",
+                    position: "left",
+                    beginAtZero: true,
+                    title: {
+                      display: true,
+                      text: "Calls",
+                    },
+                    border: {
+                      display: false,
+                    },
+                  },
+                  y1: {
+                    type: "linear",
+                    position: "right",
+                    beginAtZero: true,
+                    title: {
+                      display: true,
+                      text: "Tokens",
+                    },
+                    grid: {
+                      drawOnChartArea: false,
+                    },
+                  },
+                  x: {
+                    grid: {
+                      display: false,
+                    },
+                  },
+                },
+                plugins: {
+                  legend: {
+                    display: true,
+                    position: "bottom",
+                  },
+                },
+              },
+            }}
+          />
+        </div>
+      </div>
+    {/await}
+
+    <!-- Response Rating Chart -->
+    {#await keyMetrics}
+      <div class="bg-white rounded-lg shadow p-5 compact:p-3 animate-pulse">
+        <div class="h-5 bg-gray-200 rounded w-36 mb-4"></div>
+        <div class="h-80 bg-gray-100 rounded"></div>
+      </div>
+    {:then { responseRatings }}
+      <div class="bg-white rounded-lg shadow p-5 compact:p-3">
+        <h2 class="text-lg font-medium mb-4 compact:mb-2">Response Ratings</h2>
+        <div class="h-80">
+          <Chart
+            className="size-full"
+            config={{
+              type: "doughnut",
+              data: {
+                labels: ["Liked", "Disliked", "Unrated"],
+                datasets: [
+                  {
+                    data: [
+                      responseRatings.liked,
+                      responseRatings.disliked,
+                      responseRatings.unrated,
+                    ],
+                    backgroundColor: [
+                      "rgba(160, 32, 240, 0.6)",
+                      "rgba(232, 96, 74, 0.6)",
+                      "rgba(209, 213, 219, 0.6)",
+                    ],
+                    borderColor: [
+                      "rgba(160, 32, 240, 1)",
+                      "rgba(232, 96, 74, 1)",
+                      "rgba(209, 213, 219, 1)",
+                    ],
+                    borderWidth: 1,
+                  },
+                ],
+              },
+              options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                cutout: "60%",
+                plugins: {
+                  legend: {
+                    position: "bottom",
+                  },
+                },
+              },
+            } satisfies ChartConfiguration<"doughnut"> as ChartConfiguration}
+          />
+        </div>
+      </div>
+    {/await}
+
+    <!-- Application Usage Chart -->
+    {#await charts}
+      <div class="bg-white rounded-lg shadow p-5 compact:p-3 animate-pulse">
+        <div class="h-5 bg-gray-200 rounded w-36 mb-4"></div>
+        <div class="h-80 bg-gray-100 rounded"></div>
+      </div>
+    {:then { topApplications }}
+      <div class="bg-white rounded-lg shadow p-5 compact:p-3">
+        <h2 class="text-lg font-medium mb-4 compact:mb-2">Application Usage</h2>
+        <div class="h-80">
+          <Chart
+            className="size-full"
+            config={{
+              type: "bar",
+              data: {
+                labels: topApplications.map((app) => app.name),
+                datasets: [
+                  {
+                    label: "Calls (30 days)",
+                    data: topApplications.map((app) => app.totalCalls),
+                    backgroundColor: "rgba(160, 32, 240, 0.6)",
+                    borderColor: "rgba(160, 32, 240, 1)",
+                    borderWidth: 1,
+                    borderRadius: 4,
+                  },
+                ],
+              },
+              options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                scales: {
+                  y: {
+                    beginAtZero: true,
+                    border: {
+                      display: false,
+                    },
+                  },
+                  x: {
+                    grid: {
+                      display: false,
+                    },
+                  },
+                },
+              },
+            }}
+          />
+        </div>
+      </div>
+    {/await}
+
+    <!-- Recent Activities -->
+    {#await tables}
+      <div class="bg-white rounded-lg shadow p-5 compact:p-3 lg:col-span-2 animate-pulse">
+        <div class="h-5 bg-gray-200 rounded w-36 mb-4"></div>
+        <div class="space-y-3">
+          {#each Array(5) as _}
+            <div class="h-10 bg-gray-100 rounded"></div>
+          {/each}
+        </div>
+      </div>
+      <div class="bg-white rounded-lg shadow p-5 compact:p-3 animate-pulse">
+        <div class="h-5 bg-gray-200 rounded w-36 mb-4"></div>
+        <div class="space-y-3">
+          {#each Array(3) as _}
+            <div class="h-14 bg-gray-100 rounded"></div>
+          {/each}
+        </div>
+      </div>
+    {:then { recentActivities, recentModels }}
+      <div class="bg-white rounded-lg shadow p-5 compact:p-3 lg:col-span-2">
+        <div class="flex justify-between items-center mb-4">
+          <h2 class="text-lg font-medium">Recent Activities</h2>
+          <a href="/data" class="text-sm text-xinity-magenta hover:text-xinity-pink">View All</a>
+        </div>
+        <div class="overflow-x-auto">
+          <table class="min-w-full divide-y divide-gray-200">
+            <thead class="bg-gray-50">
+              <tr>
+                <th scope="col" class="px-6 py-3 compact:py-1.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Model</th>
+                <th scope="col" class="px-6 py-3 compact:py-1.5 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Input Tokens</th>
+                <th scope="col" class="px-6 py-3 compact:py-1.5 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Output Tokens</th>
+                <th scope="col" class="px-6 py-3 compact:py-1.5 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Duration</th>
+                <th scope="col" class="px-6 py-3 compact:py-1.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Time</th>
+                <th scope="col" class="px-6 py-3 compact:py-1.5 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Logged</th>
+              </tr>
+            </thead>
+            <tbody class="bg-white divide-y divide-gray-200">
+              {#each recentActivities as activity}
+                <tr>
+                  <td class="px-6 py-4 compact:py-2 whitespace-nowrap">
+                    <div class="text-sm font-medium text-gray-900">{activity.model}</div>
+                  </td>
+                  <td class="px-6 py-4 compact:py-2 whitespace-nowrap text-right">
+                    <div class="text-sm text-gray-500">{formatTokens(activity.inputTokens)}</div>
+                  </td>
+                  <td class="px-6 py-4 compact:py-2 whitespace-nowrap text-right">
+                    <div class="text-sm text-gray-500">{formatTokens(activity.outputTokens)}</div>
+                  </td>
+                  <td class="px-6 py-4 compact:py-2 whitespace-nowrap text-right">
+                    <div class="text-sm text-gray-500">{formatDuration(activity.duration)}</div>
+                  </td>
+                  <td class="px-6 py-4 compact:py-2 whitespace-nowrap">
+                    <div class="text-sm text-gray-500">{formatDate(activity.timestamp)}</div>
+                  </td>
+                  <td class="px-6 py-4 compact:py-2 whitespace-nowrap text-center">
+                    {#if activity.logged}
+                      <span class="inline-block h-2 w-2 rounded-full bg-green-500" title="Logged"></span>
+                    {:else}
+                      <span class="inline-block h-2 w-2 rounded-full bg-gray-300" title="Not logged"></span>
+                    {/if}
+                  </td>
+                </tr>
+              {/each}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="bg-white rounded-lg shadow p-5 compact:p-3">
+        <div class="flex justify-between items-center mb-4">
+          <h2 class="text-lg font-medium">Deployed Models</h2>
+          <a href="/modelhub" class="text-sm text-xinity-magenta hover:text-xinity-pink">View All</a>
+        </div>
+        <div class="space-y-3 compact:space-y-1">
+          {#each recentModels as model}
+            <div class="flex items-center justify-between p-3 compact:p-2 border rounded-lg hover:bg-gray-50">
+              <div class="flex items-center">
+                <div class="ml-3">
+                  <p class="text-sm font-medium text-gray-900">{model.name}</p>
+                  <div class="flex items-center mt-1">
+                    <span class="h-2 w-2 rounded-full bg-green-500 mr-1.5"></span>
+                    <p class="text-xs text-gray-500 capitalize">{model.status}</p>
+                  </div>
+                </div>
+              </div>
+              <a href="/modelhub" class="text-sm text-xinity-magenta hover:text-xinity-pink">Details</a>
+            </div>
+          {/each}
+        </div>
+        <div class="mt-4 text-center">
+          <a
+            href="/training"
+            class="inline-flex items-center px-4 py-2 border border-xinity-purple text-sm font-medium rounded-md text-xinity-magenta bg-white hover:bg-xinity-magenta/10"
+          >
+            Train New Model
+          </a>
+        </div>
+      </div>
+    {/await}
   </div>
 </div>

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/GettingStartedChecklist.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/GettingStartedChecklist.svelte
@@ -3,6 +3,7 @@
   import { invalidateAll } from "$app/navigation";
   import { toastState } from "$lib/state/toast.svelte";
   import type { DisplaySettings } from "common-db";
+  import type { ChecklistData } from "./dashboard.types";
 
   import * as Card from "$lib/components/ui/card";
   import { Button } from "$lib/components/ui/button";
@@ -21,76 +22,72 @@
     Loader2,
   } from "@lucide/svelte";
 
-  type ChecklistData = {
-    hasOrganization: boolean;
-    hasDeployment: boolean;
-    hasApiCall: boolean;
-    hasLabeledCall: boolean;
-    hasInvitation: boolean;
-    hasApplication: boolean;
-  };
-
   let {
     checklist,
     displaySettings,
   }: {
-    checklist: ChecklistData;
+    checklist: Promise<ChecklistData>;
     displaySettings: DisplaySettings;
   } = $props();
 
   let isDismissing = $state(false);
+  let resolved = $state<ChecklistData | null>(null);
 
-  const hasOrg = $derived(checklist.hasOrganization);
+  $effect(() => {
+    checklist.then(data => { resolved = data; });
+  });
 
-  const steps = $derived([
+  const hasOrg = $derived(resolved?.hasOrganization ?? false);
+
+  const steps = $derived(resolved ? [
     {
       label: "Create your organization",
-      complete: checklist.hasOrganization,
+      complete: resolved.hasOrganization,
       href: "/organizations/create/",
       icon: Rocket,
       disabled: false,
     },
     {
       label: "Deploy your first model",
-      complete: checklist.hasDeployment,
+      complete: resolved.hasDeployment,
       href: "/modelhub/",
       icon: Server,
       disabled: !hasOrg,
     },
     {
       label: "Make your first API call",
-      complete: checklist.hasApiCall,
+      complete: resolved.hasApiCall,
       href: "/docs/quick-start/",
       icon: Send,
       disabled: !hasOrg,
     },
     {
       label: "Label an API call",
-      complete: checklist.hasLabeledCall,
+      complete: resolved.hasLabeledCall,
       href: "/data/",
       icon: ThumbsUp,
       disabled: !hasOrg,
     },
     {
       label: "Invite a team member",
-      complete: checklist.hasInvitation,
+      complete: resolved.hasInvitation,
       href: "/organizations/",
       icon: Users,
       disabled: !hasOrg,
     },
     {
       label: "Create an application",
-      complete: checklist.hasApplication,
+      complete: resolved.hasApplication,
       href: "/ai-api-keys/",
       icon: AppWindow,
       disabled: !hasOrg,
     },
-  ]);
+  ] : null);
 
-  const completedCount = $derived(steps.filter((s) => s.complete).length);
-  const totalSteps = $derived(steps.length);
+  const completedCount = $derived(steps ? steps.filter((s) => s.complete).length : 0);
+  const totalSteps = $derived(steps ? steps.length : 6);
   const progressPercent = $derived(Math.round((completedCount / totalSteps) * 100));
-  const allComplete = $derived(completedCount === totalSteps);
+  const allComplete = $derived(steps != null && completedCount === totalSteps);
 
   async function dismiss() {
     isDismissing = true;
@@ -113,20 +110,34 @@
   <Card.Root class="p-4 compact:p-3">
     <div class="flex items-center justify-between mb-3 compact:mb-2">
       <div class="flex items-center gap-2">
-        {#if allComplete}
+        {#if steps == null}
+          <Rocket class="w-5 h-5 text-xinity-magenta shrink-0" />
+          <h3 class="text-base font-semibold">Getting Started</h3>
+          <div class="w-10 h-4 bg-gray-200 rounded animate-pulse"></div>
+          <div class="w-20 bg-secondary rounded-full h-1.5">
+            <div class="bg-gray-300 h-1.5 rounded-full w-0"></div>
+          </div>
+        {:else if allComplete}
           <PartyPopper class="w-5 h-5 text-green-600 shrink-0" />
           <h3 class="text-base font-semibold">All done!</h3>
+          <span class="text-xs text-muted-foreground">{completedCount}/{totalSteps}</span>
+          <div class="w-20 bg-secondary rounded-full h-1.5">
+            <div
+              class="bg-green-500 h-1.5 rounded-full transition-all duration-500 ease-out"
+              style="width: {progressPercent}%"
+            ></div>
+          </div>
         {:else}
           <Rocket class="w-5 h-5 text-xinity-magenta shrink-0" />
           <h3 class="text-base font-semibold">Getting Started</h3>
+          <span class="text-xs text-muted-foreground">{completedCount}/{totalSteps}</span>
+          <div class="w-20 bg-secondary rounded-full h-1.5">
+            <div
+              class="bg-green-500 h-1.5 rounded-full transition-all duration-500 ease-out"
+              style="width: {progressPercent}%"
+            ></div>
+          </div>
         {/if}
-        <span class="text-xs text-muted-foreground">{completedCount}/{totalSteps}</span>
-        <div class="w-20 bg-secondary rounded-full h-1.5">
-          <div
-            class="bg-green-500 h-1.5 rounded-full transition-all duration-500 ease-out"
-            style="width: {progressPercent}%"
-          ></div>
-        </div>
       </div>
       <Button
         variant="ghost"
@@ -145,29 +156,39 @@
     </div>
 
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-1.5 compact:gap-1">
-      {#each steps as step}
-        {#if step.complete}
-          <div class="flex items-center gap-2 px-2.5 py-1.5 rounded-md bg-green-50 border border-green-200">
-            <CheckCircle2 class="w-4 h-4 text-green-600 shrink-0" />
-            <span class="text-xs font-medium text-green-800 line-through truncate">{step.label}</span>
+      {#if steps == null}
+        {#each Array(6) as _}
+          <div class="flex items-center gap-2 px-2.5 py-1.5 rounded-md border border-dashed animate-pulse">
+            <div class="w-4 h-4 bg-gray-200 rounded-full shrink-0"></div>
+            <div class="h-3 bg-gray-200 rounded w-28"></div>
+            <div class="w-3.5 h-3.5 bg-gray-100 rounded shrink-0 ml-auto"></div>
           </div>
-        {:else if step.disabled}
-          <div class="flex items-center gap-2 px-2.5 py-1.5 rounded-md border border-dashed opacity-40 cursor-default">
-            <Circle class="w-4 h-4 shrink-0" />
-            <span class="text-xs font-medium truncate">{step.label}</span>
-            <step.icon class="w-3.5 h-3.5 shrink-0 ml-auto" />
-          </div>
-        {:else}
-          <a
-            href={step.href}
-            class="flex items-center gap-2 px-2.5 py-1.5 rounded-md border bg-card hover:bg-accent transition-colors"
-          >
-            <Circle class="w-4 h-4 text-muted-foreground shrink-0" />
-            <span class="text-xs font-medium truncate">{step.label}</span>
-            <step.icon class="w-3.5 h-3.5 text-muted-foreground shrink-0 ml-auto" />
-          </a>
-        {/if}
-      {/each}
+        {/each}
+      {:else}
+        {#each steps as step}
+          {#if step.complete}
+            <div class="flex items-center gap-2 px-2.5 py-1.5 rounded-md bg-green-50 border border-green-200">
+              <CheckCircle2 class="w-4 h-4 text-green-600 shrink-0" />
+              <span class="text-xs font-medium text-green-800 line-through truncate">{step.label}</span>
+            </div>
+          {:else if step.disabled}
+            <div class="flex items-center gap-2 px-2.5 py-1.5 rounded-md border border-dashed opacity-40 cursor-default">
+              <Circle class="w-4 h-4 shrink-0" />
+              <span class="text-xs font-medium truncate">{step.label}</span>
+              <step.icon class="w-3.5 h-3.5 shrink-0 ml-auto" />
+            </div>
+          {:else}
+            <a
+              href={step.href}
+              class="flex items-center gap-2 px-2.5 py-1.5 rounded-md border bg-card hover:bg-accent transition-colors"
+            >
+              <Circle class="w-4 h-4 text-muted-foreground shrink-0" />
+              <span class="text-xs font-medium truncate">{step.label}</span>
+              <step.icon class="w-3.5 h-3.5 text-muted-foreground shrink-0 ml-auto" />
+            </a>
+          {/if}
+        {/each}
+      {/if}
     </div>
   </Card.Root>
 </div>

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/dashboard.types.ts
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/dashboard.types.ts
@@ -1,0 +1,82 @@
+export type ChecklistData = {
+  hasOrganization: boolean;
+  hasDeployment: boolean;
+  hasApiCall: boolean;
+  hasLabeledCall: boolean;
+  hasInvitation: boolean;
+  hasApplication: boolean;
+};
+
+export type ApiCallStats = {
+  totalCalls: number;
+  loggedCalls: number;
+  todayCalls: number;
+  todayLoggedCalls: number;
+  approvalRate: number;
+  avgResponseTime: number;
+};
+
+export type TokenStats = {
+  avgInput1m: number | null;
+  avgOutput1m: number | null;
+  avgInput10m: number | null;
+  avgOutput10m: number | null;
+  avgInput1h: number | null;
+  avgOutput1h: number | null;
+};
+
+export type ResponseRatings = {
+  liked: number;
+  disliked: number;
+  unrated: number;
+};
+
+export type TrainingData = {
+  datapoints: number;
+  edited: number;
+  rated: number;
+};
+
+export type UsageTrendEntry = {
+  totalCalls: number;
+  loggedCalls: number;
+  inputTokens: number;
+  outputTokens: number;
+};
+
+export type TopApplication = {
+  name: string;
+  totalCalls: number;
+  totalTokens: number;
+};
+
+export type RecentActivity = {
+  model: string;
+  timestamp: string;
+  inputTokens: number;
+  outputTokens: number;
+  duration: number | null;
+  logged: boolean;
+};
+
+export type RecentModel = {
+  name: string;
+  status: string;
+};
+
+export type KeyMetrics = {
+  apiCallStats: ApiCallStats;
+  tokenStats: TokenStats;
+  responseRatings: ResponseRatings;
+  trainingData: TrainingData;
+};
+
+export type ChartsData = {
+  usageTrend: UsageTrendEntry[];
+  topApplications: TopApplication[];
+};
+
+export type TablesData = {
+  recentActivities: RecentActivity[];
+  recentModels: RecentModel[];
+};


### PR DESCRIPTION
## Description

This pull request is concerning the fact that the dashboard home page loads various information from the database. This page is the one located at /, and initially loaded after signin, by default. Its also a page that is very often navigated away from very quickly.  
The waiting should by all means not be necessary. Svelte has a builtin feature, where info when in form of a promise can be streamed over on load to the client. 
The change in this request uses that to make the home page load considerably faster. The page now shows some loading skeletons, that are very quickly replaced by real populated dashboard tiles. 

## Type of change

Bug fix

## Testing

No tests are impacted. The tests accessing that page still need to wait for network idle so they work as before.

## Checklist

- [x] Tests pass locally (`bun test`), or no testable code was changed
- [x] New or changed behavior is covered by tests, or this change does not require tests
- [x] Documentation is updated, or no user-facing behavior or configuration was changed
- [x] There are no breaking changes, or they are marked with `!` in the commit type and described above
- [x] No security-sensitive changes (authentication, credentials, input handling), or they have been reviewed
- [x] No new dependencies were added, or they have been reviewed for license and maintenance status