### PR TITLE
feat(daemon): token vllm template cli alias

### DIFF
--- a/packages/xinity-ai-daemon/src/assets/vllm-driver@.service
+++ b/packages/xinity-ai-daemon/src/assets/vllm-driver@.service
@@ -42,6 +42,7 @@ Environment=CUDA_VISIBLE_DEVICES=0
 # HuggingFace cache: ensure models are downloaded here
 Environment=HF_HOME=/var/lib/vllm/hf-cache
 Environment=TRITON_CACHE_DIR=/var/lib/vllm/triton-cache
+Environment=HF_TOKEN=
 
 ExecStart=/bin/bash -c '\
     ARGS=""; \

--- a/packages/xinity-ai-daemon/src/env-schema.ts
+++ b/packages/xinity-ai-daemon/src/env-schema.ts
@@ -37,6 +37,7 @@ export const daemonEnvSchema = z.object({
     ),
   VLLM_HF_CACHE_DIR: z.string().default("/var/lib/vllm/hf-cache").describe("HuggingFace cache directory").meta(expert()),
   VLLM_TRITON_CACHE_DIR: z.string().default("/var/lib/vllm/triton-cache").describe("Triton cache directory").meta(expert()),
+  VLLM_HF_TOKEN: z.string().optional().describe("HuggingFace token for downloading private or gated models").meta(secret()),
   VLLM_HEALTH_TIMEOUT_MS: z.coerce
     .number()
     .default(60 * 60 * 1000)

--- a/packages/xinity-ai-daemon/src/modules/model-installation/vllm-ops.ts
+++ b/packages/xinity-ai-daemon/src/modules/model-installation/vllm-ops.ts
@@ -57,6 +57,9 @@ function buildEnvFileContent(config: VllmInstanceConfig): string {
   if (config.extraArgs && config.extraArgs.length > 0) {
     lines.push(`VLLM_EXTRA_ARGS=${config.extraArgs.join(" ")}`);
   }
+  if (env.VLLM_HF_TOKEN) {
+    lines.push(`HF_TOKEN=${env.VLLM_HF_TOKEN}`);
+  }
   return lines.join("\n") + "\n";
 }
 
@@ -179,6 +182,7 @@ export function createDockerVllmOps(): VllmOps {
         "-p", `${config.port}:8000`,
         "-e", "HF_HOME=/data/hf-cache",
         "-e", "TRITON_CACHE_DIR=/data/triton-cache",
+        ...(env.VLLM_HF_TOKEN ? ["-e", `HF_TOKEN=${env.VLLM_HF_TOKEN}`] : []),
         "-v", `${env.VLLM_HF_CACHE_DIR}:/data/hf-cache`,
         "-v", `${env.VLLM_TRITON_CACHE_DIR}:/data/triton-cache`,
         "--restart", "unless-stopped",

--- a/packages/xinity-ai-daemon/src/modules/model-installation/vllm-ops.ts
+++ b/packages/xinity-ai-daemon/src/modules/model-installation/vllm-ops.ts
@@ -142,11 +142,17 @@ export function createSystemdVllmOps(): VllmOps {
       const existing = await Bun.file(targetPath).text().catch(() => null);
       if (existing != null) {
         log.debug({ targetPath }, "vLLM systemd template already present, skipping");
-        return;
+      } else {
+        await Bun.write(targetPath, templateUnit);
+        await $`systemctl daemon-reload`;
+        log.info("Installed vLLM systemd template unit");
       }
-      await Bun.write(targetPath, templateUnit);
-      await $`systemctl daemon-reload`;
-      log.info("Installed vLLM systemd template unit");
+
+      // Ensure cache and env directories exist with correct ownership.
+      // The vllm-driver@ template runs as User=vllm with
+      // ReadWritePaths=/var/lib/vllm, so these must be pre-created.
+      await $`mkdir -p ${env.VLLM_HF_CACHE_DIR} ${env.VLLM_TRITON_CACHE_DIR} ${env.VLLM_ENV_DIR}`;
+      await $`chown -R vllm:vllm ${env.VLLM_HF_CACHE_DIR} ${env.VLLM_TRITON_CACHE_DIR}`.nothrow();
     },
   };
 }

--- a/packages/xinity-ai-daemon/src/modules/model-installation/vllm-ops.ts
+++ b/packages/xinity-ai-daemon/src/modules/model-installation/vllm-ops.ts
@@ -140,11 +140,13 @@ export function createSystemdVllmOps(): VllmOps {
     async ensureSetup() {
       const targetPath = env.VLLM_TEMPLATE_UNIT_PATH;
       const existing = await Bun.file(targetPath).text().catch(() => null);
-      if (existing !== templateUnit) {
-        await Bun.write(targetPath, templateUnit);
-        await $`systemctl daemon-reload`;
-        log.info("Installed/updated vLLM systemd template unit");
+      if (existing != null) {
+        log.debug({ targetPath }, "vLLM systemd template already present, skipping");
+        return;
       }
+      await Bun.write(targetPath, templateUnit);
+      await $`systemctl daemon-reload`;
+      log.info("Installed vLLM systemd template unit");
     },
   };
 }

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-chatCompletion.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-chatCompletion.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { errorResponse, forwardBackendError, logChatUsage, validateModelType, extractAllowedRequestParams, readSSEStream, handleEndpointError, SSE_RESPONSE_HEADERS, sseEncoder, handleStreamError } from "../util";
+import { errorResponse, forwardBackendError, logChatUsage, validateModelType, extractAllowedRequestParams, readSSEStream, handleEndpointError, SSE_RESPONSE_HEADERS, sseEncoder, handleStreamError, validationError } from "../util";
 import { resolveModel } from "../ai-sdk";
 import { BackendChatChunkSchema, BackendUsageSchema } from "../backend-schemas";
 import type { ApiCallInputMessage } from "common-db";
@@ -62,7 +62,7 @@ export async function handleChatCompletion(req: Request) {
 
     const parseResult = ChatCompletionBodySchema.safeParse(rawBody);
     if (!parseResult.success) {
-      return errorResponse(`Invalid request body: ${parseResult.error.issues.map((i) => i.message).join(", ")}`, 400);
+      return validationError(parseResult.error);
     }
     const body = parseResult.data;
 

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-chatCompletion.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-chatCompletion.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { errorResponse, forwardBackendError, logChatUsage, validateModelType, extractAllowedRequestParams, readSSEStream, isConnectionRefused, isAbortError, isTimeoutError, BACKEND_RESTART_RETRY_AFTER } from "../util";
+import { errorResponse, forwardBackendError, logChatUsage, validateModelType, extractAllowedRequestParams, readSSEStream, isAbortError, handleEndpointError } from "../util";
 import { resolveModel } from "../ai-sdk";
 import { BackendChatChunkSchema, BackendUsageSchema } from "../backend-schemas";
 import type { ApiCallInputMessage } from "common-db";
@@ -264,19 +264,6 @@ export async function handleChatCompletion(req: Request) {
     }
 
   } catch (error) {
-    if (isAbortError(error)) {
-      log.info({ err: error }, "Client disconnected");
-      return new Response(null, { status: 499 });
-    }
-    if (isTimeoutError(error)) {
-      log.warn({ err: error }, "Backend timeout");
-      return errorResponse("Backend timeout", 504);
-    }
-    if (isConnectionRefused(error)) {
-      log.warn({ err: error }, "Backend unreachable");
-      return errorResponse("Service temporarily unavailable — consider adding cluster capacity", 503, { "Retry-After": String(BACKEND_RESTART_RETRY_AFTER) });
-    }
-    log.error({ err: error }, "Internal gateway error");
-    return errorResponse(error instanceof Error ? error.message : "Internal Server Error", 500);
+    return handleEndpointError(error, log);
   }
 }

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-chatCompletion.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-chatCompletion.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { errorResponse, forwardBackendError, logChatUsage, validateModelType, extractAllowedRequestParams, readSSEStream, isAbortError, handleEndpointError } from "../util";
+import { errorResponse, forwardBackendError, logChatUsage, validateModelType, extractAllowedRequestParams, readSSEStream, handleEndpointError, SSE_RESPONSE_HEADERS, sseEncoder, handleStreamError } from "../util";
 import { resolveModel } from "../ai-sdk";
 import { BackendChatChunkSchema, BackendUsageSchema } from "../backend-schemas";
 import type { ApiCallInputMessage } from "common-db";
@@ -8,8 +8,6 @@ import { processMessageImages, imageStore } from "../../image-store";
 import { env } from "../../env";
 
 const log = rootLogger.child({ name: "handle-chatCompletion" });
-
-const encoder = new TextEncoder();
 
 const ChatCompletionBodySchema = z.looseObject({
   model: z.string(),
@@ -144,7 +142,7 @@ export async function handleChatCompletion(req: Request) {
           try {
             for await (const event of readSSEStream(backendResponse)) {
               if (event.data === "[DONE]") {
-                controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+                controller.enqueue(sseEncoder.encode("data: [DONE]\n\n"));
                 break;
               }
 
@@ -174,7 +172,7 @@ export async function handleChatCompletion(req: Request) {
                 }
               }
 
-              controller.enqueue(encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`));
+              controller.enqueue(sseEncoder.encode(`data: ${JSON.stringify(chunk)}\n\n`));
             }
             controller.close();
 
@@ -194,30 +192,12 @@ export async function handleChatCompletion(req: Request) {
               stream: true,
             });
           } catch (e) {
-            if (isAbortError(e)) {
-              log.info({ err: e }, "Client disconnected during stream");
-              try { controller.close(); } catch {}
-              return;
-            }
-            log.error({ err: e }, "Stream error");
-            try {
-              controller.enqueue(encoder.encode(`data: ${JSON.stringify({ error: { message: "Internal stream error", type: "server_error" } })}\n\n`));
-              controller.enqueue(encoder.encode("data: [DONE]\n\n"));
-              controller.close();
-            } catch {
-              try { controller.error(e as Error); } catch {}
-            }
+            handleStreamError(e, controller, log);
           }
         },
       });
 
-      return new Response(stream, {
-        headers: {
-          "Content-Type": "text/event-stream",
-          "Cache-Control": "no-cache",
-          "Connection": "keep-alive",
-        },
-      });
+      return new Response(stream, { headers: SSE_RESPONSE_HEADERS });
 
     } else {
       // Non-streaming: always forward, extract logging data field-by-field

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-completions.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-completions.ts
@@ -1,14 +1,12 @@
 import { z } from "zod";
 import { resolveModel } from "../ai-sdk";
-import { errorResponse, forwardBackendError, logChatUsage, readSSEStream, validateModelType, isAbortError, handleEndpointError } from "../util";
+import { errorResponse, forwardBackendError, logChatUsage, readSSEStream, validateModelType, handleEndpointError, SSE_RESPONSE_HEADERS, sseEncoder, handleStreamError } from "../util";
 import { BackendCompletionChunkSchema, BackendUsageSchema } from "../backend-schemas";
 import type { ApiCallInputMessage } from "common-db";
 import { rootLogger } from "../../logger";
 import { env } from "../../env";
 
 const log = rootLogger.child({ name: "handle-completions" });
-
-const encoder = new TextEncoder();
 
 const CompletionBodySchema = z.looseObject({
   model: z.string(),
@@ -108,7 +106,7 @@ export async function handleCompletion(req: Request): Promise<Response> {
           try {
             for await (const event of readSSEStream(backendResponse)) {
               if (event.data === "[DONE]") {
-                controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+                controller.enqueue(sseEncoder.encode("data: [DONE]\n\n"));
                 break;
               }
 
@@ -135,7 +133,7 @@ export async function handleCompletion(req: Request): Promise<Response> {
                 }
               }
 
-              controller.enqueue(encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`));
+              controller.enqueue(sseEncoder.encode(`data: ${JSON.stringify(chunk)}\n\n`));
             }
             controller.close();
 
@@ -156,30 +154,12 @@ export async function handleCompletion(req: Request): Promise<Response> {
               stream: true,
             });
           } catch (e) {
-            if (isAbortError(e)) {
-              log.info({ err: e }, "Client disconnected during stream");
-              try { controller.close(); } catch {}
-              return;
-            }
-            log.error({ err: e }, "Stream error");
-            try {
-              controller.enqueue(encoder.encode(`data: ${JSON.stringify({ error: { message: "Internal stream error", type: "server_error" } })}\n\n`));
-              controller.enqueue(encoder.encode("data: [DONE]\n\n"));
-              controller.close();
-            } catch {
-              try { controller.error(e as Error); } catch {}
-            }
+            handleStreamError(e, controller, log);
           }
         },
       });
 
-      return new Response(stream, {
-        headers: {
-          "Content-Type": "text/event-stream",
-          "Cache-Control": "no-cache",
-          Connection: "keep-alive",
-        },
-      });
+      return new Response(stream, { headers: SSE_RESPONSE_HEADERS });
     }
 
     // Non-streaming: always forward, extract logging data field-by-field

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-completions.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-completions.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { resolveModel } from "../ai-sdk";
-import { errorResponse, forwardBackendError, logChatUsage, readSSEStream, validateModelType, isConnectionRefused, isAbortError, isTimeoutError, BACKEND_RESTART_RETRY_AFTER } from "../util";
+import { errorResponse, forwardBackendError, logChatUsage, readSSEStream, validateModelType, isAbortError, handleEndpointError } from "../util";
 import { BackendCompletionChunkSchema, BackendUsageSchema } from "../backend-schemas";
 import type { ApiCallInputMessage } from "common-db";
 import { rootLogger } from "../../logger";
@@ -219,19 +219,6 @@ export async function handleCompletion(req: Request): Promise<Response> {
 
     return Response.json(raw);
   } catch (error) {
-    if (isAbortError(error)) {
-      log.info({ err: error }, "Client disconnected");
-      return new Response(null, { status: 499 });
-    }
-    if (isTimeoutError(error)) {
-      log.warn({ err: error }, "Backend timeout");
-      return errorResponse("Backend timeout", 504);
-    }
-    if (isConnectionRefused(error)) {
-      log.warn({ err: error }, "Backend unreachable");
-      return errorResponse("Service temporarily unavailable — consider adding cluster capacity", 503, { "Retry-After": String(BACKEND_RESTART_RETRY_AFTER) });
-    }
-    log.error({ err: error }, "Internal gateway error");
-    return errorResponse(error instanceof Error ? error.message : "Internal Server Error", 500);
+    return handleEndpointError(error, log);
   }
 }

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-completions.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-completions.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { resolveModel } from "../ai-sdk";
-import { errorResponse, forwardBackendError, logChatUsage, readSSEStream, validateModelType, handleEndpointError, SSE_RESPONSE_HEADERS, sseEncoder, handleStreamError } from "../util";
+import { errorResponse, forwardBackendError, logChatUsage, readSSEStream, validateModelType, handleEndpointError, SSE_RESPONSE_HEADERS, sseEncoder, handleStreamError, validationError } from "../util";
 import { BackendCompletionChunkSchema, BackendUsageSchema } from "../backend-schemas";
 import type { ApiCallInputMessage } from "common-db";
 import { rootLogger } from "../../logger";
@@ -49,7 +49,7 @@ export async function handleCompletion(req: Request): Promise<Response> {
 
     const parseResult = CompletionBodySchema.safeParse(rawBody);
     if (!parseResult.success) {
-      return errorResponse(`Invalid request body: ${parseResult.error.issues.map((i) => i.message).join(", ")}`, 400);
+      return validationError(parseResult.error);
     }
     const body = parseResult.data;
 

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-embeddings.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-embeddings.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { resolveModel } from "../ai-sdk";
-import { errorResponse, forwardBackendError, recordUsage, validateModelType } from "../util";
+import { errorResponse, forwardBackendError, recordUsage, validateModelType, handleEndpointError } from "../util";
 import { rootLogger } from "../../logger";
 import { env } from "../../env";
 
@@ -80,7 +80,6 @@ export async function handleEmbeddingGeneration(req: Request): Promise<Response>
 
     return Response.json(raw);
   } catch (error) {
-    log.error({ err: error }, "Internal gateway error");
-    return errorResponse(error instanceof Error ? error.message : "Internal Server Error", 500);
+    return handleEndpointError(error, log);
   }
 }

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-embeddings.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-embeddings.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { resolveModel } from "../ai-sdk";
-import { errorResponse, forwardBackendError, recordUsage, validateModelType, handleEndpointError } from "../util";
+import { errorResponse, forwardBackendError, recordUsage, validateModelType, handleEndpointError, validationError } from "../util";
 import { rootLogger } from "../../logger";
 import { env } from "../../env";
 
@@ -26,7 +26,7 @@ export async function handleEmbeddingGeneration(req: Request): Promise<Response>
 
     const parseResult = EmbeddingBodySchema.safeParse(rawBody);
     if (!parseResult.success) {
-      return errorResponse(`Invalid request body: ${parseResult.error.issues.map((i) => i.message).join(", ")}`, 400);
+      return validationError(parseResult.error);
     }
     const body = parseResult.data;
 

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-rerank.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-rerank.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { resolveModel } from "../ai-sdk";
-import { errorResponse, forwardBackendError, validateModelType, handleEndpointError } from "../util";
+import { forwardBackendError, validateModelType, handleEndpointError, validationError } from "../util";
 import { rootLogger } from "../../logger";
 import { env } from "../../env";
 
@@ -36,7 +36,7 @@ export async function handleRerank(req: Request): Promise<Response> {
 
     const parseResult = RerankBodySchema.safeParse(rawBody);
     if (!parseResult.success) {
-      return errorResponse(`Invalid request body: ${parseResult.error.issues.map((i) => i.message).join(", ")}`, 400);
+      return validationError(parseResult.error);
     }
     const body = parseResult.data;
 

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-rerank.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-rerank.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { resolveModel } from "../ai-sdk";
-import { errorResponse, forwardBackendError, validateModelType } from "../util";
+import { errorResponse, forwardBackendError, validateModelType, handleEndpointError } from "../util";
 import { rootLogger } from "../../logger";
 import { env } from "../../env";
 
@@ -64,7 +64,6 @@ export async function handleRerank(req: Request): Promise<Response> {
       model: originalModel,
     });
   } catch (error) {
-    log.error({ err: error }, "Internal gateway error");
-    return errorResponse(error instanceof Error ? error.message : "Internal Server Error", 500);
+    return handleEndpointError(error, log);
   }
 }

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-responses.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-responses.ts
@@ -1,6 +1,6 @@
 import { generateText, streamText } from "ai";
 import { resolveAuthorizedModel } from "../ai-sdk";
-import { errorResponse, logChatUsage, validateModelType, toModelMessages } from "../util";
+import { errorResponse, logChatUsage, validateModelType, toModelMessages, SSE_RESPONSE_HEADERS } from "../util";
 import type { ApiCallInputMessage } from "common-db";
 import { checkAuth, type AuthResult } from "../auth";
 import { deleteResponse, getResponse, saveResponse } from "../response-store";
@@ -287,13 +287,7 @@ export async function handleCreateResponseRequest(req: Request): Promise<Respons
         },
       });
 
-      return new Response(streamBody, {
-        headers: {
-          "Content-Type": "text/event-stream",
-          "Cache-Control": "no-cache",
-          Connection: "keep-alive",
-        },
-      });
+      return new Response(streamBody, { headers: SSE_RESPONSE_HEADERS });
     }
 
     // -------------------------------------------------------------------

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-responses.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-responses.ts
@@ -1,6 +1,6 @@
 import { generateText, streamText } from "ai";
 import { resolveAuthorizedModel } from "../ai-sdk";
-import { errorResponse, logChatUsage, validateModelType, toModelMessages, SSE_RESPONSE_HEADERS } from "../util";
+import { errorResponse, logChatUsage, validateModelType, toModelMessages, SSE_RESPONSE_HEADERS, validationError } from "../util";
 import type { ApiCallInputMessage } from "common-db";
 import { checkAuth, type AuthResult } from "../auth";
 import { deleteResponse, getResponse, saveResponse } from "../response-store";
@@ -187,7 +187,7 @@ export async function handleCreateResponseRequest(req: Request): Promise<Respons
     // Validate request body
     const parseResult = CreateResponseBodySchema.safeParse(rawBody);
     if (!parseResult.success) {
-      return errorResponse(`Invalid request body: ${parseResult.error.issues.map((i) => i.message).join(", ")}`, 400);
+      return validationError(parseResult.error);
     }
     const body = parseResult.data;
 

--- a/packages/xinity-ai-gateway/src/llm-forward/util.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/util.ts
@@ -372,6 +372,34 @@ export function isConnectionRefused(error: unknown): boolean {
 /** Seconds to advertise in Retry-After when a backend node is unreachable (covers typical vLLM restart time). */
 export const BACKEND_RESTART_RETRY_AFTER = 120;
 
+/**
+ * Shared top-level error handler for endpoint catch blocks.
+ * Maps common fetch errors to appropriate HTTP status codes.
+ */
+export function handleEndpointError(
+  error: unknown,
+  log: { info: (obj: Record<string, unknown>, msg: string) => void; warn: (obj: Record<string, unknown>, msg: string) => void; error: (obj: Record<string, unknown>, msg: string) => void },
+): Response {
+  if (isAbortError(error)) {
+    log.info({ err: error }, "Client disconnected");
+    return new Response(null, { status: 499 });
+  }
+  if (isTimeoutError(error)) {
+    log.warn({ err: error }, "Backend timeout");
+    return errorResponse("Backend timeout", 504);
+  }
+  if (isConnectionRefused(error)) {
+    log.warn({ err: error }, "Backend unreachable");
+    return errorResponse(
+      "Service temporarily unavailable — consider adding cluster capacity",
+      503,
+      { "Retry-After": String(BACKEND_RESTART_RETRY_AFTER) },
+    );
+  }
+  log.error({ err: error }, "Internal gateway error");
+  return errorResponse(error instanceof Error ? error.message : "Internal Server Error", 500);
+}
+
 export function validateModelType(
   modelInfo: { type?: string },
   expectedTypes: string[],

--- a/packages/xinity-ai-gateway/src/llm-forward/util.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/util.ts
@@ -191,6 +191,48 @@ export const logChatUsage = ({
   }
 };
 
+// ---------------------------------------------------------------------------
+// SSE streaming helpers
+// ---------------------------------------------------------------------------
+
+/** Standard headers for SSE streaming responses. */
+export const SSE_RESPONSE_HEADERS = {
+  "Content-Type": "text/event-stream",
+  "Cache-Control": "no-cache",
+  "Connection": "keep-alive",
+} as const;
+
+/** Shared TextEncoder for SSE frame encoding. */
+export const sseEncoder = new TextEncoder();
+
+/**
+ * Handles errors inside an OpenAI-compatible streaming ReadableStream.
+ * Emits an error event + [DONE] sentinel and closes the controller.
+ */
+export function handleStreamError(
+  e: unknown,
+  controller: ReadableStreamDefaultController,
+  log: { info: (obj: Record<string, unknown>, msg: string) => void; error: (obj: Record<string, unknown>, msg: string) => void },
+): void {
+  if (isAbortError(e)) {
+    log.info({ err: e }, "Client disconnected during stream");
+    try { controller.close(); } catch {}
+    return;
+  }
+  log.error({ err: e }, "Stream error");
+  try {
+    controller.enqueue(sseEncoder.encode(`data: ${JSON.stringify({ error: { message: "Internal stream error", type: "server_error" } })}\n\n`));
+    controller.enqueue(sseEncoder.encode("data: [DONE]\n\n"));
+    controller.close();
+  } catch {
+    try { controller.error(e as Error); } catch {}
+  }
+}
+
+// ---------------------------------------------------------------------------
+// SSE parsing
+// ---------------------------------------------------------------------------
+
 export async function* readSSEStream(response: Response) {
   if (!response.body) throw new Error("ReadableStream not available");
 

--- a/packages/xinity-ai-gateway/src/llm-forward/util.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/util.ts
@@ -230,6 +230,15 @@ export function handleStreamError(
 }
 
 // ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+/** Returns a 400 error response with formatted Zod validation issues. */
+export function validationError(error: { issues: { message: string }[] }): Response {
+  return errorResponse(`Invalid request body: ${error.issues.map((i) => i.message).join(", ")}`, 400);
+}
+
+// ---------------------------------------------------------------------------
 // SSE parsing
 // ---------------------------------------------------------------------------
 

--- a/packages/xinity-cli/src/commands/up.ts
+++ b/packages/xinity-cli/src/commands/up.ts
@@ -9,8 +9,9 @@ import { createLocalHost } from "../lib/host.ts";
 import { connectRemoteHost } from "../lib/remote-host.ts";
 import { seaweedfsSetup } from "../lib/seaweedfs-setup.ts";
 import { discoverRedisUrl } from "../lib/redis-setup.ts";
+import { runUpdateFlow } from "./update.ts";
 
-const COMPONENTS = ["gateway", "dashboard", "daemon", "infoserver", "db", "redis", "seaweedfs", "all"] as const;
+const COMPONENTS = ["gateway", "dashboard", "daemon", "infoserver", "db", "redis", "seaweedfs", "cli", "all"] as const;
 
 export const upCommand: CommandModule = {
   command: "up <component>",
@@ -65,6 +66,11 @@ export const upCommand: CommandModule = {
         p.outro("Aborted");
         return;
       }
+    }
+
+    if (component === "cli") {
+      await runUpdateFlow({ checkOnly: false, targetVersion });
+      return;
     }
 
     if (component === "db") {

--- a/packages/xinity-cli/src/commands/update.ts
+++ b/packages/xinity-cli/src/commands/update.ts
@@ -82,6 +82,60 @@ async function selfUpdate(release: Release): Promise<boolean> {
   }
 }
 
+// ─── Shared update flow ─────────────────────────────────────────────────────
+
+export async function runUpdateFlow(opts: { checkOnly: boolean; targetVersion: string }): Promise<void> {
+  const { checkOnly, targetVersion } = opts;
+
+  p.intro(`xinity update${checkOnly ? pc.yellow(" (check only)") : ""}`);
+
+  // Fetch latest release
+  const spinner = p.spinner();
+  spinner.start("Checking for updates…");
+
+  let release: Release;
+  try {
+    release = await fetchRelease(targetVersion);
+  } catch (err) {
+    spinner.stop("Failed");
+    fail("GitHub API", (err as Error).message);
+    p.outro("Done");
+    return;
+  }
+  spinner.stop(`Latest release: ${release.tagName}`);
+
+  // Compare versions
+  const needsUpdate = CLI_VERSION !== release.tagName && CLI_VERSION !== "dev";
+  const status = needsUpdate
+    ? pc.yellow(`${CLI_VERSION} → ${release.tagName}`)
+    : pc.green(`${CLI_VERSION} (up to date)`);
+  p.log.info(`  ${pc.cyan("cli")}  ${status}`);
+
+  if (!needsUpdate) {
+    p.log.success("Already up to date");
+    p.outro("Done");
+    return;
+  }
+
+  if (checkOnly) {
+    p.outro("Run " + pc.cyan("xinity update") + " to apply the update");
+    return;
+  }
+
+  // Confirm
+  const proceed = await p.confirm({
+    message: `Update CLI to ${release.tagName}?`,
+    initialValue: true,
+  });
+  if (p.isCancel(proceed) || !proceed) {
+    p.cancel("Cancelled.");
+    return;
+  }
+
+  await selfUpdate(release);
+  p.outro("Done");
+}
+
 // ─── Command ────────────────────────────────────────────────────────────────
 
 export const updateCommand: CommandModule = {
@@ -100,55 +154,9 @@ export const updateCommand: CommandModule = {
         default: "latest",
       }),
   handler: async (argv) => {
-    const checkOnly = argv.check as boolean;
-    const targetVersion = argv["target-version"] as string;
-
-    p.intro(`xinity update${checkOnly ? pc.yellow(" (check only)") : ""}`);
-
-    // Fetch latest release
-    const spinner = p.spinner();
-    spinner.start("Checking for updates…");
-
-    let release: Release;
-    try {
-      release = await fetchRelease(targetVersion);
-    } catch (err) {
-      spinner.stop("Failed");
-      fail("GitHub API", (err as Error).message);
-      p.outro("Done");
-      return;
-    }
-    spinner.stop(`Latest release: ${release.tagName}`);
-
-    // Compare versions
-    const needsUpdate = CLI_VERSION !== release.tagName && CLI_VERSION !== "dev";
-    const status = needsUpdate
-      ? pc.yellow(`${CLI_VERSION} → ${release.tagName}`)
-      : pc.green(`${CLI_VERSION} (up to date)`);
-    p.log.info(`  ${pc.cyan("cli")}  ${status}`);
-
-    if (!needsUpdate) {
-      p.log.success("Already up to date");
-      p.outro("Done");
-      return;
-    }
-
-    if (checkOnly) {
-      p.outro("Run " + pc.cyan("xinity update") + " to apply the update");
-      return;
-    }
-
-    // Confirm
-    const proceed = await p.confirm({
-      message: `Update CLI to ${release.tagName}?`,
-      initialValue: true,
+    await runUpdateFlow({
+      checkOnly: argv.check as boolean,
+      targetVersion: argv["target-version"] as string,
     });
-    if (p.isCancel(proceed) || !proceed) {
-      p.cancel("Cancelled.");
-      return;
-    }
-
-    await selfUpdate(release);
-    p.outro("Done");
   },
 };

--- a/packages/xinity-cli/src/lib/installer.ts
+++ b/packages/xinity-cli/src/lib/installer.ts
@@ -23,6 +23,8 @@ import {
   ENV_SCHEMAS, ENV_DIR, SECRETS_DIR, BIN_DIR, DASHBOARD_DIR, UNIT_DIR,
   binaryBaseName, getAutoDefaults,
 } from "./component-meta.ts";
+// @ts-ignore
+import vllmTemplateUnit from "xinity-ai-daemon/src/assets/vllm-driver@.service" with { type: "text" };
 
 export type { Release } from "./github.ts";
 
@@ -87,6 +89,27 @@ export async function preflightCheck(
 async function preChecks(component: Component, host: Host): Promise<string[]> {
   const issues = await preflightCheck([component], host);
   return issues.map((i) => `${i.reason}${i.hint ? `. Install it: ${i.hint}` : ""}`);
+}
+
+// ─── vLLM systemd template install ─────────────────────────────────────────
+
+async function installVllmTemplate(host: Host, templatePath: string): Promise<void> {
+  const exists = await host.fileExists(templatePath);
+  if (exists) {
+    pass("vLLM template", `Already installed at ${templatePath}`);
+    return;
+  }
+
+  const result = await host.withElevation(
+    `cat > ${templatePath} << 'VLLMEOF'\n${vllmTemplateUnit}VLLMEOF\nsystemctl daemon-reload`,
+    "Install vLLM systemd template unit",
+  );
+
+  if (result.success) {
+    pass("vLLM template", `Installed at ${templatePath}`);
+  } else if (!result.skipped) {
+    warn("vLLM template", `Failed to install: ${result.output}`);
+  }
 }
 
 // ─── Driver tool checks (daemon only) ───────────────────────────────────────
@@ -210,6 +233,9 @@ async function ensureDriverTools(
       warn("vLLM", `vllm binary not found at ${vllmPath}`);
       p.log.info(pc.dim("  Ensure vLLM is installed: pip install vllm"));
     }
+
+    const templatePath = all.VLLM_TEMPLATE_UNIT_PATH ?? "/etc/systemd/system/vllm-driver@.service";
+    await installVllmTemplate(host, templatePath);
   }
 }
 


### PR DESCRIPTION
## Description

This PR makes it possible to specify a HF token, when configuring the daemon. That way, it is possible to use a user based model download, use potentially user gated models and depend less on the unauthenticated download speeds on huggingface.  
Some changes from a slightly earlier branch, revolving around refactoring of some of the util code in the gateway are also included

## Type of change

Replace with one of: New feature + Refactor

## Testing

The tests were not impacted.

## Checklist

- [x] Tests pass locally (`bun test`), or no testable code was changed
- [x] New or changed behavior is covered by tests, or this change does not require tests
- [x] Documentation is updated, or no user-facing behavior or configuration was changed
- [x] There are no breaking changes, or they are marked with `!` in the commit type and described above
- [x] No security-sensitive changes (authentication, credentials, input handling), or they have been reviewed
- [x] No new dependencies were added, or they have been reviewed for license and maintenance status