### PR TITLE
feat: dashboard binary distribution and cli reliability fixes

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -44,6 +44,11 @@ jobs:
             binary_name: xinity
             workdir: packages/xinity-cli
             custom_build: true
+          - package: xinity-ai-dashboard
+            workdir: packages/xinity-ai-dashboard
+            custom_build: true
+            pre_build: true
+            build_flags: "--no-vite"
 
     steps:
       - name: Checkout repository
@@ -57,10 +62,17 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Compile all targets and zip
+      - name: Pre-build (platform-independent step)
+        if: ${{ matrix.pre_build }}
         working-directory: ${{ matrix.workdir }}
         run: |
           if [ -f example.env ]; then cp example.env .env; fi
+          bun run build
+
+      - name: Compile all targets and zip
+        working-directory: ${{ matrix.workdir }}
+        run: |
+          if [ -f example.env ] && [ ! -f .env ]; then cp example.env .env; fi
           BINARY_NAME="${{ matrix.binary_name || matrix.package }}"
 
           for target in bun-linux-x64 bun-linux-x64-baseline bun-linux-arm64; do
@@ -69,7 +81,7 @@ jobs:
 
             if [ "${{ matrix.custom_build || 'false' }}" = "true" ]; then
               # Custom two-step build (bundle with plugins, then compile)
-              bun run build.ts --target "$target" --outfile "${BINARY_NAME}"
+              bun run build.ts --target "$target" --outfile "${BINARY_NAME}" ${{ matrix.build_flags }}
             else
               bun build --compile --minify \
                 --sourcemap=external \
@@ -93,13 +105,11 @@ jobs:
           retention-days: 1
 
   # ---------------------------------------------------------------------------
-  # JS bundles (platform-independent) + Dashboard tarball
+  # JS bundles (platform-independent)
   # Single-file bundles that run on any OS with `bun run <file>.js`.
-  # Dashboard is a SvelteKit app (server + static assets) so it ships as a
-  # tarball: extract and run with `bun run ./`.
   # ---------------------------------------------------------------------------
   build-bundles:
-    name: JS bundles + dashboard
+    name: JS bundles
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -137,13 +147,6 @@ jobs:
             --outfile xinity-infoserver.js \
             ./server.ts
 
-      - name: Build dashboard
-        working-directory: packages/xinity-ai-dashboard
-        run: |
-          cp example.env .env
-          bun run build
-          tar czf xinity-ai-dashboard.tar.gz -C build .
-
       - name: Package database migrations
         run: tar czf db-migrations.tar.gz -C packages/common-db/db-migration .
 
@@ -153,7 +156,6 @@ jobs:
           cp packages/xinity-ai-gateway/xinity-ai-gateway.js staging/
           cp packages/xinity-ai-daemon/xinity-ai-daemon.js staging/
           cp packages/xinity-infoserver/xinity-infoserver.js staging/
-          cp packages/xinity-ai-dashboard/xinity-ai-dashboard.tar.gz staging/
           cp db-migrations.tar.gz staging/
 
       - name: Upload artifacts
@@ -256,7 +258,7 @@ jobs:
               -o gateway.zip
             ```
 
-            Replace `xinity-ai-gateway` with `xinity-ai-daemon` or `xinity-infoserver` as needed.
+            Replace `xinity-ai-gateway` with `xinity-ai-daemon`, `xinity-infoserver`, or `xinity-ai-dashboard` as needed.
 
             **JS bundle** (requires [Bun](https://bun.sh)):
 
@@ -264,14 +266,6 @@ jobs:
             curl -fSL "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/xinity-ai-gateway.js" \
               -o xinity-ai-gateway.js
             bun run xinity-ai-gateway.js
-            ```
-
-            **Dashboard** (requires [Bun](https://bun.sh)):
-
-            ```bash
-            curl -fSL "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/xinity-ai-dashboard.tar.gz" \
-              | tar xz -C dashboard
-            bun run dashboard/
             ```
 
             ## Verify

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,7 +74,7 @@ graph TB
 
 ### Dashboard
 
-**Package:** `packages/xinity-ai-dashboard` | **Runtime:** SvelteKit 2 + Svelte 5 on Bun
+**Package:** `packages/xinity-ai-dashboard` | **Runtime:** SvelteKit 2 + Svelte 5, compiled to a self-contained binary (Bun runtime embedded)
 
 The dashboard is the central management surface. It serves three distinct roles within a single process:
 

--- a/packages/xinity-ai-daemon/src/modules/hardware-detect.ts
+++ b/packages/xinity-ai-daemon/src/modules/hardware-detect.ts
@@ -1,5 +1,5 @@
 import { $ } from "bun";
-import { totalmem } from "node:os";
+import { freemem, totalmem } from "node:os";
 import { readdir, readFile } from "node:fs/promises";
 import { rootLogger } from "../logger";
 
@@ -387,4 +387,32 @@ export async function detectHardwareProfile(): Promise<HardwareProfile> {
     detectedCapacityGb: mbToGb(getSystemRamMb()),
     source: "system-ram",
   };
+}
+
+/**
+ * Query current free memory in MB for the given capacity source.
+ *
+ * - nvidia: queries nvidia-smi for live free VRAM (works for both dedicated and unified memory GPUs like GB10)
+ * - amd: queries rocm-smi for live free VRAM
+ * - unified-memory / system-ram / intel / mixed: uses OS free memory
+ *
+ * Returns null only if the underlying query fails (e.g. nvidia-smi crashes).
+ */
+export async function getFreeMemoryMb(source: CapacitySource): Promise<number | null> {
+  try {
+    if (source === "nvidia") {
+      const stats = await getNvidiaRuntimeStats();
+      if (stats.length === 0) return null;
+      return stats.reduce((sum, s) => sum + s.freeMemory, 0);
+    }
+    if (source === "amd") {
+      const stats = await getAmdRuntimeStats();
+      if (stats.length === 0) return null;
+      return stats.reduce((sum, s) => sum + s.freeMemory, 0);
+    }
+    // unified-memory, system-ram, intel, mixed: use OS free memory
+    return bytesToMb(freemem());
+  } catch {
+    return null;
+  }
 }

--- a/packages/xinity-ai-daemon/src/modules/model-installation/vllm.test.ts
+++ b/packages/xinity-ai-daemon/src/modules/model-installation/vllm.test.ts
@@ -87,6 +87,12 @@ mock.module("../statekeeper", () => ({
   }),
 }));
 
+// Mock free memory query (20 GiB free on a 24 GiB GPU)
+const mockGetFreeMemoryMb = mock(() => Promise.resolve(20480 as number | null));
+mock.module("../hardware-detect", () => ({
+  getFreeMemoryMb: mockGetFreeMemoryMb,
+}));
+
 const { syncVllmInstallations$ } = await import("./vllm");
 
 // ---------------------------------------------------------------------------
@@ -137,6 +143,7 @@ describe("syncVllmInstallations$", () => {
     mockHasTag.mockImplementation(() => Promise.resolve(false));
     mockResolveDriverArgs.mockImplementation(() => Promise.resolve([]));
     mockFetchModel.mockImplementation(() => Promise.resolve({ type: "chat" }));
+    mockGetFreeMemoryMb.mockImplementation(() => Promise.resolve(20480));
   });
 
   test("completes with no changes when desired matches running", async () => {
@@ -507,5 +514,67 @@ describe("syncVllmInstallations$", () => {
     expect((failedWrite![0].errorMessage as string)).toContain("crash-looping");
     expect(failedWrite![0].failureLogs).toBe(sampleLogs);
     expect(ops.stop).toHaveBeenCalled();
+  });
+
+  test("calculates gpuMemoryUtilization from free VRAM, not total", async () => {
+    const id = crypto.randomUUID();
+    const inst = makeInstallation("mem-test-model", id, 9100);
+    // estCapacity=16, totalCapacity=24, freeMemory=20480 MB (20 GiB)
+    // requiredGb = 16 * 1.1 = 17.6
+    // maxClaimGb = max(20 - 1, 17.6) = 19
+    // utilization = min(19 / 24, 0.90) = min(0.7917, 0.90) ≈ 0.792
+    mockGetFreeMemoryMb.mockImplementation(() => Promise.resolve(20480));
+    const ops = createMockOps({
+      listRunning: mock(() => Promise.resolve([])),
+      checkHealth: mock(() => Promise.resolve(true)),
+      isAlive: mock(() => Promise.resolve(true)),
+    });
+
+    await firstValueFrom(syncVllmInstallations$([inst], ops));
+
+    const startCall = (ops.start as ReturnType<typeof mock>).mock.calls[0]!;
+    const util = startCall[1].gpuMemoryUtilization as number;
+    expect(util).toBeCloseTo(19 / 24, 2);
+  });
+
+  test("falls back to estCapacity-based calculation when free memory unavailable", async () => {
+    const id = crypto.randomUUID();
+    const inst = makeInstallation("fallback-model", id, 9101);
+    // estCapacity=16, totalCapacity=24, freeMemory=null (query failed)
+    // requiredGb = 16 * 1.1 = 17.6
+    // utilization = min(17.6 / 24, 0.90) = min(0.733, 0.90) ≈ 0.733
+    mockGetFreeMemoryMb.mockImplementation(() => Promise.resolve(null));
+    const ops = createMockOps({
+      listRunning: mock(() => Promise.resolve([])),
+      checkHealth: mock(() => Promise.resolve(true)),
+      isAlive: mock(() => Promise.resolve(true)),
+    });
+
+    await firstValueFrom(syncVllmInstallations$([inst], ops));
+
+    const startCall = (ops.start as ReturnType<typeof mock>).mock.calls[0]!;
+    const util = startCall[1].gpuMemoryUtilization as number;
+    expect(util).toBeCloseTo((16 * 1.1) / 24, 2);
+  });
+
+  test("caps gpuMemoryUtilization at 0.90", async () => {
+    const id = crypto.randomUUID();
+    // High free memory — without the cap, utilization would exceed 0.90
+    const inst = makeInstallation("cap-model", id, 9102);
+    // freeMemory = 23552 MB (23 GiB), total = 24 GiB
+    // maxClaimGb = max(23 - 1, 17.6) = 22
+    // utilization = min(22 / 24, 0.90) = min(0.917, 0.90) = 0.90
+    mockGetFreeMemoryMb.mockImplementation(() => Promise.resolve(23552));
+    const ops = createMockOps({
+      listRunning: mock(() => Promise.resolve([])),
+      checkHealth: mock(() => Promise.resolve(true)),
+      isAlive: mock(() => Promise.resolve(true)),
+    });
+
+    await firstValueFrom(syncVllmInstallations$([inst], ops));
+
+    const startCall = (ops.start as ReturnType<typeof mock>).mock.calls[0]!;
+    const util = startCall[1].gpuMemoryUtilization as number;
+    expect(util).toBe(0.90);
   });
 });

--- a/packages/xinity-ai-daemon/src/modules/model-installation/vllm.ts
+++ b/packages/xinity-ai-daemon/src/modules/model-installation/vllm.ts
@@ -32,12 +32,35 @@ const infoClient = createInfoserverClient({ baseUrl: env.INFOSERVER_URL, cacheTt
 const log = rootLogger.child({ name: "vllm" });
 
 const FATAL_LOG_PATTERNS: Array<{ pattern: RegExp; label: string }> = [
-  { pattern: /torch\.cuda\.OutOfMemoryError|CUDA out of memory/i, label: "GPU out of memory" },
+  // ── GPU / VRAM ───────────────────────────────────────────────────────────
+  { pattern: /Free memory on device.*is less than desired GPU memory utilization|Decrease GPU memory utilization/i, label: "GPU memory utilization too high" },
+  { pattern: /torch\.cuda\.OutOfMemoryError|torch\.OutOfMemoryError|CUDA out of memory/i, label: "GPU out of memory" },
+  { pattern: /Bfloat16 is not supported|bfloat16.*not supported/i, label: "GPU does not support bfloat16" },
+
+  // ── CUDA / driver ────────────────────────────────────────────────────────
+  { pattern: /CUDA error: invalid device ordinal/i, label: "Invalid GPU device index" },
+  { pattern: /NVIDIA driver on your system is too old|provided PTX was compiled with an unsupported toolchain|cuda capability.*not compatible/i, label: "CUDA/driver version mismatch" },
   { pattern: /RuntimeError:.*CUDA error/i, label: "CUDA runtime error" },
+
+  // ── Container / runtime ──────────────────────────────────────────────────
+  { pattern: /could not select device driver|unknown or invalid runtime name: nvidia|Found no NVIDIA driver/i, label: "NVIDIA container runtime missing" },
+  { pattern: /ncclSystemError|ncclInternalError|NCCL error/i, label: "NCCL communication error" },
+  { pattern: /address already in use|Address already in use/i, label: "Port already in use" },
+
+  // ── Model / config ───────────────────────────────────────────────────────
+  { pattern: /Model architectures \[.*\] are not supported/i, label: "Unsupported model architecture" },
+  { pattern: /max_model_len.*is too large|the model's max seq_len/i, label: "Configured context length too large" },
+  { pattern: /Access to model.*is restricted|gated repo|Cannot access gated repo/i, label: "HuggingFace authentication required" },
+  { pattern: /OSError:.*does not appear to have a file named|repository.*not found|does not exist on the Hub/i, label: "Model files missing or not found" },
+
+  // ── Permissions ──────────────────────────────────────────────────────────
   { pattern: /PermissionError:.*triton|triton.*PermissionError/i, label: "Triton cache permission error" },
   { pattern: /PermissionError|Permission denied/i, label: "Permission error" },
-  { pattern: /OSError:.*does not appear to have a file named/i, label: "Model files missing or corrupt" },
+
+  // ── System / process ─────────────────────────────────────────────────────
   { pattern: /error while loading shared libraries/i, label: "Missing shared library" },
+  { pattern: /Aborted due to the lack of CPU swap space/i, label: "Insufficient CPU swap space" },
+  { pattern: /Engine core initialization failed|EngineCore failed to start/i, label: "Engine initialization failed" },
 ];
 
 function matchFatalPattern(logs: string): string | null {

--- a/packages/xinity-ai-daemon/src/modules/model-installation/vllm.ts
+++ b/packages/xinity-ai-daemon/src/modules/model-installation/vllm.ts
@@ -26,6 +26,7 @@ import {
 import { createInfoserverClient } from "xinity-infoserver";
 import { rootLogger } from "../../logger";
 import { getHardwareProfile } from "../statekeeper";
+import { getFreeMemoryMb } from "../hardware-detect";
 
 const infoClient = createInfoserverClient({ baseUrl: env.INFOSERVER_URL, cacheTtlMs: env.INFOSERVER_CACHE_TTL_MS });
 
@@ -399,15 +400,24 @@ export function syncVllmInstallations$(
                         infoClient.resolveDriverArgs(installation.model),
                         infoClient.fetchModel(installation.model),
                         getHardwareProfile(),
-                      ]).then(([trustRemoteCode, hasToolsTag, extraArgs, modelInfo, profile]) => {
+                      ]).then(async ([trustRemoteCode, hasToolsTag, extraArgs, modelInfo, profile]) => {
                         let gpuMemoryUtilization: number | undefined;
                         if (profile.gpuCount > 0 && profile.detectedCapacityGb > 0) {
-                          gpuMemoryUtilization = Math.min(
-                            (installation.estCapacity * 1.1) / profile.detectedCapacityGb,
-                            0.95,
-                          );
+                          const totalCapacityGb = profile.detectedCapacityGb;
+                          const requiredGb = installation.estCapacity * 1.1;
+                          const freeMemoryMb = await getFreeMemoryMb(profile.source);
+
+                          if (freeMemoryMb != null) {
+                            const freeGb = freeMemoryMb / 1024;
+                            const safetyMarginGb = 1.0;
+                            const maxClaimGb = Math.max(freeGb - safetyMarginGb, requiredGb);
+                            gpuMemoryUtilization = Math.min(maxClaimGb / totalCapacityGb, 0.90);
+                          } else {
+                            gpuMemoryUtilization = Math.min(requiredGb / totalCapacityGb, 0.90);
+                          }
+
                           log.info(
-                            { model: installation.model, gpuMemoryUtilization: gpuMemoryUtilization.toFixed(3), estCapacityGb: installation.estCapacity, totalCapacityGb: profile.detectedCapacityGb },
+                            { model: installation.model, gpuMemoryUtilization: gpuMemoryUtilization.toFixed(3), estCapacityGb: installation.estCapacity, totalCapacityGb, freeMemoryMb },
                             "Calculated GPU memory utilization",
                           );
                         }

--- a/packages/xinity-ai-dashboard/build.ts
+++ b/packages/xinity-ai-dashboard/build.ts
@@ -1,0 +1,95 @@
+/**
+ * Two-step dashboard build:
+ *   1. SvelteKit/Vite build (bundles devDependencies, marks runtime deps external)
+ *   2. bun build --compile (bundles remaining runtime deps + embeds Bun runtime)
+ *
+ * Usage:
+ *   bun run build.ts
+ *   bun run build.ts --target bun-linux-arm64 --outfile dist/xinity-ai-dashboard
+ */
+import { parseArgs } from "util";
+import { $ } from "bun";
+
+const { values } = parseArgs({
+  args: process.argv.slice(2),
+  options: {
+    target: { type: "string", default: "bun-linux-x64" },
+    outfile: { type: "string", default: "xinity-ai-dashboard" },
+    // Skip the Vite build step (used in CI where vite runs once before the
+    // per-arch loop to avoid repeating the ~10 minute build three times).
+    "no-vite": { type: "boolean", default: false },
+  },
+});
+
+const target = values.target!;
+const outfile = values.outfile!;
+
+console.log(`Building ${outfile} for ${target}…`);
+
+// ── Step 1: SvelteKit/Vite build ────────────────────────────────────────────
+
+if (!values["no-vite"]) {
+  const viteResult = await $`bun run build`.nothrow();
+  if (viteResult.exitCode !== 0) {
+    console.error("Vite build failed");
+    process.exit(viteResult.exitCode ?? 1);
+  }
+  console.log("Vite build OK");
+} else {
+  console.log("Vite build skipped (--no-vite)");
+}
+
+// ── Step 2: Compile to standalone binary ────────────────────────────────────
+//
+// mjml-core (a dep of mjml) requires html-minifier at the top of its module,
+// and html-minifier in turn requires uglify-js. We never call mjml with
+// `minify: true`, so neither is ever actually used at runtime. However, Bun's
+// bundler converts CJS to ESM, and uglify-js uses its own JS parser internally
+// which chokes on the resulting `export` keyword.
+//
+// Fix: use the programmatic Bun build API with a plugin that replaces
+// html-minifier with a no-op stub, so uglify-js is never pulled in at all.
+
+// compile mode derives the output filename from the entrypoint path, ignoring
+// naming/outfile options. Output to a temp dir then rename to the desired name.
+const tmpDir = await import("os").then((os) => os.tmpdir());
+const tmpOut = `${tmpDir}/bun-dashboard-compile-${Date.now()}`;
+
+const buildResult = await Bun.build({
+  entrypoints: ["build/index.js"],
+  outdir: tmpOut,
+  compile: true,
+  minify: true,
+  target: target as Parameters<typeof Bun.build>[0]["target"],
+  plugins: [
+    {
+      name: "stub-html-minifier",
+      setup(build) {
+        // html-minifier is only used by mjml-core when minify:true (which we never pass).
+        // Replace it with a pass-through stub to avoid pulling in uglify-js.
+        build.onResolve({ filter: /^html-minifier$/ }, () => ({
+          path: "html-minifier",
+          namespace: "stub",
+        }));
+        build.onLoad({ filter: /.*/, namespace: "stub" }, () => ({
+          contents: `export function minify(html) { return html; }`,
+          loader: "js",
+        }));
+      },
+    },
+  ],
+});
+
+if (!buildResult.success) {
+  console.error("Compile failed");
+  for (const msg of buildResult.logs) {
+    console.error(msg);
+  }
+  process.exit(1);
+}
+
+// Rename the compiled binary from its auto-derived name to the desired outfile.
+const compiledPath = buildResult.outputs[0]!.path;
+await $`mv ${compiledPath} ${outfile} && chmod +x ${outfile}`;
+
+console.log(`Done: ${outfile} (${target})`);

--- a/packages/xinity-ai-dashboard/e2e/api-keys/api-key-crud.test.ts
+++ b/packages/xinity-ai-dashboard/e2e/api-keys/api-key-crud.test.ts
@@ -94,18 +94,38 @@ describe("API key CRUD", () => {
       await page.goto("/ai-api-keys/");
       await page.waitForLoadState("networkidle");
 
-      const deleteBtn = page.getByRole("button", { name: "Delete" }).first();
-      if (await deleteBtn.isVisible({ timeout: 5_000 }).catch(() => false)) {
-        await deleteBtn.click();
+      // Create a key specifically for this test so deletion is guaranteed to have a target
+      await page.getByRole("button", { name: /Generate New Key/ }).click();
+      await page.locator("#keyName").waitFor({ state: "visible", timeout: 5_000 });
+      await page.locator("#keyName").fill(`e2e-delete-${Date.now()}`);
 
-        // Confirmation modal
-        const confirmDelete = page.getByRole("dialog").getByRole("button", { name: "Delete" });
-        await confirmDelete.waitFor({ state: "visible", timeout: 15_000 });
-        await confirmDelete.click();
-
-        // Toast confirmation
-        await page.getByRole("alert").getByText(/Deleted API key/).waitFor({ state: "visible", timeout: 15_000 });
+      const appSelect = page.locator("#appSelect");
+      if (await appSelect.isVisible({ timeout: 2_000 }).catch(() => false)) {
+        await appSelect.click();
+        await page.getByRole("option", { name: /Create new application/ }).click();
+        const appDesc = page.locator("#appDesc");
+        if (await appDesc.isVisible({ timeout: 1_000 }).catch(() => false)) {
+          await appDesc.fill("E2E test application");
+        }
       }
+
+      await page.getByRole("button", { name: "Create", exact: true }).click();
+      await page.locator("#fullKey").waitFor({ state: "visible", timeout: 10_000 });
+      await page.getByRole("button", { name: "OK", exact: true }).click();
+      await page.locator("#keyName").waitFor({ state: "hidden", timeout: 5_000 });
+
+      // Now delete it
+      const deleteBtn = page.getByRole("button", { name: "Delete" }).first();
+      await deleteBtn.waitFor({ state: "visible", timeout: 5_000 });
+      await deleteBtn.click();
+
+      // Confirmation modal
+      const confirmDelete = page.getByRole("dialog").getByRole("button", { name: "Delete" });
+      await confirmDelete.waitFor({ state: "visible", timeout: 15_000 });
+      await confirmDelete.click();
+
+      // Toast confirmation
+      await page.getByRole("alert").getByText(/Deleted API key/).waitFor({ state: "visible", timeout: 15_000 });
     } finally {
       await context.close();
     }

--- a/packages/xinity-ai-dashboard/e2e/settings/password-change.test.ts
+++ b/packages/xinity-ai-dashboard/e2e/settings/password-change.test.ts
@@ -125,9 +125,21 @@ describe("Password change via UI", () => {
       throw new Error(`Sign-up failed: ${signUpRes.status} ${await signUpRes.text()}`);
     }
 
-    // 3. Verify email via Mailhog
-    const verifyUrl = await getVerificationUrl(TEST_USER.email);
-    await fetch(verifyUrl, { redirect: "manual" });
+    // 3. Try to sign in immediately -- if email verification is not required
+    //    (MAIL_URL not set), the account is already active after sign-up.
+    //    Only fall back to Mailhog verification if the sign-in fails.
+    const quickSignIn = await fetch(`${BASE_URL}/api/auth/sign-in/email`, {
+      method: "POST",
+      headers: AUTH_HEADERS,
+      body: JSON.stringify({ email: TEST_USER.email, password: TEST_USER.password }),
+      redirect: "manual",
+    });
+
+    if (!quickSignIn.ok && quickSignIn.status !== 302) {
+      // Email verification required -- fetch the link from Mailhog
+      const verifyUrl = await getVerificationUrl(TEST_USER.email);
+      await fetch(verifyUrl, { redirect: "manual" });
+    }
 
     // 4. Sign in and save storage state for browser tests
     await signInAndSaveState(TEST_USER.email, TEST_USER.password);

--- a/packages/xinity-ai-dashboard/example.env
+++ b/packages/xinity-ai-dashboard/example.env
@@ -1,3 +1,4 @@
+HTTP_PORT=5173
 MAIL_URL=smtp://localhost:1025
 MAIL_FROM="Auth Service <noreply@example.com>"
 # Generate with: openssl rand -base64 33

--- a/packages/xinity-ai-dashboard/package.json
+++ b/packages/xinity-ai-dashboard/package.json
@@ -5,6 +5,7 @@
 	"scripts": {
 		"dev": "bun --bun vite dev --port 5173 | pino-pretty",
 		"build": "bun --bun vite build",
+		"build:compile": "bun run build.ts",
 		"preview": "bun --bun vite preview --port 5173 | pino-pretty",
 		"prepare": "svelte-kit sync || echo ''",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
@@ -52,13 +53,13 @@
 		"zod": "^4.1.12"
 	},
 	"dependencies": {
+		"@better-auth/sso": "^1.4.18",
 		"@types/bun": "^1.3.6",
 		"common-log": "workspace:*",
 		"mjml": "^4.16.1",
 		"nodemailer": "^7.0.11",
 		"pino": "^10.1.0",
 		"prom-client": "^15.1.3",
-		"uuid": "^13.0.0",
-		"@better-auth/sso": "^1.4.18"
+		"uuid": "^13.0.0"
 	}
 }

--- a/packages/xinity-ai-dashboard/src/lib/server/env-schema.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/env-schema.ts
@@ -5,6 +5,7 @@ export const dashboardEnvSchema = z.object({
   DB_CONNECTION_URL: z.url().describe("PostgreSQL connection string (e.g. postgresql://user:pass@host:5432/dbname)").meta(secret()),
   NODE_ENV: z.enum(["production", "development", "test"]).describe("Node environment").meta(expert()),
   ORIGIN: z.url().default("http://localhost:5173").describe("Public origin URL, no trailing slash (e.g. https://xinity.mydomain.com)"),
+  HTTP_PORT: z.coerce.number().int().default(5173).describe("TCP port the server listens on (use a reverse proxy if deploying behind HTTPS)").meta(expert()),
   BETTER_AUTH_SECRET: z.string().describe("Better Auth secret key, generate with: openssl rand -base64 33").meta(secret()),
   BETTER_AUTH_URL: z.string().describe("Better Auth URL, usually the same as ORIGIN (e.g. https://xinity.mydomain.com)"),
   INFOSERVER_URL: z.url().describe("Infoserver URL (default hosted: https://sysinfo.xinity.ai, or your self-hosted instance)"),

--- a/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/deployment.procedure.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/deployment.procedure.ts
@@ -201,7 +201,7 @@ const updateDeployment = rootOs
   })
   .input(DeploymentDto.omit(commonInputFilter))
   .output(DeploymentDto)
-  .errors({ NOT_FOUND: {}, BAD_REQUEST: {}, INSUFFICIENT_CAPACITY: {} })
+  .errors({ NOT_FOUND: {}, BAD_REQUEST: {}, INSUFFICIENT_CAPACITY: {}, CONFLICT: {} })
   .handler(async ({ context, input, errors }) => {
     if (input.modelSpecifier && input.earlyModelSpecifier) {
       try {
@@ -249,7 +249,13 @@ const updateDeployment = rootOs
       }
     }
 
-    const deployment = await internalUpdateDeployment(context.activeOrganizationId, input.id, input);
+    let deployment;
+    try {
+      deployment = await internalUpdateDeployment(context.activeOrganizationId, input.id, input);
+    } catch (err) {
+      log.error(err);
+      throw errors.CONFLICT({ message: "A deployment with this specifier already exists in your organization" });
+    }
     if (!deployment) {
       throw errors.NOT_FOUND();
     }
@@ -415,7 +421,7 @@ export const createDeployment = rootOs
       return deployment;
     } catch (err) {
       log.error(err);
-      throw errors.CONFLICT({ message: "A deployment of the same name already exists in your organization" })
+      throw errors.CONFLICT({ message: "A deployment with this specifier already exists in your organization" })
     }
   });
 

--- a/packages/xinity-ai-dashboard/src/lib/util.ts
+++ b/packages/xinity-ai-dashboard/src/lib/util.ts
@@ -110,7 +110,14 @@ export async function updateOptimistically<E>({
 /** Formats a date using the "de" locale for consistent UI display. */
 export function humanDate(d: Date | undefined) {
   if (!d || !d.toLocaleDateString) return "Unknown date";
-  return d.toLocaleString("de");
+  return d.toLocaleString("de", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
 }
 
 /** Formats a duration expressed in hours into a human-readable label. */

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/docs/deployment-troubleshooting/+page.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/docs/deployment-troubleshooting/+page.svelte
@@ -48,6 +48,49 @@
   <!-- Error cards -->
   <div class="space-y-4 mb-8">
 
+    <!-- GPU Memory Utilization Too High -->
+    <section class="p-6 bg-white rounded-lg shadow-md">
+      <div class="flex items-start gap-3 mb-3">
+        <span class="mt-0.5 inline-block px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-800 shrink-0">GPU</span>
+        <div>
+          <h3 class="text-lg font-semibold">GPU memory utilization too high</h3>
+          <p class="text-sm text-gray-500 mt-0.5">
+            Look for: <code class="bg-gray-100 px-1 rounded">Free memory on device ... is less than desired GPU memory utilization</code>
+          </p>
+        </div>
+      </div>
+      <p class="text-gray-600 mb-3">
+        The configured GPU memory utilization percentage requires more VRAM than is
+        currently free on the GPU. Other processes may be using some of the memory.
+      </p>
+      <p class="text-sm font-semibold text-gray-700 mb-1">Likely fix:</p>
+      <ul class="list-disc pl-6 space-y-1 text-sm text-gray-600 mb-3">
+        <li>Lower the <strong>GPU memory utilization</strong> in Expert Settings (e.g. from 0.95 to 0.85).</li>
+        <li>Stop other GPU processes on the node to free VRAM.</li>
+        <li>Reduce the <strong>KV cache size</strong> to lower overall memory demand.</li>
+      </ul>
+      <Collapsible.Root>
+        <Collapsible.Trigger class="flex items-center gap-1 text-xs text-muted-foreground hover:underline cursor-pointer group">
+          <ChevronRight class="w-3 h-3 transition-transform group-data-[state=open]:rotate-90" />
+          Technical details
+        </Collapsible.Trigger>
+        <Collapsible.Content>
+          <div class="mt-3 p-3 bg-gray-50 rounded text-sm text-gray-600 space-y-2">
+            <p>
+              vLLM's <code class="bg-gray-100 px-1 rounded">--gpu-memory-utilization</code> flag
+              (default 0.90) tells it to claim a percentage of <em>total</em> GPU memory. If the
+              free memory at startup is less than that amount (e.g. because the display driver or
+              another process is using some), vLLM refuses to start rather than risk an OOM later.
+            </p>
+            <p>
+              The error message shows exactly how much is free vs. how much was requested, making
+              it easy to pick a lower value.
+            </p>
+          </div>
+        </Collapsible.Content>
+      </Collapsible.Root>
+    </section>
+
     <!-- GPU OOM -->
     <section class="p-6 bg-white rounded-lg shadow-md">
       <div class="flex items-start gap-3 mb-3">
@@ -204,15 +247,210 @@
       </Collapsible.Root>
     </section>
 
+    <!-- BFloat16 Not Supported -->
+    <section class="p-6 bg-white rounded-lg shadow-md">
+      <div class="flex items-start gap-3 mb-3">
+        <span class="mt-0.5 inline-block px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-800 shrink-0">GPU</span>
+        <div>
+          <h3 class="text-lg font-semibold">GPU does not support bfloat16</h3>
+          <p class="text-sm text-gray-500 mt-0.5">
+            Look for: <code class="bg-gray-100 px-1 rounded">Bfloat16 is not supported</code>
+          </p>
+        </div>
+      </div>
+      <p class="text-gray-600 mb-3">
+        The GPU is too old to run this model's default data type (bfloat16 requires
+        compute capability 8.0+, i.e. Ampere or newer).
+      </p>
+      <p class="text-sm font-semibold text-gray-700 mb-1">Likely fix:</p>
+      <ul class="list-disc pl-6 space-y-1 text-sm text-gray-600 mb-3">
+        <li>Add <code class="bg-gray-100 px-1 rounded">--dtype float16</code> to Extra Args in Expert Settings.</li>
+        <li>Or deploy to a node with a newer GPU (Ampere / Ada / Hopper).</li>
+      </ul>
+    </section>
+
+    <!-- CUDA/Driver Mismatch -->
+    <section class="p-6 bg-white rounded-lg shadow-md">
+      <div class="flex items-start gap-3 mb-3">
+        <span class="mt-0.5 inline-block px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-800 shrink-0">GPU</span>
+        <div>
+          <h3 class="text-lg font-semibold">CUDA/driver version mismatch</h3>
+          <p class="text-sm text-gray-500 mt-0.5">
+            Look for: <code class="bg-gray-100 px-1 rounded">NVIDIA driver on your system is too old</code>
+            or <code class="bg-gray-100 px-1 rounded">unsupported toolchain</code>
+          </p>
+        </div>
+      </div>
+      <p class="text-gray-600 mb-3">
+        The inference engine was built against a newer CUDA version than your GPU driver supports.
+      </p>
+      <p class="text-sm font-semibold text-gray-700 mb-1">Likely fix:</p>
+      <ul class="list-disc pl-6 space-y-1 text-sm text-gray-600 mb-3">
+        <li>Update the NVIDIA driver on the inference node.</li>
+        <li>Or use a vLLM image that matches the installed CUDA version.</li>
+      </ul>
+    </section>
+
+    <!-- Invalid GPU Device -->
+    <section class="p-6 bg-white rounded-lg shadow-md">
+      <div class="flex items-start gap-3 mb-3">
+        <span class="mt-0.5 inline-block px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-800 shrink-0">GPU</span>
+        <div>
+          <h3 class="text-lg font-semibold">Invalid GPU device index</h3>
+          <p class="text-sm text-gray-500 mt-0.5">
+            Look for: <code class="bg-gray-100 px-1 rounded">CUDA error: invalid device ordinal</code>
+          </p>
+        </div>
+      </div>
+      <p class="text-gray-600 mb-3">
+        The process is trying to use a GPU index that does not exist on this node.
+      </p>
+      <p class="text-sm font-semibold text-gray-700 mb-1">Likely fix:</p>
+      <ul class="list-disc pl-6 space-y-1 text-sm text-gray-600 mb-3">
+        <li>Check that <code class="bg-gray-100 px-1 rounded">CUDA_VISIBLE_DEVICES</code> is set correctly.</li>
+        <li>Ensure <code class="bg-gray-100 px-1 rounded">--tensor-parallel-size</code> does not exceed the number of GPUs.</li>
+      </ul>
+    </section>
+
+    <!-- NVIDIA Runtime Missing -->
+    <section class="p-6 bg-white rounded-lg shadow-md">
+      <div class="flex items-start gap-3 mb-3">
+        <span class="mt-0.5 inline-block px-2 py-0.5 rounded text-xs font-medium bg-orange-100 text-orange-800 shrink-0">Runtime</span>
+        <div>
+          <h3 class="text-lg font-semibold">NVIDIA container runtime missing</h3>
+          <p class="text-sm text-gray-500 mt-0.5">
+            Look for: <code class="bg-gray-100 px-1 rounded">could not select device driver</code>
+            or <code class="bg-gray-100 px-1 rounded">unknown or invalid runtime name: nvidia</code>
+          </p>
+        </div>
+      </div>
+      <p class="text-gray-600 mb-3">
+        Docker cannot access the GPU because the NVIDIA container toolkit is not installed.
+      </p>
+      <p class="text-sm font-semibold text-gray-700 mb-1">Likely fix:</p>
+      <ul class="list-disc pl-6 space-y-1 text-sm text-gray-600 mb-3">
+        <li>Install <code class="bg-gray-100 px-1 rounded">nvidia-container-toolkit</code> on the node.</li>
+        <li>Run <code class="bg-gray-100 px-1 rounded">nvidia-ctk runtime configure --runtime=docker</code> and restart Docker.</li>
+      </ul>
+    </section>
+
+    <!-- NCCL Error -->
+    <section class="p-6 bg-white rounded-lg shadow-md">
+      <div class="flex items-start gap-3 mb-3">
+        <span class="mt-0.5 inline-block px-2 py-0.5 rounded text-xs font-medium bg-orange-100 text-orange-800 shrink-0">Runtime</span>
+        <div>
+          <h3 class="text-lg font-semibold">NCCL communication error</h3>
+          <p class="text-sm text-gray-500 mt-0.5">
+            Look for: <code class="bg-gray-100 px-1 rounded">ncclSystemError</code>
+            or <code class="bg-gray-100 px-1 rounded">NCCL error</code>
+          </p>
+        </div>
+      </div>
+      <p class="text-gray-600 mb-3">
+        GPU-to-GPU communication failed during multi-GPU initialization.
+      </p>
+      <p class="text-sm font-semibold text-gray-700 mb-1">Likely fix:</p>
+      <ul class="list-disc pl-6 space-y-1 text-sm text-gray-600 mb-3">
+        <li>Ensure Docker is running with <code class="bg-gray-100 px-1 rounded">--ipc=host</code> (the daemon does this automatically).</li>
+        <li>Check that <code class="bg-gray-100 px-1 rounded">/dev/shm</code> is large enough (at least a few GB).</li>
+        <li>Verify GPUs are not assigned to conflicting processes.</li>
+      </ul>
+    </section>
+
+    <!-- Port Conflict -->
+    <section class="p-6 bg-white rounded-lg shadow-md">
+      <div class="flex items-start gap-3 mb-3">
+        <span class="mt-0.5 inline-block px-2 py-0.5 rounded text-xs font-medium bg-orange-100 text-orange-800 shrink-0">Runtime</span>
+        <div>
+          <h3 class="text-lg font-semibold">Port already in use</h3>
+          <p class="text-sm text-gray-500 mt-0.5">
+            Look for: <code class="bg-gray-100 px-1 rounded">Address already in use</code>
+          </p>
+        </div>
+      </div>
+      <p class="text-gray-600 mb-3">
+        Another process is already using the port assigned to this deployment.
+      </p>
+      <p class="text-sm font-semibold text-gray-700 mb-1">Likely fix:</p>
+      <ul class="list-disc pl-6 space-y-1 text-sm text-gray-600 mb-3">
+        <li>Stop the conflicting process, or delete and re-deploy (a new port will be assigned).</li>
+        <li>Check for zombie vLLM processes with <code class="bg-gray-100 px-1 rounded">lsof -i :&lt;port&gt;</code>.</li>
+      </ul>
+    </section>
+
+    <!-- Unsupported Architecture -->
+    <section class="p-6 bg-white rounded-lg shadow-md">
+      <div class="flex items-start gap-3 mb-3">
+        <span class="mt-0.5 inline-block px-2 py-0.5 rounded text-xs font-medium bg-xinity-purple/15 text-xinity-pink shrink-0">Config</span>
+        <div>
+          <h3 class="text-lg font-semibold">Unsupported model architecture</h3>
+          <p class="text-sm text-gray-500 mt-0.5">
+            Look for: <code class="bg-gray-100 px-1 rounded">Model architectures [...] are not supported</code>
+          </p>
+        </div>
+      </div>
+      <p class="text-gray-600 mb-3">
+        This model uses an architecture that the installed vLLM version does not support yet.
+      </p>
+      <p class="text-sm font-semibold text-gray-700 mb-1">Likely fix:</p>
+      <ul class="list-disc pl-6 space-y-1 text-sm text-gray-600 mb-3">
+        <li>Upgrade to a newer vLLM version that supports this architecture.</li>
+        <li>Or choose a model with a supported architecture.</li>
+      </ul>
+    </section>
+
+    <!-- Context Length Too Large -->
+    <section class="p-6 bg-white rounded-lg shadow-md">
+      <div class="flex items-start gap-3 mb-3">
+        <span class="mt-0.5 inline-block px-2 py-0.5 rounded text-xs font-medium bg-xinity-purple/15 text-xinity-pink shrink-0">Config</span>
+        <div>
+          <h3 class="text-lg font-semibold">Configured context length too large</h3>
+          <p class="text-sm text-gray-500 mt-0.5">
+            Look for: <code class="bg-gray-100 px-1 rounded">max_model_len ... is too large</code>
+          </p>
+        </div>
+      </div>
+      <p class="text-gray-600 mb-3">
+        The requested maximum sequence length exceeds what the model supports or what fits in GPU memory.
+      </p>
+      <p class="text-sm font-semibold text-gray-700 mb-1">Likely fix:</p>
+      <ul class="list-disc pl-6 space-y-1 text-sm text-gray-600 mb-3">
+        <li>Reduce <code class="bg-gray-100 px-1 rounded">--max-model-len</code> in Extra Args, or remove it to use the model's default.</li>
+        <li>Deploy to a node with more VRAM if you need the full context window.</li>
+      </ul>
+    </section>
+
+    <!-- HuggingFace Auth -->
+    <section class="p-6 bg-white rounded-lg shadow-md">
+      <div class="flex items-start gap-3 mb-3">
+        <span class="mt-0.5 inline-block px-2 py-0.5 rounded text-xs font-medium bg-xinity-purple/15 text-xinity-pink shrink-0">Config</span>
+        <div>
+          <h3 class="text-lg font-semibold">HuggingFace authentication required</h3>
+          <p class="text-sm text-gray-500 mt-0.5">
+            Look for: <code class="bg-gray-100 px-1 rounded">Access to model ... is restricted</code>
+            or <code class="bg-gray-100 px-1 rounded">gated repo</code>
+          </p>
+        </div>
+      </div>
+      <p class="text-gray-600 mb-3">
+        The model is gated or private on HuggingFace and requires an access token.
+      </p>
+      <p class="text-sm font-semibold text-gray-700 mb-1">Likely fix:</p>
+      <ul class="list-disc pl-6 space-y-1 text-sm text-gray-600 mb-3">
+        <li>Set the <code class="bg-gray-100 px-1 rounded">HF_TOKEN</code> environment variable on the inference node.</li>
+        <li>Make sure you have accepted the model's license on HuggingFace.</li>
+      </ul>
+    </section>
+
     <!-- Model Not Found -->
     <section class="p-6 bg-white rounded-lg shadow-md">
       <div class="flex items-start gap-3 mb-3">
         <span class="mt-0.5 inline-block px-2 py-0.5 rounded text-xs font-medium bg-xinity-purple/15 text-xinity-pink shrink-0">Config</span>
         <div>
-          <h3 class="text-lg font-semibold">Model not found</h3>
+          <h3 class="text-lg font-semibold">Model files missing or not found</h3>
           <p class="text-sm text-gray-500 mt-0.5">
             Look for: <code class="bg-gray-100 px-1 rounded">does not appear to have a file named</code>
-            or <code class="bg-gray-100 px-1 rounded">not found</code>
+            or <code class="bg-gray-100 px-1 rounded">does not exist on the Hub</code>
           </p>
         </div>
       </div>
@@ -222,7 +460,7 @@
       </p>
       <p class="text-sm font-semibold text-gray-700 mb-1">Likely fix:</p>
       <ul class="list-disc pl-6 space-y-1 text-sm text-gray-600 mb-3">
-        <li>Double-check the model name matches a valid model identifier.</li>
+        <li>Double-check the model name matches a valid HuggingFace model identifier.</li>
         <li>If the model is private, make sure authentication is configured.</li>
         <li>Try deleting and re-deploying to trigger a fresh download.</li>
       </ul>
@@ -249,6 +487,70 @@
         <li>Expand <strong>View logs</strong> in the Model Hub to find the real error.</li>
         <li>The root cause is usually one of the other errors on this page.</li>
         <li>Fix the underlying issue, then delete and re-create the deployment.</li>
+      </ul>
+    </section>
+
+    <!-- Missing Shared Library -->
+    <section class="p-6 bg-white rounded-lg shadow-md">
+      <div class="flex items-start gap-3 mb-3">
+        <span class="mt-0.5 inline-block px-2 py-0.5 rounded text-xs font-medium bg-gray-200 text-gray-800 shrink-0">System</span>
+        <div>
+          <h3 class="text-lg font-semibold">Missing shared library</h3>
+          <p class="text-sm text-gray-500 mt-0.5">
+            Look for: <code class="bg-gray-100 px-1 rounded">error while loading shared libraries</code>
+          </p>
+        </div>
+      </div>
+      <p class="text-gray-600 mb-3">
+        A required system library (CUDA, NCCL, etc.) is not installed or not in the library path.
+      </p>
+      <p class="text-sm font-semibold text-gray-700 mb-1">Likely fix:</p>
+      <ul class="list-disc pl-6 space-y-1 text-sm text-gray-600 mb-3">
+        <li>Verify the CUDA toolkit and NVIDIA libraries are installed on the node.</li>
+        <li>For Docker deployments, ensure the NVIDIA container runtime is configured.</li>
+      </ul>
+    </section>
+
+    <!-- Insufficient Swap Space -->
+    <section class="p-6 bg-white rounded-lg shadow-md">
+      <div class="flex items-start gap-3 mb-3">
+        <span class="mt-0.5 inline-block px-2 py-0.5 rounded text-xs font-medium bg-gray-200 text-gray-800 shrink-0">System</span>
+        <div>
+          <h3 class="text-lg font-semibold">Insufficient CPU swap space</h3>
+          <p class="text-sm text-gray-500 mt-0.5">
+            Look for: <code class="bg-gray-100 px-1 rounded">Aborted due to the lack of CPU swap space</code>
+          </p>
+        </div>
+      </div>
+      <p class="text-gray-600 mb-3">
+        The system ran out of CPU swap space for request scheduling.
+      </p>
+      <p class="text-sm font-semibold text-gray-700 mb-1">Likely fix:</p>
+      <ul class="list-disc pl-6 space-y-1 text-sm text-gray-600 mb-3">
+        <li>Increase the system swap space on the node.</li>
+        <li>Reduce the number of concurrent sequences or swap space allocation.</li>
+      </ul>
+    </section>
+
+    <!-- Engine Init Failed -->
+    <section class="p-6 bg-white rounded-lg shadow-md">
+      <div class="flex items-start gap-3 mb-3">
+        <span class="mt-0.5 inline-block px-2 py-0.5 rounded text-xs font-medium bg-gray-200 text-gray-800 shrink-0">General</span>
+        <div>
+          <h3 class="text-lg font-semibold">Engine initialization failed</h3>
+          <p class="text-sm text-gray-500 mt-0.5">
+            Look for: <code class="bg-gray-100 px-1 rounded">Engine core initialization failed</code>
+          </p>
+        </div>
+      </div>
+      <p class="text-gray-600 mb-3">
+        The vLLM engine process crashed during startup. This is a wrapper error &mdash;
+        the real cause is usually one of the other errors on this page.
+      </p>
+      <p class="text-sm font-semibold text-gray-700 mb-1">Likely fix:</p>
+      <ul class="list-disc pl-6 space-y-1 text-sm text-gray-600 mb-3">
+        <li>Expand <strong>View logs</strong> and scroll up to find the root cause error.</li>
+        <li>Match the underlying error to another pattern on this page.</li>
       </ul>
     </section>
   </div>

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/DeploymentFormBody.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/DeploymentFormBody.svelte
@@ -40,6 +40,7 @@
     onDeploymentNameInput,
     onCanaryEnabledChange,
     idSuffix = "",
+    publicSpecifierError,
   }: {
     selectedPrimaryModel: ModelWithSpecifier | undefined;
     selectedCanaryModel: ModelWithSpecifier | undefined;
@@ -65,6 +66,7 @@
     showTrafficSlider?: boolean;
     maxNodeFreeCapacity?: number;
     availableDrivers?: string[];
+    publicSpecifierError?: string;
     onPublicSpecifierInput?: () => void;
     onDeploymentNameInput?: () => void;
     onCanaryEnabledChange?: (enabled: boolean) => void;
@@ -213,10 +215,15 @@
           oninput={() => onPublicSpecifierInput?.()}
           placeholder="e.g., my-chatbot or company/translator-en-de"
           required
+          aria-invalid={publicSpecifierError ? true : undefined}
         />
-        <p class="text-sm text-muted-foreground">
-          This is the public-facing name used to invoke the model via the API.
-        </p>
+        {#if publicSpecifierError}
+          <p class="text-sm text-destructive">{publicSpecifierError}</p>
+        {:else}
+          <p class="text-sm text-muted-foreground">
+            This is the public-facing name used to invoke the model via the API.
+          </p>
+        {/if}
       </div>
       <div class="space-y-2">
         <Label for="deployment-name{idSuffix}">

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/DeploymentModal.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/DeploymentModal.svelte
@@ -11,7 +11,6 @@
   import type { DeploymentDefinition } from "./+page.server";
 
   import { Button } from "$lib/components/ui/button";
-  import { Label } from "$lib/components/ui/label";
   import { Checkbox } from "$lib/components/ui/checkbox";
   import { X } from "@lucide/svelte";
   import { isDefinedError } from "@orpc/client";
@@ -391,21 +390,23 @@
       </main>
 
       <footer class="p-6 border-t bg-muted/50 rounded-b-xl flex justify-between items-center gap-4">
-        <div class="flex items-center gap-2">
+        <label
+          for="enabled{idSuffix}"
+          class="flex items-center gap-2 py-1.5 px-1 -ml-1 rounded select-none {isEditMode && cannotReEnable && !enabled ? 'cursor-not-allowed' : 'cursor-pointer'}"
+        >
           <Checkbox
             id="enabled{idSuffix}"
             checked={enabled}
             disabled={isEditMode && cannotReEnable && !enabled}
             onCheckedChange={(checked) => enabled = checked === true}
           />
-          <Label for="enabled{idSuffix}"
-            class="text-sm cursor-pointer {isEditMode && cannotReEnable ? 'text-muted-foreground' : ''}">
+          <span class="text-sm {isEditMode && cannotReEnable ? 'text-muted-foreground' : ''}">
             {isEditMode ? "Enabled" : "Start deployment in enabled state"}
-          </Label>
+          </span>
           {#if isEditMode && cannotReEnable && !enabled}
             <span class="text-sm text-destructive">{cannotReEnableReason ?? "Insufficient cluster capacity"}</span>
           {/if}
-        </div>
+        </label>
         <div class="flex items-center gap-3">
           <Button variant="outline" onclick={close}>Cancel</Button>
           <Button onclick={handleSubmit} disabled={!isFormValid || (isEditMode && !hasChanges)}>

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/DeploymentModal.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/DeploymentModal.svelte
@@ -14,6 +14,7 @@
   import { Label } from "$lib/components/ui/label";
   import { Checkbox } from "$lib/components/ui/checkbox";
   import { X } from "@lucide/svelte";
+  import { isDefinedError } from "@orpc/client";
 
   // --- Props ---
   let {
@@ -38,6 +39,7 @@
   // --- Form State ---
   let publicSpecifier = $state("");
   let publicSpecifierEdited = $state(false);
+  let publicSpecifierError = $state<string | undefined>(undefined);
   let deploymentName = $state("");
   let deploymentNameEdited = $state(false);
   let enabled = $state(true);
@@ -314,7 +316,11 @@
         });
 
     if (error) {
-      toastState.add(`Failed to ${isEditMode ? "update" : "create"} deployment: ${error.message}`, "error");
+      if(isDefinedError(error) && error.code === "CONFLICT") {
+        publicSpecifierError = error.message ?? "A deployment with this specifier already exists in your organization";
+      } else {
+        toastState.add(`Failed to ${isEditMode ? "update" : "create"} deployment: ${error.message}`, "error");
+      }
     } else {
       close();
       if (!isEditMode) clearState();
@@ -323,7 +329,7 @@
   }
 
   function clearState() {
-    publicSpecifier = ""; publicSpecifierEdited = false;
+    publicSpecifier = ""; publicSpecifierEdited = false; publicSpecifierError = undefined;
     deploymentName = ""; deploymentNameEdited = false;
     enabled = true;
     selectedPrimarySpecifier = null; selectedCanarySpecifier = null;
@@ -372,7 +378,8 @@
           bind:preferredDriver
           {canaryTypeMismatch}
           {showTrafficSlider}
-          onPublicSpecifierInput={() => (publicSpecifierEdited = true)}
+          {publicSpecifierError}
+          onPublicSpecifierInput={() => { publicSpecifierEdited = true; publicSpecifierError = undefined; }}
           onDeploymentNameInput={() => (deploymentNameEdited = true)}
           onCanaryEnabledChange={isEditMode ? () => (shouldAutoSelectCanary = false) : undefined}
           {idSuffix}

--- a/packages/xinity-ai-dashboard/src/routes/login/+page.server.ts
+++ b/packages/xinity-ai-dashboard/src/routes/login/+page.server.ts
@@ -25,5 +25,6 @@ export const load: PageServerLoad = async ({ request, url }) => {
     callbackUrl,
     ssoProviders,
     signupEnabled: serverEnv.SIGNUP_ENABLED,
+    emailVerificationRequired: Boolean(serverEnv.MAIL_URL),
   };
 };

--- a/packages/xinity-ai-dashboard/src/routes/login/+page.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/login/+page.svelte
@@ -78,9 +78,11 @@
 
       if (res?.error) {
         errorSignUp = friendlyError(res.error.message);
-      } else {
+      } else if (data.emailVerificationRequired) {
         signUpSuccess = true;
         setTimeout(() => window.close(), 3000);
+      } else {
+        await goto(data.callbackUrl);
       }
     } catch (e) {
       errorSignUp = (e as Error).message ?? "Unexpected error";

--- a/packages/xinity-cli/src/commands/act.ts
+++ b/packages/xinity-cli/src/commands/act.ts
@@ -251,7 +251,12 @@ export const actCommand: CommandModule = {
         process.exit(1);
       }
     } else if (rawData) {
-      data = JSON.parse(rawData);
+      try {
+        data = JSON.parse(rawData);
+      } catch {
+        p.log.error("Invalid JSON in --data argument.");
+        process.exit(1);
+      }
     } else if (route.input) {
       // No data provided, prompt interactively for each field
       p.intro(`${pc.cyan(routeName)} ${pc.dim(`(${route.summary})`)}`);

--- a/packages/xinity-cli/src/lib/component-meta.ts
+++ b/packages/xinity-cli/src/lib/component-meta.ts
@@ -26,6 +26,7 @@ export const ENV_SCHEMAS: Record<Component, z.ZodObject<any>> = {
 export const ENV_DIR = "/etc/xinity-ai";
 export const SECRETS_DIR = "/etc/xinity-ai/secrets";
 export const BIN_DIR = "/opt/xinity/bin";
+/** Legacy install path used by the tarball-based installer. Kept for migration/uninstall cleanup. */
 export const DASHBOARD_DIR = "/opt/xinity/dashboard";
 export const UNIT_DIR = "/etc/systemd/system";
 

--- a/packages/xinity-cli/src/lib/connectivity.ts
+++ b/packages/xinity-cli/src/lib/connectivity.ts
@@ -51,22 +51,23 @@ export async function testRedisConnection(url: string, host: Host): Promise<bool
       : null;
 
     const ok = await new Promise<boolean>((resolve) => {
-      const timer = setTimeout(() => resolve(false), 5000);
-
-      const fail = () => {
+      let settled = false;
+      const done = (value: boolean) => {
+        if (settled) return;
+        settled = true;
         clearTimeout(timer);
-        resolve(false);
+        resolve(value);
       };
+      const timer = setTimeout(() => done(false), 5000);
 
       Bun.connect({
         hostname,
         port,
         socket: {
           data(_socket, data) {
-            clearTimeout(timer);
             const response = new TextDecoder().decode(data);
             _socket.end();
-            resolve(response.includes("+PONG") || response.includes("+OK"));
+            done(response.includes("+PONG") || response.includes("+OK"));
           },
           open(socket) {
             if (password) {
@@ -75,10 +76,10 @@ export async function testRedisConnection(url: string, host: Host): Promise<bool
               socket.write("PING\r\n");
             }
           },
-          error() { fail(); },
-          connectError() { fail(); },
+          error(_socket) { _socket.end(); done(false); },
+          connectError() { done(false); },
         },
-      }).catch(fail);
+      }).catch(() => done(false));
     });
 
     if (ok) {

--- a/packages/xinity-cli/src/lib/doctor.ts
+++ b/packages/xinity-cli/src/lib/doctor.ts
@@ -210,13 +210,19 @@ function probeTcpService(opts: TcpProbeOptions): Promise<CheckResult> {
   const failStatus = opts.failStatus ?? "fail";
 
   return new Promise<CheckResult>((resolve) => {
+    let settled = false;
+    const done = (result: CheckResult) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
     const timer = setTimeout(() => {
-      resolve({ label, status: failStatus, message: "Connection timed out" });
+      done({ label, status: failStatus, message: "Connection timed out" });
     }, timeoutMs);
 
     const fail = (error: unknown) => {
-      clearTimeout(timer);
-      resolve({ label, status: failStatus, message: "Connection failed", detail: String(error) });
+      done({ label, status: failStatus, message: "Connection failed", detail: String(error) });
     };
 
     Bun.connect({
@@ -225,14 +231,14 @@ function probeTcpService(opts: TcpProbeOptions): Promise<CheckResult> {
       socket: {
         data(_socket, data) {
           const response = new TextDecoder().decode(data);
-          clearTimeout(timer);
           _socket.end();
-          resolve({ label, ...opts.onData(response) });
+          done({ label, ...opts.onData(response) });
         },
         open(socket) {
           opts.onOpen?.(socket);
         },
         error(_socket, error) {
+          _socket.end();
           fail(error);
         },
         connectError(_socket, error) {

--- a/packages/xinity-cli/src/lib/github.ts
+++ b/packages/xinity-cli/src/lib/github.ts
@@ -187,10 +187,6 @@ export async function resolveDirectUrl(asset: ReleaseAsset): Promise<string> {
 
 /** Determine the expected asset filename for a component on the given platform. */
 export function getAssetName(component: string, arch?: string): string {
-  if (component === "dashboard") {
-    return "xinity-ai-dashboard.tar.gz";
-  }
-
   const resolved = (arch ?? process.arch) === "arm64" ? "arm64" : "x64";
 
   if (component === "cli") {

--- a/packages/xinity-cli/src/lib/host.ts
+++ b/packages/xinity-cli/src/lib/host.ts
@@ -8,7 +8,7 @@
  * RemoteHost (which executes SSH commands on the local machine). Consumer code
  * should NEVER import them; always use a Host instance instead.
  */
-import { existsSync, readFileSync } from "fs";
+import { existsSync, readFileSync, statSync } from "fs";
 import * as p from "./clack.ts";
 import pc from "picocolors";
 
@@ -316,7 +316,14 @@ export class LocalHost implements Host {
   }
 
   async fileExists(path: string): Promise<boolean> {
-    return existsSync(path);
+    try {
+      statSync(path);
+      return true;
+    } catch (err: any) {
+      // EACCES means the file exists but isn't readable by the current user.
+      // Treat that as "exists" so the caller can decide to elevate.
+      return err?.code === "EACCES";
+    }
   }
 
   /** No-op: caller already has the file at localPath on the local filesystem. */

--- a/packages/xinity-cli/src/lib/host.ts
+++ b/packages/xinity-cli/src/lib/host.ts
@@ -132,6 +132,15 @@ async function localWithElevation(
     if (sensitive) {
       // Capture stdout to prevent secret values from leaking to the terminal.
       // sudo prompts on /dev/tty, so stdin/stderr inheritance is sufficient.
+      // We must pause/resume stdin around the child process (same as
+      // localRunInteractive) to prevent Bun from leaving the stream in an
+      // ended state, which would cause all subsequent clack prompts to
+      // immediately resolve with EOF and silently exit the CLI.
+      if (process.stdin.isTTY) {
+        process.stdin.setRawMode(false);
+      }
+      process.stdin.pause();
+
       const proc = Bun.spawn(["sudo", "sh", "-c", command], {
         stdin: "inherit",
         stdout: "pipe",
@@ -141,6 +150,12 @@ async function localWithElevation(
         proc.exited,
         new Response(proc.stdout).text(),
       ]);
+
+      process.stdin.resume();
+      if (process.stdin.isTTY) {
+        process.stdin.setRawMode(false);
+      }
+
       return {
         success: exitCode === 0,
         output: stdout,

--- a/packages/xinity-cli/src/lib/installer.ts
+++ b/packages/xinity-cli/src/lib/installer.ts
@@ -549,7 +549,10 @@ async function configureEnv(
       if (content !== null) {
         existingSecrets[key] = content.trim();
       } else {
-        needsElevation = true;
+        // Only flag for elevation if the file actually exists (permission denied).
+        // If the file doesn't exist (fresh install), there's nothing to read.
+        const exists = await host.fileExists(`${SECRETS_DIR}/${key}`);
+        if (exists) needsElevation = true;
       }
     }
     if (needsElevation && Object.keys(existingSecrets).length < secretKeys.length) {

--- a/packages/xinity-cli/src/lib/installer.ts
+++ b/packages/xinity-cli/src/lib/installer.ts
@@ -63,9 +63,9 @@ export async function preflightCheck(
     await check("systemctl", "systemd is required to manage services");
   }
 
-  // unzip is needed for binary extraction (all service components except dashboard)
+  // unzip is needed for binary extraction (all service components)
   const needsUnzip = components.some(
-    (c) => c === "all" || (serviceComponents.includes(c) && c !== "dashboard"),
+    (c) => c === "all" || serviceComponents.includes(c),
   );
   if (needsUnzip) {
     const target = host.isRemote ? "the remote host" : "this machine";
@@ -75,11 +75,6 @@ export async function preflightCheck(
   // curl is needed on remote hosts for downloading release assets
   if (host.isRemote && components.some((c) => serviceComponents.includes(c) || c === "all" || c === "db")) {
     await check("curl", "required on the remote host for downloading release assets");
-  }
-
-  // bun is needed for the dashboard
-  if (components.includes("dashboard") || components.includes("all")) {
-    await check("bun", "required for the dashboard", "curl -fsSL https://bun.sh/install | bash");
   }
 
   return issues;
@@ -271,8 +266,8 @@ async function resolveVersion(
   if (installedVersion === release.tagName) {
     spinner.stop(`${release.tagName} already installed`);
 
-    // For binary components, verify the installed binary is intact before deciding.
-    if (component !== "dashboard" && installedEntry?.binaryChecksum && installedEntry.binaryPath) {
+    // Verify the installed binary is intact before deciding.
+    if (installedEntry?.binaryChecksum && installedEntry.binaryPath) {
       const checksumSpinner = p.spinner();
       checksumSpinner.start("Verifying installed binary…");
       const currentHash = await host.computeSha256(installedEntry.binaryPath);
@@ -285,7 +280,7 @@ async function resolveVersion(
       return { status: "proceed", release, isUpdate: true };
     }
 
-    // No stored checksum (legacy install) or dashboard, prompt the user.
+    // No stored checksum (legacy install), prompt the user.
     const reinstall = await p.confirm({
       message: `${component} ${release.tagName} is already installed. Reinstall?`,
       initialValue: false,
@@ -425,99 +420,68 @@ async function downloadAndVerifyOnHost(
 // ─── Install binary ────────────────────────────────────────────────────────
 
 async function installBinary(component: Component, archivePath: string, host: Host): Promise<boolean> {
-  if (component === "dashboard") {
-    if (host.isRemote) {
-      // Archive already on remote, extract directly
-      const result = await host.withElevation(
-        `mkdir -p ${DASHBOARD_DIR} && tar xzf ${archivePath} -C ${DASHBOARD_DIR} && rm -f ${archivePath}`,
-        "Install dashboard files",
-      );
-      if (!result.success && !result.skipped) {
-        fail("Install", result.output);
-        return false;
-      }
-      if (result.skipped) return false;
-    } else {
-      // Local: upload archive to host, extract on host
-      const remoteTar = "/tmp/xinity-dashboard.tar.gz";
-      let effectiveTar: string;
-      const uploadSpinner = p.spinner();
-      uploadSpinner.start("Uploading…");
-      try {
-        effectiveTar = await host.uploadFile(archivePath, remoteTar);
-      } catch (err) {
-        uploadSpinner.stop("Upload failed");
-        fail("Upload", (err as Error).message);
-        return false;
-      }
-      uploadSpinner.stop("Uploaded");
-      const result = await host.withElevation(
-        `mkdir -p ${DASHBOARD_DIR} && tar xzf ${effectiveTar} -C ${DASHBOARD_DIR}` +
-          (effectiveTar !== archivePath ? ` && rm -f ${effectiveTar}` : ""),
-        "Install dashboard files",
-      );
-      if (!result.success && !result.skipped) {
-        fail("Install", result.output);
-        return false;
-      }
-      if (result.skipped) return false;
+  const binName = binaryBaseName(component);
+
+  if (host.isRemote) {
+    // Archive already on remote, extract and install directly
+    const tmpExtract = archivePath.replace(/\.zip$/, "");
+    const result = await host.withElevation(
+      `mkdir -p ${tmpExtract} && unzip -o ${archivePath} -d ${tmpExtract}` +
+      ` && mkdir -p ${BIN_DIR} && cp ${tmpExtract}/${binName} ${BIN_DIR}/${binName}` +
+      ` && chmod +x ${BIN_DIR}/${binName}` +
+      ` && rm -rf ${tmpExtract} ${archivePath}`,
+      `Install ${binName} binary`,
+    );
+    if (!result.success && !result.skipped) {
+      fail("Install", result.output);
+      return false;
     }
+    if (result.skipped) return false;
   } else {
-    const binName = binaryBaseName(component);
+    // Local: extract locally, upload binary, place on host
+    const tmpExtract = archivePath.replace(/\.zip$/, "");
+    mkdirSync(tmpExtract, { recursive: true });
 
-    if (host.isRemote) {
-      // Archive already on remote, extract and install directly
-      const tmpExtract = archivePath.replace(/\.zip$/, "");
-      const result = await host.withElevation(
-        `mkdir -p ${tmpExtract} && unzip -o ${archivePath} -d ${tmpExtract}` +
-        ` && mkdir -p ${BIN_DIR} && cp ${tmpExtract}/${binName} ${BIN_DIR}/${binName}` +
-        ` && chmod +x ${BIN_DIR}/${binName}` +
-        ` && rm -rf ${tmpExtract} ${archivePath}`,
-        `Install ${binName} binary`,
-      );
-      if (!result.success && !result.skipped) {
-        fail("Install", result.output);
-        return false;
-      }
-      if (result.skipped) return false;
-    } else {
-      // Local: extract locally, upload binary, place on host
-      const tmpExtract = archivePath.replace(/\.zip$/, "");
-      mkdirSync(tmpExtract, { recursive: true });
-
-      const extractSpinner = p.spinner();
-      extractSpinner.start("Extracting…");
-      const local = createLocalHost();
-      const unzip = await local.run(["unzip", "-o", archivePath, "-d", tmpExtract]);
-      if (!unzip.ok) {
-        extractSpinner.stop("Extract failed");
-        fail("Extract", unzip.output);
-        return false;
-      }
-
-      const localBinPath = `${tmpExtract}/${binName}`;
-      const remoteTmpPath = `/tmp/xinity-upload-${binName}`;
-      let effectivePath: string;
-      try {
-        effectivePath = await host.uploadFile(localBinPath, remoteTmpPath);
-      } catch (err) {
-        extractSpinner.stop("Upload failed");
-        fail("Upload", (err as Error).message);
-        return false;
-      }
-      extractSpinner.stop("Extracted");
-
-      const result = await host.withElevation(
-        `mkdir -p ${BIN_DIR} && cp ${effectivePath} ${BIN_DIR}/${binName} && chmod +x ${BIN_DIR}/${binName}` +
-          (effectivePath !== localBinPath ? ` && rm -f ${effectivePath}` : ""),
-        `Install ${binName} binary`,
-      );
-      if (!result.success && !result.skipped) {
-        fail("Install", result.output);
-        return false;
-      }
-      if (result.skipped) return false;
+    const extractSpinner = p.spinner();
+    extractSpinner.start("Extracting…");
+    const local = createLocalHost();
+    const unzip = await local.run(["unzip", "-o", archivePath, "-d", tmpExtract]);
+    if (!unzip.ok) {
+      extractSpinner.stop("Extract failed");
+      fail("Extract", unzip.output);
+      return false;
     }
+
+    const localBinPath = `${tmpExtract}/${binName}`;
+    const remoteTmpPath = `/tmp/xinity-upload-${binName}`;
+    let effectivePath: string;
+    try {
+      effectivePath = await host.uploadFile(localBinPath, remoteTmpPath);
+    } catch (err) {
+      extractSpinner.stop("Upload failed");
+      fail("Upload", (err as Error).message);
+      return false;
+    }
+    extractSpinner.stop("Extracted");
+
+    const result = await host.withElevation(
+      `mkdir -p ${BIN_DIR} && cp ${effectivePath} ${BIN_DIR}/${binName} && chmod +x ${BIN_DIR}/${binName}` +
+        (effectivePath !== localBinPath ? ` && rm -f ${effectivePath}` : ""),
+      `Install ${binName} binary`,
+    );
+    if (!result.success && !result.skipped) {
+      fail("Install", result.output);
+      return false;
+    }
+    if (result.skipped) return false;
+  }
+
+  // Best-effort cleanup of the legacy tarball installation directory
+  if (component === "dashboard") {
+    await host.withElevation(
+      `rm -rf ${DASHBOARD_DIR} 2>/dev/null || true`,
+      "Remove legacy dashboard directory",
+    );
   }
 
   pass("Install", "Installed");
@@ -637,26 +601,11 @@ async function configureEnv(
   return promptForEnv(component, schema, existing);
 }
 
-// ─── Bun path resolution ──────────────────────────────────────────────────
-
-async function resolveBunPath(host: Host): Promise<string> {
-  const result = await host.runShell(
-    `command -v bun || echo "$HOME/.bun/bin/bun"`,
-  );
-  return result.output.trim();
-}
-
 // ─── Systemd unit ──────────────────────────────────────────────────────────
 
 async function installUnit(component: Component, secretKeys: string[], host: Host): Promise<boolean> {
   const baseConfig = getComponentConfig(component);
   const config: UnitConfig = { ...baseConfig, secretKeys };
-
-  // Dashboard runs via bun, resolve its actual path on the target host
-  if (component === "dashboard") {
-    const bunPath = await resolveBunPath(host);
-    config.execStart = `${bunPath} run /opt/xinity/dashboard/`;
-  }
 
   const unitContent = generateUnit(config);
   const unitPath = `${UNIT_DIR}/${unitName(component)}`;
@@ -821,15 +770,9 @@ export async function installComponent(opts: {
   }
 
   // 9. Update manifest
-  const binaryPath =
-    component === "dashboard"
-      ? DASHBOARD_DIR
-      : `${BIN_DIR}/${binaryBaseName(component)}`;
+  const binaryPath = `${BIN_DIR}/${binaryBaseName(component)}`;
 
-  const binaryChecksum =
-    component !== "dashboard"
-      ? (await host.computeSha256(binaryPath)) ?? undefined
-      : undefined;
+  const binaryChecksum = (await host.computeSha256(binaryPath)) ?? undefined;
 
   await updateManifestEntry(component, {
     version: release.tagName,
@@ -905,11 +848,7 @@ function dryRunSummary(
   }
 
   // Install path
-  if (component === "dashboard") {
-    info("Install", `Extract to ${DASHBOARD_DIR}`);
-  } else {
-    info("Install", `Binary → ${BIN_DIR}/${binaryBaseName(component)}`);
-  }
+  info("Install", `Binary → ${BIN_DIR}/${binaryBaseName(component)}`);
 
   // Env config
   info("Config", `${configFields.length} config fields → ${ENV_DIR}/${component}.env`);
@@ -1165,28 +1104,18 @@ export async function removeComponent(opts: {
     errors.push(`Failed to remove unit: ${rmUnit.output}`);
   }
 
-  // 3. Remove binary / dashboard files
-  if (component === "dashboard") {
-    const rmDash = await host.withElevation(
-      `rm -rf ${DASHBOARD_DIR}`,
-      "Remove dashboard files",
-    );
-    if (rmDash.success) {
-      pass("Files", `Removed ${DASHBOARD_DIR}`);
-    } else if (!rmDash.skipped) {
-      errors.push(`Failed to remove dashboard: ${rmDash.output}`);
-    }
-  } else {
-    const binaryPath = `${BIN_DIR}/${binaryBaseName(component)}`;
-    const rmBin = await host.withElevation(
-      `rm -f ${binaryPath}`,
-      `Remove ${component} binary`,
-    );
-    if (rmBin.success) {
-      pass("Files", `Removed ${binaryPath}`);
-    } else if (!rmBin.skipped) {
-      errors.push(`Failed to remove binary: ${rmBin.output}`);
-    }
+  // 3. Remove binary and (for dashboard) any legacy tarball directory
+  const binaryPath = `${BIN_DIR}/${binaryBaseName(component)}`;
+  const rmBin = await host.withElevation(
+    component === "dashboard"
+      ? `rm -f ${binaryPath} && rm -rf ${DASHBOARD_DIR} 2>/dev/null || true`
+      : `rm -f ${binaryPath}`,
+    `Remove ${component} binary`,
+  );
+  if (rmBin.success) {
+    pass("Files", `Removed ${binaryPath}`);
+  } else if (!rmBin.skipped) {
+    errors.push(`Failed to remove binary: ${rmBin.output}`);
   }
 
   // 4. Remove env config file

--- a/packages/xinity-cli/src/lib/remote-host.ts
+++ b/packages/xinity-cli/src/lib/remote-host.ts
@@ -170,9 +170,12 @@ export class RemoteHost implements Host {
   async fileExists(path: string): Promise<boolean> {
     const result = await localRun([
       "ssh", ...this.ctrlArgs, this.hostname,
-      `test -e ${shellEscape(path)} && echo yes || echo no`,
+      // stat exits 0 when the file exists. If it fails with "Permission denied"
+      // the file exists but the current user cannot access it (needs elevation).
+      `s=$(stat ${shellEscape(path)} 2>&1) && echo yes || (echo "$s" | grep -qi 'permission denied' && echo perm || echo no)`,
     ]);
-    return result.ok && result.output.trim() === "yes";
+    const out = result.output.trim();
+    return out === "yes" || out === "perm";
   }
 
   async uploadFile(localPath: string, destPath: string): Promise<string> {

--- a/packages/xinity-cli/src/lib/remote-probe.ts
+++ b/packages/xinity-cli/src/lib/remote-probe.ts
@@ -31,7 +31,7 @@ export async function collectRemoteState(
 ): Promise<RemoteState> {
   const filesToCheck: string[] = [];
   const filesToRead: string[] = [];
-  const commandsToCheck: string[] = ["systemctl", "weed", "ollama", "docker", "nvidia-smi", "bun"];
+  const commandsToCheck: string[] = ["systemctl", "weed", "ollama", "docker", "nvidia-smi", "unzip", "curl"];
   const unitsToCheck: string[] = ["xinity-ai-seaweedfs.service", "ollama.service", "ollama"];
 
   // SeaweedFS paths

--- a/packages/xinity-cli/src/lib/systemd.ts
+++ b/packages/xinity-cli/src/lib/systemd.ts
@@ -28,7 +28,7 @@ const COMPONENT_CONFIGS: Record<string, Omit<UnitConfig, "secretKeys">> = {
   dashboard: {
     component: "dashboard",
     description: "Xinity AI Dashboard",
-    execStart: "bun run /opt/xinity/dashboard/",
+    execStart: "/opt/xinity/bin/xinity-ai-dashboard",
     afterUnits: ["network-online.target"],
   },
   daemon: {

--- a/packages/xinity-cli/tests/unit/github.test.ts
+++ b/packages/xinity-cli/tests/unit/github.test.ts
@@ -4,8 +4,9 @@ import { createTempDir, type TempDir } from "../helpers/temp-config.ts";
 
 describe("github", () => {
   describe("getAssetName", () => {
-    test("returns tar.gz for dashboard", () => {
-      expect(getAssetName("dashboard")).toBe("xinity-ai-dashboard.tar.gz");
+    test("returns platform-specific zip for dashboard", () => {
+      const name = getAssetName("dashboard");
+      expect(name).toMatch(/^xinity-ai-dashboard-linux-(x64|arm64)\.zip$/);
     });
 
     test("returns tar.gz for db migrations", () => {
@@ -33,9 +34,10 @@ describe("github", () => {
       expect(name).toContain(expectedArch);
     });
 
-    test("dashboard asset name is architecture-independent", () => {
-      expect(getAssetName("dashboard")).not.toContain("x64");
-      expect(getAssetName("dashboard")).not.toContain("arm64");
+    test("dashboard asset name is architecture-specific", () => {
+      const name = getAssetName("dashboard");
+      const expectedArch = process.arch === "arm64" ? "arm64" : "x64";
+      expect(name).toContain(expectedArch);
     });
 
     test("db asset name is architecture-independent", () => {
@@ -58,8 +60,9 @@ describe("github", () => {
       expect(getAssetName("gateway", "x86_64")).toBe("xinity-ai-gateway-linux-x64.zip");
     });
 
-    test("dashboard and db ignore explicit arch parameter", () => {
-      expect(getAssetName("dashboard", "arm64")).toBe("xinity-ai-dashboard.tar.gz");
+    test("dashboard respects explicit arch parameter, db does not", () => {
+      expect(getAssetName("dashboard", "arm64")).toBe("xinity-ai-dashboard-linux-arm64.zip");
+      expect(getAssetName("dashboard", "x64")).toBe("xinity-ai-dashboard-linux-x64.zip");
       expect(getAssetName("db", "arm64")).toBe("db-migrations.tar.gz");
     });
   });

--- a/packages/xinity-cli/tests/unit/systemd.test.ts
+++ b/packages/xinity-cli/tests/unit/systemd.test.ts
@@ -26,11 +26,10 @@ describe("systemd", () => {
       expect(config.afterUnits).toContain("network-online.target");
     });
 
-    test("returns dashboard config with bun runner", () => {
+    test("returns dashboard config with binary runner", () => {
       const config = getComponentConfig("dashboard");
       expect(config.component).toBe("dashboard");
-      expect(config.execStart).toContain("bun");
-      expect(config.execStart).toContain("/opt/xinity/dashboard/");
+      expect(config.execStart).toBe("/opt/xinity/bin/xinity-ai-dashboard");
     });
 
     test("returns daemon config", () => {


### PR DESCRIPTION
## Description

Fixes several CLI reliability issues (stdin corruption around sudo prompts, socket cleanup, secret file handling, invalid JSON in `act --data`), expands daemon vLLM failure detection, adds deployment conflict error clarity, and ships the dashboard as a self-contained compiled binary, removing Bun as a deployment prerequisite. The CLI installer now treats the dashboard identically to every other service: zip download, SHA256 verification, binary at `/opt/xinity/bin/xinity-ai-dashboard`, managed by systemd. Legacy tarball installs at `/opt/xinity/dashboard/` are cleaned up automatically on the next update or uninstall.

## Type of change

Bug fix | New feature

## Testing

Aside from the stabilization, most of the changes are to CI not to application code. No new tests seem required. Tests were locally run through, some required updates.

## Checklist

- [x] Tests pass locally (`bun test`), or no testable code was changed
- [x] New or changed behavior is covered by tests, or this change does not require tests
- [x] Documentation is updated, or no user-facing behavior or configuration was changed
- [x] There are no breaking changes, or they are marked with `!` in the commit type and described above
- [x] No security-sensitive changes (authentication, credentials, input handling), or they have been reviewed
- [x] No new dependencies were added, or they have been reviewed for license and maintenance status