### PR TITLE
fix: added model-not-found state for infoserver model removal

### DIFF
--- a/packages/xinity-ai-dashboard/.env.test
+++ b/packages/xinity-ai-dashboard/.env.test
@@ -1,4 +1,4 @@
-MAIL_URL=smtps://localhost:1025
+MAIL_URL=smtp://localhost:1025
 MAIL_FROM=Auth Service <noreply@example.com>
 BETTER_AUTH_SECRET=secret_key
 BETTER_AUTH_URL=http://localhost:5173

--- a/packages/xinity-ai-dashboard/src/lib/server/lib/deployment-phase.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/lib/deployment-phase.ts
@@ -6,7 +6,7 @@
  * This module provides the common types and aggregation function.
  */
 
-export type DeploymentPhase = "ready" | "downloading" | "installing" | "failed" | "pending" | "scheduling";
+export type DeploymentPhase = "ready" | "downloading" | "installing" | "failed" | "pending" | "scheduling" | "not_in_catalog";
 
 /** Higher number = worse state. Used to pick the "worst" phase across installations. */
 export const PHASE_PRIORITY: Record<string, number> = {
@@ -14,6 +14,7 @@ export const PHASE_PRIORITY: Record<string, number> = {
   installing: 2,
   downloading: 3,
   scheduling: 3,
+  not_in_catalog: 3,
   failed: 4,
 };
 

--- a/packages/xinity-ai-dashboard/src/lib/server/lib/orchestration.mod.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/lib/orchestration.mod.ts
@@ -190,11 +190,19 @@ async function planNewInstallations(requiredModels: ModelRequirementTable, state
     const current = (state.installationsByModel.get(model) || []).length;
     if (current >= requirement.replicas) continue;
 
-    const modelInfo = await infoClient?.fetchModel(model);
-    if (!modelInfo) {
-      log.warn({ model }, `Model not found`);
+    const modelStatus = await infoClient?.fetchModelStatus(model);
+    if (!modelStatus || modelStatus.status === "unavailable") {
+      log.warn({ model, error: modelStatus?.status === "unavailable" ? modelStatus.error : undefined },
+        "Info server unreachable; skipping installation planning for this sync cycle");
       continue;
     }
+    if (modelStatus.status === "not_found") {
+      log.warn({ model },
+        "Model not found in catalog; installations cannot be scheduled. " +
+        "If this model has been intentionally removed, disable or delete the deployment.");
+      continue;
+    }
+    const modelInfo = modelStatus.model;
 
     const driver = resolveDriverForProviderModel(modelInfo, model) ?? "ollama";
     const minVersion = resolveMinVersionForDriver(modelInfo, driver);

--- a/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/deployment.procedure.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/deployment.procedure.ts
@@ -65,20 +65,26 @@ async function checkDeploymentCapacity(input: z.infer<typeof CapacityCheckInput>
     modelsToCheck.push({ specifier: input.modelSpecifier, replicas: input.replicas, kvCacheSize: input.kvCacheSize });
   }
 
-  // Fetch model info for all models (including driver/version/platform requirements)
+  // Fetch model info for all models, distinguishing not_found from unavailable
   const modelInfos = await Promise.all(
     modelsToCheck.map(async (m) => {
-      const info = await infoClient?.fetchModel(m.specifier);
-      if (!info) return null;
+      const status = await infoClient?.fetchModelStatus(m.specifier);
+      if (!status || status.status === "unavailable") return { kind: "unavailable" as const, specifier: m.specifier };
+      if (status.status === "not_found") return { kind: "not_found" as const, specifier: m.specifier };
+      const info = status.model;
       const effectiveKvCache = Math.max(m.kvCacheSize ?? 0, info.minKvCache);
       const driver = resolveDriverForProviderModel(info, m.specifier);
       const minVersion = driver ? resolveMinVersionForDriver(info, driver) : undefined;
       const requiredPlatforms = driver ? resolveRequiredPlatformsForDriver(info, driver) : [];
-      return { ...m, perReplica: info.weight + effectiveKvCache, driver, minVersion, requiredPlatforms };
+      return { kind: "found" as const, specifier: m.specifier, replicas: m.replicas, perReplica: info.weight + effectiveKvCache, driver, minVersion, requiredPlatforms };
     }),
   );
-  const resolved = modelInfos.filter((m): m is NonNullable<typeof m> => m !== null);
-  if (resolved.length === 0) return { deployable: true }; // Can't validate without model info; let orchestration handle it
+
+  const notFound = modelInfos.find(m => m.kind === "not_found");
+  if (notFound) return { deployable: false, reason: `Model "${notFound.specifier}" was not found in the model catalog` };
+
+  const resolved = modelInfos.filter((m): m is Extract<typeof modelInfos[number], { kind: "found" }> => m.kind === "found");
+  if (resolved.length === 0) return { deployable: true, reason: "Capacity could not be verified: model catalog is unavailable" };
 
   const { nodeCapabilities } = await buildClusterCapacity();
   const remaining = nodeCapabilities
@@ -134,7 +140,7 @@ async function internalUpdateDeployment(orgId: string, id: string, params: Parti
 // ---------------------------------------------------------------------------
 
 const DeploymentStatusSchema = z.object({
-  phase: z.enum(["ready", "downloading", "installing", "failed", "scheduling"]),
+  phase: z.enum(["ready", "downloading", "installing", "failed", "scheduling", "not_in_catalog"]),
   progress: z.number().nullable(),
   error: z.string().nullable().optional(),
   failureLogs: z.string().nullable().optional(),
@@ -142,7 +148,7 @@ const DeploymentStatusSchema = z.object({
 
 export const DeploymentWithStatusDto = DeploymentDto.extend({ status: DeploymentStatusSchema.optional() });
 export type DeploymentWithStatus = z.infer<typeof DeploymentWithStatusDto>;
-type StatusPhase = "ready" | "downloading" | "installing" | "failed" | "scheduling";
+type StatusPhase = "ready" | "downloading" | "installing" | "failed" | "scheduling" | "not_in_catalog";
 
 /**
  * Runs the status join query and aggregates installation phase info for the given deployments.
@@ -200,7 +206,37 @@ const listDeployments = rootOs.use(withOrganization)
   .handler(async ({ context, input }) => {
     const orgCondition = sql`${modelDeploymentT.organizationId} = ${context.activeOrganizationId} AND ${modelDeploymentT.deletedAt} IS NULL`;
     if (input?.withStatus) {
-      return queryDeploymentsWithStatus(orgCondition);
+      const results = await queryDeploymentsWithStatus(orgCondition);
+
+      // For enabled deployments with no installations at all, check whether the
+      // model still exists in the catalog. If it has been removed, surface that
+      // as a distinct "not_in_catalog" phase so the UI can warn the operator.
+      const noStatusEnabled = results.filter(r => !r.status && r.enabled);
+      if (noStatusEnabled.length > 0 && infoClient) {
+        const specifiers = [...new Set(
+          noStatusEnabled.flatMap(e => [
+            e.modelSpecifier,
+            ...(e.earlyModelSpecifier ? [e.earlyModelSpecifier] : []),
+          ]),
+        )];
+        try {
+          const batchResult = await infoClient.fetchModelsBatch(specifiers);
+          for (const entry of noStatusEnabled) {
+            const primaryMissing = batchResult[entry.modelSpecifier] === null;
+            const earlyMissing = entry.earlyModelSpecifier
+              ? batchResult[entry.earlyModelSpecifier] === null
+              : false;
+            if (primaryMissing || earlyMissing) {
+              (entry as any).status = { phase: "not_in_catalog" as const, progress: null, error: null };
+            }
+          }
+        } catch {
+          // Info server unreachable: leave status as undefined rather than
+          // falsely marking deployments as not_in_catalog.
+        }
+      }
+
+      return results;
     }
     return await getDB().select().from(modelDeploymentT).where(orgCondition);
   });
@@ -402,6 +438,22 @@ export const createDeployment = rootOs
   .output(DeploymentDto)
   .errors({ CONFLICT: {}, BAD_REQUEST: {} })
   .handler(async ({ context, input, errors }) => {
+    // Validate that the requested model specifiers exist in the catalog.
+    // If the info server is unreachable we let the request through. An outage
+    // should not prevent operators from managing deployments.
+    if (infoClient) {
+      const client = infoClient;
+      const specsToCheck = [
+        { field: "modelSpecifier", specifier: input.modelSpecifier },
+        ...(input.earlyModelSpecifier ? [{ field: "earlyModelSpecifier", specifier: input.earlyModelSpecifier }] : []),
+      ];
+      const statuses = await Promise.all(specsToCheck.map(async s => ({ ...s, status: await client.fetchModelStatus(s.specifier) })));
+      const missing = statuses.find(s => s.status.status === "not_found");
+      if (missing) {
+        throw errors.BAD_REQUEST({ message: `Model "${missing.specifier}" was not found in the model catalog` });
+      }
+    }
+
     try {
       await validateCanaryModelTypes(input.modelSpecifier, input.earlyModelSpecifier);
     } catch (err: any) {

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/+page.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/+page.svelte
@@ -137,11 +137,12 @@
 
   // Status chip colors/labels by phase
   const phaseConfig = {
-    ready:       { dot: "bg-[#4ade80]",      chip: "bg-[#4ade80]/15 text-[#16a34a]",  pulse: false, label: "Ready" },
-    failed:      { dot: "bg-destructive",     chip: "bg-destructive/15 text-destructive", pulse: false, label: "Failed" },
-    scheduling:  { dot: "bg-[#98B9FD]",      chip: "bg-[#98B9FD]/15 text-[#5b8ae6]", pulse: true,  label: "Scheduling" },
-    downloading: { dot: "bg-primary",         chip: "bg-primary/15 text-primary",      pulse: true,  label: "Downloading" },
-    installing:  { dot: "bg-primary",         chip: "bg-primary/15 text-primary",      pulse: true,  label: "Installing" },
+    ready:          { dot: "bg-[#4ade80]",      chip: "bg-[#4ade80]/15 text-[#16a34a]",        pulse: false, label: "Ready" },
+    failed:         { dot: "bg-destructive",     chip: "bg-destructive/15 text-destructive",   pulse: false, label: "Failed" },
+    scheduling:     { dot: "bg-[#98B9FD]",      chip: "bg-[#98B9FD]/15 text-[#5b8ae6]",      pulse: true,  label: "Scheduling" },
+    downloading:    { dot: "bg-primary",         chip: "bg-primary/15 text-primary",            pulse: true,  label: "Downloading" },
+    installing:     { dot: "bg-primary",         chip: "bg-primary/15 text-primary",            pulse: true,  label: "Installing" },
+    not_in_catalog: { dot: "bg-[#f59e0b]",      chip: "bg-[#f59e0b]/15 text-[#d97706]",      pulse: false, label: "Not in Catalog" },
   } as const;
 
   async function confirmDelete() {

--- a/packages/xinity-infoserver/client.test.ts
+++ b/packages/xinity-infoserver/client.test.ts
@@ -150,7 +150,7 @@ describe("createInfoserverClient", () => {
 
     it("throws on server error", async () => {
       const client = makeClient();
-      await expect(client.fetchModel("server-error")).rejects.toThrow("Infoserver error: 500");
+      await expect(client.fetchModel("server-error")).rejects.toThrow('Infoserver unavailable for "server-error": HTTP 500');
     });
   });
 

--- a/packages/xinity-infoserver/client.ts
+++ b/packages/xinity-infoserver/client.ts
@@ -12,6 +12,18 @@ export interface InfoserverClientConfig {
   cacheTtlMs: number;
 }
 
+/**
+ * Typed result from a single-model lookup.
+ * Distinguishes between a found model, a model that genuinely does not exist in
+ * the catalog (404), and an unreachable info server (network error / 5xx).
+ * Only `found` results are cached. `not_found` is intentionally never cached
+ * so a re-added model is picked up within the next TTL window.
+ */
+export type FetchModelStatus =
+  | { status: "found"; model: ModelWithSpecifier }
+  | { status: "not_found" }
+  | { status: "unavailable"; error: string };
+
 export interface PaginatedModels {
   models: ModelWithSpecifier[];
   total: number;
@@ -49,14 +61,35 @@ export function createInfoserverClient(config: InfoserverClientConfig) {
     return data;
   }
 
-  async function fetchModel(specifier: string): Promise<ModelWithSpecifier | undefined> {
+  /**
+   * Fetches a model and returns a typed status result.
+   * - `found`: model exists; result is cached for `cacheTtlMs`
+   * - `not_found`: server returned 404; result is NOT cached so a re-added model
+   *   is visible on the next request without waiting for TTL expiry
+   * - `unavailable`: network error or non-404 HTTP error; result is NOT cached
+   */
+  async function fetchModelStatus(specifier: string): Promise<FetchModelStatus> {
     const key = `model:${specifier}`;
-    return cachedFetch(key, async () => {
+    const existing = cache.get(key);
+    if (isFresh(existing)) return { status: "found", model: existing.data };
+
+    try {
       const res = await fetch(`${baseUrl}/api/v1/models/${encodeURIComponent(specifier)}`);
-      if (res.status === 404) return undefined;
-      if (!res.ok) throw new Error(`Infoserver error: ${res.status}`);
-      return res.json() as Promise<ModelWithSpecifier>;
-    });
+      if (res.status === 404) return { status: "not_found" };
+      if (!res.ok) return { status: "unavailable", error: `HTTP ${res.status}` };
+      const model = await res.json() as ModelWithSpecifier;
+      cache.set(key, { data: model, fetchedAt: Date.now() });
+      return { status: "found", model };
+    } catch (err) {
+      return { status: "unavailable", error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  async function fetchModel(specifier: string): Promise<ModelWithSpecifier | undefined> {
+    const result = await fetchModelStatus(specifier);
+    if (result.status === "found") return result.model;
+    if (result.status === "unavailable") throw new Error(`Infoserver unavailable for "${specifier}": ${result.error}`);
+    return undefined;
   }
 
   async function fetchModelsByFamily(family: string): Promise<ModelWithSpecifier[]> {
@@ -132,6 +165,7 @@ export function createInfoserverClient(config: InfoserverClientConfig) {
 
   return {
     fetchModel,
+    fetchModelStatus,
     fetchModelsBatch,
     fetchModelsByFamily,
     fetchModels,

--- a/packages/xinity-infoserver/index.ts
+++ b/packages/xinity-infoserver/index.ts
@@ -2,5 +2,5 @@ export * from "./definitions/model-definition";
 export * from "./model-tags";
 export { satisfiesMinVersion, normalizePep440 } from "./semver";
 export { checkNodeCompatibility, isDeployableOnCluster, type GpuInfo, type NodeCapability, type ModelNodeRequirements, type IncompatibilityReason } from "./node-compat";
-export { createInfoserverClient, type InfoserverClientConfig, type InfoserverClient, type PaginatedModels, type FetchModelsParams } from "./client";
+export { createInfoserverClient, type InfoserverClientConfig, type InfoserverClient, type PaginatedModels, type FetchModelsParams, type FetchModelStatus } from "./client";
 export { PaginationSchema, ModelListQuerySchema } from "./api-schemas";


### PR DESCRIPTION
## Description

When a model is removed from the infoserver catalog, deployments referencing it would silently stall with no visible status. This adds a `fetchModelStatus()` method to the infoserver client that returns a typed discriminated union, allowing callers to distinguish a genuine 404 from a network error.

Orchestration now logs a clear warning and skips scheduling for missing models. Deployment creation validates specifiers against the catalog before inserting. The deployment list batch-checks enabled deployments with no installations and surfaces a `not_in_catalog` phase as an amber badge in the modelhub UI.

## Type of change

Bug fix

## Testing

Potentially affected tests (daemon+dashboard) pass locally.
Manually verified with missing model specifiers.

## Checklist

- [x] Tests pass locally (`bun test`), or no testable code was changed
- [x] New or changed behavior is covered by tests, or this change does not require tests
- [x] Documentation is updated, or no user-facing behavior or configuration was changed
- [x] There are no breaking changes, or they are marked with `!` in the commit type and described above
- [x] No security-sensitive changes (authentication, credentials, input handling), or they have been reviewed
- [x] No new dependencies were added, or they have been reviewed for license and maintenance status