### PR TITLE
feat: better vllm provider arg defaults

### DIFF
--- a/packages/xinity-ai-daemon/src/modules/model-installation/vllm.test.ts
+++ b/packages/xinity-ai-daemon/src/modules/model-installation/vllm.test.ts
@@ -421,6 +421,56 @@ describe("syncVllmInstallations$", () => {
     expect(ops.start).not.toHaveBeenCalled();
   });
 
+  test("adds --runner pooling for embedding models", async () => {
+    const id = crypto.randomUUID();
+    const inst = makeInstallation("embed-model", id, 9102);
+    mockFetchModel.mockImplementation(() => Promise.resolve({ type: "embedding" }));
+    const ops = createMockOps({
+      listRunning: mock(() => Promise.resolve([])),
+      checkHealth: mock(() => Promise.resolve(true)),
+      isAlive: mock(() => Promise.resolve(true)),
+    });
+
+    await firstValueFrom(syncVllmInstallations$([inst], ops));
+
+    const startCall = (ops.start as ReturnType<typeof mock>).mock.calls[0]!;
+    expect(startCall[1].extraArgs).toContain("--runner");
+    expect(startCall[1].extraArgs).toContain("pooling");
+  });
+
+  test("adds --runner pooling for rerank models", async () => {
+    const id = crypto.randomUUID();
+    const inst = makeInstallation("rerank-model", id, 9103);
+    mockFetchModel.mockImplementation(() => Promise.resolve({ type: "rerank" }));
+    const ops = createMockOps({
+      listRunning: mock(() => Promise.resolve([])),
+      checkHealth: mock(() => Promise.resolve(true)),
+      isAlive: mock(() => Promise.resolve(true)),
+    });
+
+    await firstValueFrom(syncVllmInstallations$([inst], ops));
+
+    const startCall = (ops.start as ReturnType<typeof mock>).mock.calls[0]!;
+    expect(startCall[1].extraArgs).toContain("--runner");
+    expect(startCall[1].extraArgs).toContain("pooling");
+  });
+
+  test("does not add --runner pooling for chat models", async () => {
+    const id = crypto.randomUUID();
+    const inst = makeInstallation("chat-model", id, 9104);
+    mockFetchModel.mockImplementation(() => Promise.resolve({ type: "chat" }));
+    const ops = createMockOps({
+      listRunning: mock(() => Promise.resolve([])),
+      checkHealth: mock(() => Promise.resolve(true)),
+      isAlive: mock(() => Promise.resolve(true)),
+    });
+
+    await firstValueFrom(syncVllmInstallations$([inst], ops));
+
+    const startCall = (ops.start as ReturnType<typeof mock>).mock.calls[0]!;
+    expect(startCall[1].extraArgs).not.toContain("--runner");
+  });
+
   test("reconciles crash-looping container to failed and stops it", async () => {
     const id = crypto.randomUUID();
     const inst = makeInstallation("reconcile-crashloop", id, 9101);

--- a/packages/xinity-ai-daemon/src/modules/model-installation/vllm.ts
+++ b/packages/xinity-ai-daemon/src/modules/model-installation/vllm.ts
@@ -388,16 +388,20 @@ export function syncVllmInstallations$(
                             "Calculated GPU memory utilization",
                           );
                         }
+                        const modelType = modelInfo?.type;
+                        const resolvedExtraArgs = [
+                          ...(modelType === "embedding" || modelType === "rerank" ? ["--runner", "pooling"] : []),
+                          ...(hasToolsTag ? ["--enable-auto-tool-choice"] : []),
+                          ...extraArgs,
+                        ];
                         return ops.start(installation.id, {
                           model: installation.model,
                           port: installation.port,
                           kvCacheBytes: `${installation.kvCacheCapacity}G`,
                           trustRemoteCode,
                           gpuMemoryUtilization,
-                          extraArgs: hasToolsTag
-                            ? ["--enable-auto-tool-choice", ...extraArgs]
-                            : extraArgs,
-                        }).then(() => modelInfo?.type);
+                          extraArgs: resolvedExtraArgs,
+                        }).then(() => modelType);
                       }),
                     ),
                   ),

--- a/packages/xinity-infoserver/definitions/model-definition.ts
+++ b/packages/xinity-infoserver/definitions/model-definition.ts
@@ -13,6 +13,8 @@ export type Tag = z.infer<typeof TagEnum>;
 export const BLOCKED_VLLM_ARGS = new Set([
   "--trust-remote-code",       // controlled by custom_code tag
   "--enable-auto-tool-choice", // auto-derived from tools tag
+  "--runner",                  // auto-derived from model type (embedding/rerank → pooling)
+  "--task",                    // deprecated in favor of --runner, auto-managed
   "--host",                    // system-managed
   "--port",                    // system-managed
   "--served-model-name",       // system-managed
@@ -46,10 +48,19 @@ const flatStringArray = z.array(nestedStringItem)
   .pipe(z.array(z.string()));
 
 const vllmArgs = flatStringArray
-  .refine(
-    (args: string[]) => !args.some(arg => BLOCKED_VLLM_ARGS.has(arg)),
-    { message: `providerArgs.vllm must not contain system-managed or tag-derived arguments: ${[...BLOCKED_VLLM_ARGS].join(", ")}` },
-  );
+  .transform((args: string[]) => {
+    const result: string[] = [];
+    for (let i = 0; i < args.length; i++) {
+      if (BLOCKED_VLLM_ARGS.has(args[i]!)) {
+        if (args[i + 1] && !args[i + 1]!.startsWith("--")) {
+          i++;
+        }
+      } else {
+        result.push(args[i]!);
+      }
+    }
+    return result;
+  });
 
 export const ModelSchema = z.looseObject({
   name: z.string().describe("Display name of the model. Intended to be easily human readable"),

--- a/packages/xinity-infoserver/model-tags.test.ts
+++ b/packages/xinity-infoserver/model-tags.test.ts
@@ -8,7 +8,7 @@ import {
   driverHasTag,
   resolveArgsForDriver,
 } from "./model-tags";
-import type { Model } from "./definitions/model-definition";
+import { ModelSchema, type Model } from "./definitions/model-definition";
 
 /** Minimal model with both providers */
 function makeModel(overrides: Partial<Model> = {}): Model {
@@ -152,5 +152,46 @@ describe("resolveArgsForDriver", () => {
   it("returns empty array when driver has no args entry", () => {
     const m = makeModel({ providerArgs: { vllm: ["--some-arg"] } });
     expect(resolveArgsForDriver(m, "ollama")).toEqual([]);
+  });
+});
+
+describe("ModelSchema vllm providerArgs filtering", () => {
+  function parseModel(providerArgs: string[]) {
+    return ModelSchema.parse({
+      name: "Test", description: "test", weight: 1, minKvCache: 1,
+      registeredAt: "2025-01-01", url: "https://example.com", entryVersion: "0.1.0",
+      providers: { vllm: "org/test" },
+      providerArgs: { vllm: providerArgs },
+    });
+  }
+
+  it("filters out blocked flag with its value", () => {
+    const m = parseModel(["--runner", "pooling", "--some-flag"]);
+    expect(m.providerArgs!.vllm).toEqual(["--some-flag"]);
+  });
+
+  it("filters out standalone blocked flag followed by another flag", () => {
+    const m = parseModel(["--trust-remote-code", "--some-flag"]);
+    expect(m.providerArgs!.vllm).toEqual(["--some-flag"]);
+  });
+
+  it("filters out blocked flag at end of array", () => {
+    const m = parseModel(["--some-flag", "--trust-remote-code"]);
+    expect(m.providerArgs!.vllm).toEqual(["--some-flag"]);
+  });
+
+  it("filters out multiple blocked args", () => {
+    const m = parseModel(["--runner", "pooling", "--task", "embed", "--some-flag"]);
+    expect(m.providerArgs!.vllm).toEqual(["--some-flag"]);
+  });
+
+  it("passes through non-blocked args unchanged", () => {
+    const m = parseModel(["--max-model-len", "4096", "--dtype", "float16"]);
+    expect(m.providerArgs!.vllm).toEqual(["--max-model-len", "4096", "--dtype", "float16"]);
+  });
+
+  it("returns empty array when all args are blocked", () => {
+    const m = parseModel(["--runner", "pooling"]);
+    expect(m.providerArgs!.vllm).toEqual([]);
   });
 });

--- a/packages/xinity-infoserver/models.schema.json
+++ b/packages/xinity-infoserver/models.schema.json
@@ -122,6 +122,40 @@
               }
             }
           },
+          "requestParams": {
+            "description": "Per-driver allowlist of extra request-level parameters that the gateway may forward. Dot-notation paths mapped to primitive types (boolean, number, string). All are optional at request time",
+            "type": "object",
+            "properties": {
+              "vllm": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {
+                  "type": "string",
+                  "enum": [
+                    "boolean",
+                    "number",
+                    "string"
+                  ]
+                }
+              },
+              "ollama": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {
+                  "type": "string",
+                  "enum": [
+                    "boolean",
+                    "number",
+                    "string"
+                  ]
+                }
+              }
+            }
+          },
           "providers": {
             "type": "object",
             "properties": {


### PR DESCRIPTION
## Description

This issue improves the handling of vllm args. So far, certain args were blocked from the configuration entirely, due to them being managed from within the gateway based on other information we have about models. We now follow a more stable approach, filtering out any duplicates, accounting for currently model specific config arguments, that we might move to daemon managed variables in the future.  
As an example of that, this PR also includes an example of that, specifically, where the embedding and reranker models require --runner pooling to be passed. This was so far managed by `providerArgs`. From here on out these are filtered out of `providerArgs`, and managed by the daemon directly based on the models type.

## Type of change

Bug fix | New feature

## Testing

The model definition tests, and vllm service tests have been adapted accordingly.

## Checklist

- [x] Tests pass locally (`bun test`), or no testable code was changed
- [x] New or changed behavior is covered by tests, or this change does not require tests
- [x] Documentation is updated, or no user-facing behavior or configuration was changed
- [x] There are no breaking changes, or they are marked with `!` in the commit type and described above
- [x] No security-sensitive changes (authentication, credentials, input handling), or they have been reviewed
- [x] No new dependencies were added, or they have been reviewed for license and maintenance status