### PR TITLE
feat: optional tls for internal services + llm proxy

### DIFF
--- a/docs/security/tls.md
+++ b/docs/security/tls.md
@@ -1,0 +1,147 @@
+# TLS: Encrypted Inference Backend Communication
+
+xinity supports optional TLS between the gateway and inference daemons. When enabled, inference traffic is encrypted in transit. Authentication between services is handled automatically via per-node tokens exchanged through the shared database.
+
+## Architecture
+
+```
+Gateway --HTTP(S)--> Daemon (:4044) /proxy/{model}/v1/... --plain HTTP--> Backend on 127.0.0.1
+```
+
+- The daemon acts as a reverse proxy for all inference traffic on its existing HTTP(S) port
+- Inference backends (vLLM, Ollama) bind to `127.0.0.1` only and are not directly reachable from the network
+- Each daemon generates a random auth token on startup and writes it to the database; the gateway reads it automatically
+- When TLS is configured on a daemon, it reports this to the database so the gateway connects via HTTPS
+
+## Security layers
+
+1. **App-level auth**: Each daemon generates a per-instance token on startup, stored in the database. The gateway reads the token and sends it with every request. No manual configuration needed.
+2. **TLS** (opt-in): Encrypts traffic between gateway and daemons. Configure with cert/key env vars.
+3. **Overlay networks** (recommended): For production deployments, use an overlay network like WireGuard, Tailscale, or Nebula to isolate service-to-service traffic at the network level.
+
+## Quickstart with self-signed certs
+
+Generate a CA + server certificate using the bundled script:
+
+```bash
+./scripts/generate-tls-certs.sh ./certs
+```
+
+To add extra SANs (additional IPs or hostnames the daemon listens on):
+
+```bash
+./scripts/generate-tls-certs.sh ./certs 10.0.0.5 daemon.internal
+```
+
+This creates:
+
+| File | Description | Used by |
+|------|-------------|---------|
+| `ca.pem` | CA certificate | Gateway (`XINITY_INFERENCE_CA`) |
+| `ca-key.pem` | CA private key | Keep secure, only for signing new certs |
+| `server.pem` | Server certificate | Daemon (`XINITY_TLS_CERT`) |
+| `server-key.pem` | Server private key | Daemon (`XINITY_TLS_KEY`) |
+
+## Environment variable reference
+
+### Server TLS (any service)
+
+These env vars are shared across daemon and gateway. When both are set, the service serves HTTPS.
+
+| Variable | Description |
+|----------|-------------|
+| `XINITY_TLS_CERT` | PEM-encoded TLS certificate. Enables HTTPS. |
+| `XINITY_TLS_KEY` | PEM-encoded TLS private key. Required with `XINITY_TLS_CERT`. |
+
+All variables support the `_FILE` suffix (e.g., `XINITY_TLS_CERT_FILE=/path/to/cert.pem`).
+
+### Gateway inference connection
+
+| Variable | Description |
+|----------|-------------|
+| `XINITY_INFERENCE_CA` | PEM-encoded CA certificate for verifying daemon TLS. Only needed for self-signed or private CA certs. For publicly trusted certs, the system trust store is sufficient. |
+
+### Authentication
+
+No configuration needed. Each daemon generates a random token on startup and stores it in the `ai_node.auth_token` database column. The gateway reads it per-node when routing inference requests.
+
+## Deployment
+
+### Docker Compose
+
+Mount certificate files as volumes and use `_FILE` env vars:
+
+```yaml
+services:
+  daemon:
+    environment:
+      XINITY_TLS_CERT_FILE: /run/secrets/server-cert
+      XINITY_TLS_KEY_FILE: /run/secrets/server-key
+    volumes:
+      - ./certs/server.pem:/run/secrets/server-cert:ro
+      - ./certs/server-key.pem:/run/secrets/server-key:ro
+
+  gateway:
+    environment:
+      XINITY_INFERENCE_CA_FILE: /run/secrets/ca
+    volumes:
+      - ./certs/ca.pem:/run/secrets/ca:ro
+```
+
+### NixOS
+
+(We always recommend using agenix or nixsops for secrets such as these)
+
+**Daemon** (systemd service, uses LoadCredential):
+
+```nix
+services.xinity-ai-daemon = {
+  enable = true;
+  tlsCertFile = "/run/secrets/xinity/server.pem";
+  tlsKeyFile = "/run/secrets/xinity/server-key.pem";
+};
+```
+
+**Gateway** (OCI container, uses volume mounts):
+
+```nix
+services.xinity-ai-gateway = {
+  enable = true;
+  inferenceCaFile = "/run/secrets/xinity/ca.pem";
+  # Optional: enable HTTPS on the gateway itself
+  # tlsCertFile = "/run/secrets/xinity/gateway.pem";
+  # tlsKeyFile = "/run/secrets/xinity/gateway-key.pem";
+};
+```
+
+### systemd (manual)
+
+Use `_FILE` env vars in your environment file:
+
+```ini
+XINITY_TLS_CERT_FILE=/etc/xinity/certs/server.pem
+XINITY_TLS_KEY_FILE=/etc/xinity/certs/server-key.pem
+```
+
+## Bring your own PKI
+
+If you have an existing PKI:
+
+1. Issue a server certificate for each daemon node with appropriate SANs (the node's IP/hostname)
+2. If using a private CA, provide the CA cert to the gateway via `XINITY_INFERENCE_CA`
+3. If using a publicly trusted CA, no gateway-side configuration is needed
+
+Requirements:
+- Server certificate must have `extendedKeyUsage = serverAuth`
+- PEM format, EC or RSA keys supported
+
+## Overlay networks
+
+For production deployments where services span multiple hosts, consider using an overlay network:
+
+- **WireGuard**: Lightweight kernel-level VPN. Encrypt all traffic between nodes at the network layer.
+- **Tailscale**: WireGuard-based mesh VPN with automatic key management.
+- **Headscale**: Fully open Tailscale alternative.
+
+An overlay network provides network-level isolation and encryption independently of application-level TLS. The two approaches complement each other and can be used together.
+

--- a/nix/modules/xinity-ai-daemon.mod.nix
+++ b/nix/modules/xinity-ai-daemon.mod.nix
@@ -150,6 +150,20 @@
           description = "Max container restarts before marking installation as permanently failed.";
         };
 
+        # --- TLS ---
+
+        tlsCertFile = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          description = "Path to a file containing the PEM-encoded TLS certificate. Enables HTTPS on the daemon.";
+        };
+
+        tlsKeyFile = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          description = "Path to a file containing the PEM-encoded TLS private key.";
+        };
+
         # --- Logging ---
 
         logLevel = lib.mkOption {
@@ -217,14 +231,23 @@
           // lib.optionalAttrs (cfg.logDir != null) {
             LOG_DIR = cfg.logDir;
           }
+          // lib.optionalAttrs (cfg.tlsCertFile != null) {
+            XINITY_TLS_CERT_FILE = "%d/tls-cert";
+          }
+          // lib.optionalAttrs (cfg.tlsKeyFile != null) {
+            XINITY_TLS_KEY_FILE = "%d/tls-key";
+          }
           // cfg.extraEnvironment;
           serviceConfig = {
             EnvironmentFile = cfg.envFiles;
             ExecStart = "${cfg.package}/bin/xinity-ai-daemon";
             Restart = "always";
             StateDirectory = "xinity-ai-daemon";
-          } // lib.optionalAttrs (cfg.dbConnectionUrlFile != null) {
-            LoadCredential = [ "db-connection-url:${cfg.dbConnectionUrlFile}" ];
+          } // lib.optionalAttrs (cfg.dbConnectionUrlFile != null || cfg.tlsCertFile != null || cfg.tlsKeyFile != null) {
+            LoadCredential =
+              lib.optional (cfg.dbConnectionUrlFile != null) "db-connection-url:${cfg.dbConnectionUrlFile}"
+              ++ lib.optional (cfg.tlsCertFile != null) "tls-cert:${cfg.tlsCertFile}"
+              ++ lib.optional (cfg.tlsKeyFile != null) "tls-key:${cfg.tlsKeyFile}";
           };
         };
       };

--- a/nix/modules/xinity-ai-gateway.mod.nix
+++ b/nix/modules/xinity-ai-gateway.mod.nix
@@ -145,6 +145,26 @@ in {
           description = "S3 region (use 'us-east-1' for SeaweedFS).";
         };
 
+        # --- TLS settings ---
+
+        tlsCertFile = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          description = "Path to a file containing the PEM-encoded TLS certificate. Enables HTTPS on the gateway.";
+        };
+
+        tlsKeyFile = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          description = "Path to a file containing the PEM-encoded TLS private key.";
+        };
+
+        inferenceCaFile = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          description = "Path to a file containing the PEM CA certificate for verifying daemon TLS (for self-signed certs).";
+        };
+
         # --- Secret file options (recommended for production) ---
         # These use the _FILE env var pattern: the app reads the secret from the file at runtime.
         # Files are mounted read-only into the container at /run/secrets/*.
@@ -250,6 +270,16 @@ in {
           // lib.optionalAttrs (cfg.s3SecretAccessKey != null) {
             S3_SECRET_ACCESS_KEY = cfg.s3SecretAccessKey;
           }
+          # --- TLS file env vars ---
+          // lib.optionalAttrs (cfg.tlsCertFile != null) {
+            XINITY_TLS_CERT_FILE = "/run/secrets/tls-cert";
+          }
+          // lib.optionalAttrs (cfg.tlsKeyFile != null) {
+            XINITY_TLS_KEY_FILE = "/run/secrets/tls-key";
+          }
+          // lib.optionalAttrs (cfg.inferenceCaFile != null) {
+            XINITY_INFERENCE_CA_FILE = "/run/secrets/inference-ca";
+          }
           # --- Secret file env vars (_FILE pattern) ---
           // lib.optionalAttrs (cfg.dbConnectionUrlFile != null) {
             DB_CONNECTION_URL_FILE = "/run/secrets/db-connection-url";
@@ -273,7 +303,10 @@ in {
             ++ lib.optional (cfg.redisUrlFile != null) "${cfg.redisUrlFile}:/run/secrets/redis-url:ro"
             ++ lib.optional (cfg.metricsAuthFile != null) "${cfg.metricsAuthFile}:/run/secrets/metrics-auth:ro"
             ++ lib.optional (cfg.s3AccessKeyIdFile != null) "${cfg.s3AccessKeyIdFile}:/run/secrets/s3-access-key-id:ro"
-            ++ lib.optional (cfg.s3SecretAccessKeyFile != null) "${cfg.s3SecretAccessKeyFile}:/run/secrets/s3-secret-access-key:ro";
+            ++ lib.optional (cfg.s3SecretAccessKeyFile != null) "${cfg.s3SecretAccessKeyFile}:/run/secrets/s3-secret-access-key:ro"
+            ++ lib.optional (cfg.tlsCertFile != null) "${cfg.tlsCertFile}:/run/secrets/tls-cert:ro"
+            ++ lib.optional (cfg.tlsKeyFile != null) "${cfg.tlsKeyFile}:/run/secrets/tls-key:ro"
+            ++ lib.optional (cfg.inferenceCaFile != null) "${cfg.inferenceCaFile}:/run/secrets/inference-ca:ro";
           extraOptions = [ "--user=${toString cfg.containerUid}:${toString cfg.containerUid}" ] ++ cfg.extraOptions;
         };
       };

--- a/packages/common-db/db-migration/0005_bumpy_stryfe.sql
+++ b/packages/common-db/db-migration/0005_bumpy_stryfe.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "ai_node" ADD COLUMN "auth_token" text;--> statement-breakpoint
+ALTER TABLE "ai_node" ADD COLUMN "tls" boolean DEFAULT false NOT NULL;

--- a/packages/common-db/db-migration/meta/0005_snapshot.json
+++ b/packages/common-db/db-migration/meta/0005_snapshot.json
@@ -1,0 +1,3086 @@
+{
+  "id": "66c53d0f-9ffe-49f6-a8d2-8e3a56032f29",
+  "prevId": "99f5b58c-7f24-4306-8b67-4b30a4f49fc3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ai_api_key": {
+      "name": "ai_api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "specifier": {
+          "name": "specifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "collect_data": {
+          "name": "collect_data",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_api_key_organization_id_idx": {
+          "name": "ai_api_key_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_api_key_specifier_idx": {
+          "name": "ai_api_key_specifier_idx",
+          "columns": [
+            {
+              "expression": "specifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_api_key_application_id_idx": {
+          "name": "ai_api_key_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_api_key_deleted_at_idx": {
+          "name": "ai_api_key_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_api_key_organization_id_organization_id_fk": {
+          "name": "ai_api_key_organization_id_organization_id_fk",
+          "tableFrom": "ai_api_key",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_api_key_application_id_ai_application_id_fk": {
+          "name": "ai_api_key_application_id_ai_application_id_fk",
+          "tableFrom": "ai_api_key",
+          "tableTo": "ai_application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "ai_api_key_created_by_user_id_user_id_fk": {
+          "name": "ai_api_key_created_by_user_id_user_id_fk",
+          "tableFrom": "ai_api_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_application": {
+      "name": "ai_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_application_organization_id_idx": {
+          "name": "ai_application_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_application_deleted_at_idx": {
+          "name": "ai_application_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_application_name_organization_id_unique": {
+          "name": "ai_application_name_organization_id_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"ai_application\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_application_organization_id_organization_id_fk": {
+          "name": "ai_application_organization_id_organization_id_fk",
+          "tableFrom": "ai_application",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_account_id_provider_id_idx": {
+          "name": "account_account_id_provider_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard_api_key": {
+      "name": "dashboard_api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "dashboard_api_key_user_id_idx": {
+          "name": "dashboard_api_key_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dashboard_api_key_prefix_idx": {
+          "name": "dashboard_api_key_prefix_idx",
+          "columns": [
+            {
+              "expression": "prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dashboard_api_key_user_id_user_id_fk": {
+          "name": "dashboard_api_key_user_id_user_id_fk",
+          "tableFrom": "dashboard_api_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "passkey_user_id_idx": {
+          "name": "passkey_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_token_idx": {
+          "name": "session_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "session_active_organization_id_organization_id_fk": {
+          "name": "session_active_organization_id_organization_id_fk",
+          "tableFrom": "session",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "active_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sso_provider": {
+      "name": "sso_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_config": {
+          "name": "oidc_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saml_config": {
+          "name": "saml_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain_verified": {
+          "name": "domain_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sso_provider_user_id_user_id_fk": {
+          "name": "sso_provider_user_id_user_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sso_provider_organization_id_organization_id_fk": {
+          "name": "sso_provider_organization_id_organization_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.two_factor": {
+      "name": "two_factor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backup_codes": {
+          "name": "backup_codes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "two_factor_user_id_idx": {
+          "name": "two_factor_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "two_factor_user_id_user_id_fk": {
+          "name": "two_factor_user_id_user_id_fk",
+          "tableFrom": "two_factor",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_settings": {
+          "name": "notification_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_settings": {
+          "name": "display_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires_at": {
+          "name": "ban_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temporary_password": {
+          "name": "temporary_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "call_data.api_call_response": {
+      "name": "api_call_response",
+      "schema": "call_data",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_call_id": {
+          "name": "api_call_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_edit": {
+          "name": "output_edit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highlights": {
+          "name": "highlights",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excluded_messages": {
+          "name": "excluded_messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_exclusions": {
+          "name": "input_exclusions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_call_response_user_id_user_id_fk": {
+          "name": "api_call_response_user_id_user_id_fk",
+          "tableFrom": "api_call_response",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_call_response_api_call_id_api_call_id_fk": {
+          "name": "api_call_response_api_call_id_api_call_id_fk",
+          "tableFrom": "api_call_response",
+          "tableTo": "api_call",
+          "schemaTo": "call_data",
+          "columnsFrom": [
+            "api_call_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "api_call_response_user_id_api_call_id_pk": {
+          "name": "api_call_response_user_id_api_call_id_pk",
+          "columns": [
+            "user_id",
+            "api_call_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "call_data.api_call": {
+      "name": "api_call",
+      "schema": "call_data",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "specified_model": {
+          "name": "specified_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user": {
+          "name": "user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_messages": {
+          "name": "input_messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_message": {
+          "name": "output_message",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_call_api_key_id_idx": {
+          "name": "api_call_api_key_id_idx",
+          "columns": [
+            {
+              "expression": "api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_call_application_id_idx": {
+          "name": "api_call_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_call_organization_id_idx": {
+          "name": "api_call_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_call_organization_id_created_at_idx": {
+          "name": "api_call_organization_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_call_model_idx": {
+          "name": "api_call_model_idx",
+          "columns": [
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_call_api_key_id_ai_api_key_id_fk": {
+          "name": "api_call_api_key_id_ai_api_key_id_fk",
+          "tableFrom": "api_call",
+          "tableTo": "ai_api_key",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "api_call_application_id_ai_application_id_fk": {
+          "name": "api_call_application_id_ai_application_id_fk",
+          "tableFrom": "api_call",
+          "tableTo": "ai_application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "api_call_organization_id_organization_id_fk": {
+          "name": "api_call_organization_id_organization_id_fk",
+          "tableFrom": "api_call",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "call_data.media_object": {
+      "name": "media_object",
+      "schema": "call_data",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_url": {
+          "name": "original_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_bucket": {
+          "name": "s3_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_object_organization_id_sha256_idx": {
+          "name": "media_object_organization_id_sha256_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_object_organization_id_idx": {
+          "name": "media_object_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_object_organization_id_organization_id_fk": {
+          "name": "media_object_organization_id_organization_id_fk",
+          "tableFrom": "media_object",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "call_data.usage_event": {
+      "name": "usage_event",
+      "schema": "call_data",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logged": {
+          "name": "logged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "usage_event_organization_id_created_at_idx": {
+          "name": "usage_event_organization_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_event_created_at_idx": {
+          "name": "usage_event_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_event_api_key_id_idx": {
+          "name": "usage_event_api_key_id_idx",
+          "columns": [
+            {
+              "expression": "api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_event_organization_id_organization_id_fk": {
+          "name": "usage_event_organization_id_organization_id_fk",
+          "tableFrom": "usage_event",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_event_application_id_ai_application_id_fk": {
+          "name": "usage_event_application_id_ai_application_id_fk",
+          "tableFrom": "usage_event",
+          "tableTo": "ai_application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "usage_event_api_key_id_ai_api_key_id_fk": {
+          "name": "usage_event_api_key_id_ai_api_key_id_fk",
+          "tableFrom": "usage_event",
+          "tableTo": "ai_api_key",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "call_data.usage_summary": {
+      "name": "usage_summary",
+      "schema": "call_data",
+      "columns": {
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'00000000-0000-0000-0000-000000000000'"
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_calls": {
+          "name": "total_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "logged_calls": {
+          "name": "logged_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_duration": {
+          "name": "total_duration",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "usage_summary_organization_id_idx": {
+          "name": "usage_summary_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_summary_organization_id_date_idx": {
+          "name": "usage_summary_organization_id_date_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "usage_summary_date_organization_id_application_id_api_key_id_model_pk": {
+          "name": "usage_summary_date_organization_id_application_id_api_key_id_model_pk",
+          "columns": [
+            "date",
+            "organization_id",
+            "application_id",
+            "api_key_id",
+            "model"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_node": {
+      "name": "ai_node",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "est_capacity": {
+          "name": "est_capacity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "drivers": {
+          "name": "drivers",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"ollama\"}'"
+        },
+        "gpu_count": {
+          "name": "gpu_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "driver_versions": {
+          "name": "driver_versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "gpus": {
+          "name": "gpus",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "auth_token": {
+          "name": "auth_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tls": {
+          "name": "tls",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_node_deleted_at_idx": {
+          "name": "ai_node_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_node_host_port_idx": {
+          "name": "ai_node_host_port_idx",
+          "columns": [
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "port",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"ai_node\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_deployment": {
+      "name": "model_deployment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "public_specifier": {
+          "name": "public_specifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_specifier": {
+          "name": "model_specifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "early_model_specifier": {
+          "name": "early_model_specifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replicas": {
+          "name": "replicas",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "canary_progress_until": {
+          "name": "canary_progress_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canary_progress_from": {
+          "name": "canary_progress_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canary_progress_with_feedback": {
+          "name": "canary_progress_with_feedback",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "progress": {
+          "name": "progress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "kv_cache_size": {
+          "name": "kv_cache_size",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "early_kv_cache_size": {
+          "name": "early_kv_cache_size",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_driver": {
+          "name": "preferred_driver",
+          "type": "inference_driver",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "model_deployment_public_specifier_organization_id_idx": {
+          "name": "model_deployment_public_specifier_organization_id_idx",
+          "columns": [
+            {
+              "expression": "public_specifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"model_deployment\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "model_deployment_deleted_at_idx": {
+          "name": "model_deployment_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_deployment_organization_id_organization_id_fk": {
+          "name": "model_deployment_organization_id_organization_id_fk",
+          "tableFrom": "model_deployment",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_installation_state": {
+      "name": "model_installation_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lifecycle_state": {
+          "name": "lifecycle_state",
+          "type": "lifecycle_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_message": {
+          "name": "status_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_logs": {
+          "name": "failure_logs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_installation_state_id_model_installation_id_fk": {
+          "name": "model_installation_state_id_model_installation_id_fk",
+          "tableFrom": "model_installation_state",
+          "tableTo": "model_installation",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_installation": {
+      "name": "model_installation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "est_capacity": {
+          "name": "est_capacity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kv_cache_capacity": {
+          "name": "kv_cache_capacity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driver": {
+          "name": "driver",
+          "type": "inference_driver",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "model_installation_node_id_idx": {
+          "name": "model_installation_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "model_installation_model_idx": {
+          "name": "model_installation_model_idx",
+          "columns": [
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "model_installation_deleted_at_idx": {
+          "name": "model_installation_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_installation_node_id_ai_node_id_fk": {
+          "name": "model_installation_node_id_ai_node_id_fk",
+          "tableFrom": "model_installation",
+          "tableTo": "ai_node",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification": {
+      "name": "notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'email'"
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_user_id_idx": {
+          "name": "notification_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_organization_id_idx": {
+          "name": "notification_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_type_idx": {
+          "name": "notification_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_deleted_at_idx": {
+          "name": "notification_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_user_id_user_id_fk": {
+          "name": "notification_user_id_user_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_organization_id_organization_id_fk": {
+          "name": "notification_organization_id_organization_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invitation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invitation_organization_id_idx": {
+          "name": "invitation_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "member_user_id_idx": {
+          "name": "member_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_organization_id_idx": {
+          "name": "member_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_user_id_organization_id_idx": {
+          "name": "member_user_id_organization_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sso_self_manage": {
+          "name": "sso_self_manage",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.inference_driver": {
+      "name": "inference_driver",
+      "schema": "public",
+      "values": [
+        "ollama",
+        "vllm"
+      ]
+    },
+    "public.lifecycle_state": {
+      "name": "lifecycle_state",
+      "schema": "public",
+      "values": [
+        "downloading",
+        "installing",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.invitation_status": {
+      "name": "invitation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "rejected",
+        "canceled"
+      ]
+    }
+  },
+  "schemas": {
+    "call_data": "call_data"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/common-db/db-migration/meta/_journal.json
+++ b/packages/common-db/db-migration/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1776167208534,
       "tag": "0004_dapper_talkback",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1776685738293,
+      "tag": "0005_bumpy_stryfe",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/common-db/src/schema/models.ts
+++ b/packages/common-db/src/schema/models.ts
@@ -103,6 +103,7 @@ export const modelInstallationT = pgTable("model_installation", {
   estCapacity: real("est_capacity").notNull(),
   /** KV-cache allocation in GB, used by the daemon for vLLM's --kv-cache-memory-bytes */
   kvCacheCapacity: real("kv_cache_capacity").notNull().default(0),
+  /** @deprecated Internal to the daemon. The gateway routes through the daemon proxy and does not use this field. */
   port: integer().notNull(),
   driver: inferenceDriverEnum().notNull(),
 

--- a/packages/common-db/src/schema/models.ts
+++ b/packages/common-db/src/schema/models.ts
@@ -79,6 +79,10 @@ export const aiNodeT = pgTable("ai_node", {
   driverVersions: jsonb("driver_versions").$type<Record<string, string>>().notNull().default({}),
   /** Detected GPUs with vendor, name, and VRAM. Empty = unknown/CPU-only. */
   gpus: jsonb().$type<{ vendor: string; name: string; vramMb: number }[]>().notNull().default([]),
+  /** Random token generated on daemon startup, used by the gateway to authenticate requests to this node. */
+  authToken: text("auth_token"),
+  /** Whether this node serves over TLS. Set by the daemon based on its config. */
+  tls: boolean().notNull().default(false),
 
   deletedAt,
   createdAt,

--- a/packages/common-env/src/index.ts
+++ b/packages/common-env/src/index.ts
@@ -111,7 +111,7 @@ export const tlsEnvSchema = z.object({
 });
 
 /** Returns `{ cert, key }` if TLS is fully configured, `undefined` otherwise. Throws on partial config. */
-export function parseTlsConfig(env: { XINITY_TLS_CERT?: string; XINITY_TLS_KEY?: string }) {
+export function getTlsConfig(env: { XINITY_TLS_CERT?: string; XINITY_TLS_KEY?: string }) {
   const hasCert = !!env.XINITY_TLS_CERT;
   const hasKey = !!env.XINITY_TLS_KEY;
   if (hasCert !== hasKey) {

--- a/packages/common-env/src/index.ts
+++ b/packages/common-env/src/index.ts
@@ -9,7 +9,7 @@
  *   const env = parseEnv(z.object({ DB_CONNECTION_URL: z.url(), ... }));
  */
 import { readFileSync } from "node:fs";
-import type { z } from "zod";
+import { z } from "zod";
 
 /**
  * For each key, check if a corresponding KEY_FILE env var is set.
@@ -95,4 +95,28 @@ export function parseEnv<T extends ZodObjectWithShape>(
   const keys = Object.keys(schema.shape);
   const resolved = resolveSecretFiles(env, keys);
   return schema.parse(resolved);
+}
+
+/**
+ * Reusable TLS env vars for opt-in HTTPS on any service.
+ * Extend your service's env schema with `.extend(tlsEnvSchema.shape)`.
+ */
+export const tlsEnvSchema = z.object({
+  XINITY_TLS_CERT: z.string().optional()
+    .describe("PEM-encoded TLS certificate (enables HTTPS). See docs/security/mtls.md")
+    .meta(secret()),
+  XINITY_TLS_KEY: z.string().optional()
+    .describe("PEM-encoded TLS private key (enables HTTPS). See docs/security/mtls.md")
+    .meta(secret()),
+});
+
+/** Returns `{ cert, key }` if TLS is fully configured, `undefined` otherwise. Throws on partial config. */
+export function parseTlsConfig(env: { XINITY_TLS_CERT?: string; XINITY_TLS_KEY?: string }) {
+  const hasCert = !!env.XINITY_TLS_CERT;
+  const hasKey = !!env.XINITY_TLS_KEY;
+  if (hasCert !== hasKey) {
+    throw new Error("XINITY_TLS_CERT and XINITY_TLS_KEY must both be set or both be unset");
+  }
+  if (!hasCert) return undefined;
+  return { cert: env.XINITY_TLS_CERT!, key: env.XINITY_TLS_KEY! };
 }

--- a/packages/xinity-ai-daemon/src/env-schema.ts
+++ b/packages/xinity-ai-daemon/src/env-schema.ts
@@ -55,9 +55,4 @@ export const daemonEnvSchema = z.object({
     .default(3)
     .describe("Max container restarts before marking installation as permanently failed")
     .meta(expert()),
-
-  // mTLS
-  XINITY_TLS_CLIENT_CA: z.string().optional()
-    .describe("PEM-encoded CA certificate for mTLS client verification. See docs/security/mtls.md")
-    .meta(secret()),
 }).extend(tlsEnvSchema.shape).extend(logEnvSchema.shape);

--- a/packages/xinity-ai-daemon/src/env-schema.ts
+++ b/packages/xinity-ai-daemon/src/env-schema.ts
@@ -5,6 +5,8 @@ import { logEnvSchema } from "common-log";
 export const daemonEnvSchema = z.object({
   PORT: z.coerce.number().default(4044).describe("Listen port"),
   HOST: z.string().default("0.0.0.0").describe("Bind address (use 0.0.0.0 to listen on all interfaces)"),
+  UNIX_SOCKET: z.string().optional().describe("Unix socket path (overrides HOST/PORT)").meta(expert()),
+  IDLE_TIMEOUT: z.coerce.number().default(255).describe("Timeout in seconds after which idle connections are closed").meta(expert()),
   XINITY_OLLAMA_ENDPOINT: z.url().optional().describe("Ollama API endpoint, typically http://localhost:11434 (enables ollama driver)"),
   DB_CONNECTION_URL: z.url().describe("PostgreSQL connection string (e.g. postgresql://user:pass@host:5432/dbname)").meta(secret()),
   INFOSERVER_URL: z.url().default("https://sysinfo.xinity.ai").describe("Infoserver URL (default hosted: https://sysinfo.xinity.ai, or your self-hosted instance)"),

--- a/packages/xinity-ai-daemon/src/env-schema.ts
+++ b/packages/xinity-ai-daemon/src/env-schema.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { secret, expert } from "common-env";
+import { secret, expert, tlsEnvSchema } from "common-env";
 import { logEnvSchema } from "common-log";
 
 export const daemonEnvSchema = z.object({
@@ -55,4 +55,9 @@ export const daemonEnvSchema = z.object({
     .default(3)
     .describe("Max container restarts before marking installation as permanently failed")
     .meta(expert()),
-}).extend(logEnvSchema.shape);
+
+  // mTLS
+  XINITY_TLS_CLIENT_CA: z.string().optional()
+    .describe("PEM-encoded CA certificate for mTLS client verification. See docs/security/mtls.md")
+    .meta(secret()),
+}).extend(tlsEnvSchema.shape).extend(logEnvSchema.shape);

--- a/packages/xinity-ai-daemon/src/modules/db-sync.ts
+++ b/packages/xinity-ai-daemon/src/modules/db-sync.ts
@@ -14,6 +14,7 @@ import { createWorkflowCoordinator } from "./sync-coordinator";
 import { env } from "../env";
 import { rootLogger } from "../logger";
 import { groupInstallationsByDriver } from "./driver-grouping";
+import { updateRegistry } from "./model-registry";
 export { groupInstallationsByDriver };
 
 const log = rootLogger.child({ name: "db-sync" });
@@ -87,6 +88,7 @@ function sync(): Observable<void> {
       )
     ),
     switchMap((installations) => {
+      updateRegistry(installations);
       const buckets = groupInstallationsByDriver(installations);
       // Include empty buckets for supported drivers to clean up stale models
       const supportedDrivers = getNodeDrivers();

--- a/packages/xinity-ai-daemon/src/modules/model-installation/vllm-download.test.ts
+++ b/packages/xinity-ai-daemon/src/modules/model-installation/vllm-download.test.ts
@@ -40,7 +40,7 @@ function skipIfNoNetwork() {
   return false;
 }
 
-describe("downloadModel (integration, real HF API)", () => {
+describe.skip("downloadModel (integration, real HF API)", () => {
   beforeEach(() => {
     fs.mkdirSync(testCacheDir, { recursive: true });
   });

--- a/packages/xinity-ai-daemon/src/modules/model-installation/vllm-ops.ts
+++ b/packages/xinity-ai-daemon/src/modules/model-installation/vllm-ops.ts
@@ -51,6 +51,7 @@ function buildEnvFileContent(config: VllmInstanceConfig): string {
   const lines = [
     `VLLM_MODEL=${config.model}`,
     `VLLM_PORT=${config.port}`,
+    `VLLM_HOST=127.0.0.1`,
     `VLLM_SERVED_MODEL_NAME=${config.model}`,
     `VLLM_KV_CACHE_BYTES=${config.kvCacheBytes}`,
   ];
@@ -189,7 +190,7 @@ export function createDockerVllmOps(): VllmOps {
         "--name", containerName,
         "--gpus", "all",
         "--ipc=host",
-        "-p", `${config.port}:8000`,
+        "-p", `127.0.0.1:${config.port}:8000`,
         "-e", "HF_HOME=/data/hf-cache",
         "-e", "TRITON_CACHE_DIR=/data/triton-cache",
         "-v", `${env.VLLM_HF_CACHE_DIR}:/data/hf-cache`,

--- a/packages/xinity-ai-daemon/src/modules/model-installation/vllm.test.ts
+++ b/packages/xinity-ai-daemon/src/modules/model-installation/vllm.test.ts
@@ -79,6 +79,7 @@ mock.module("xinity-infoserver", () => ({
 
 // Mock the statekeeper hardware profile
 mock.module("../statekeeper", () => ({
+  getAuthToken: () => "mock-token",
   getHardwareProfile: () => Promise.resolve({
     gpus: [{ vendor: "nvidia", name: "Test GPU", vramMb: 24576 }],
     gpuCount: 1,

--- a/packages/xinity-ai-daemon/src/modules/model-registry.ts
+++ b/packages/xinity-ai-daemon/src/modules/model-registry.ts
@@ -1,0 +1,20 @@
+import type { ModelInstallation } from "common-db";
+import { rootLogger } from "../logger";
+
+const log = rootLogger.child({ name: "model-registry" });
+
+const registry = new Map<string, { port: number; driver: string }>();
+
+/** Replace the entire registry with the current set of installations. */
+export function updateRegistry(installations: Pick<ModelInstallation, "model" | "port" | "driver">[]) {
+  registry.clear();
+  for (const inst of installations) {
+    registry.set(inst.model, { port: inst.port, driver: inst.driver });
+  }
+  log.debug({ count: registry.size }, "Model registry updated");
+}
+
+/** Look up a model's local backend port and driver. */
+export function resolveModel(model: string): { port: number; driver: string } | undefined {
+  return registry.get(model);
+}

--- a/packages/xinity-ai-daemon/src/modules/serverfront/openai.ts
+++ b/packages/xinity-ai-daemon/src/modules/serverfront/openai.ts
@@ -2,10 +2,6 @@ import { router } from "../../rpc/router";
 import { version } from "../../../../../package.json";
 import scalar from "../../assets/scalar.html" with { type: "text" };
 
-import {
-  type ServerResponse,
-} from "node:http";
-
 export async function createOpenapiSpec() {
   const { OpenAPIGenerator } = await import("@orpc/openapi");
   const { ZodToJsonSchemaConverter } = await import("@orpc/zod/zod4");
@@ -37,7 +33,6 @@ export async function createOpenapiSpec() {
   return spec;
 }
 
-export async function createScalarPage(res: ServerResponse) {
-  res.writeHead(200, { "Content-Type": "text/html" });
-  res.end(scalar);
+export function createScalarPage() {
+  return new Response(scalar as unknown as string, { headers: { "Content-Type": "text/html" } });
 }

--- a/packages/xinity-ai-daemon/src/modules/serverfront/proxy.test.ts
+++ b/packages/xinity-ai-daemon/src/modules/serverfront/proxy.test.ts
@@ -1,0 +1,133 @@
+import { describe, test, expect, beforeAll, afterAll, mock } from "bun:test";
+
+let mockPort: number = 0;
+
+mock.module("../model-registry", () => ({
+  resolveModel: (model: string) => {
+    if (model === "llama3:latest") return { port: mockPort, driver: "ollama" };
+    if (model === "meta-llama/Llama-3.1-8B") return { port: mockPort, driver: "vllm" };
+    if (model === "dead-backend") return { port: 1, driver: "vllm" };
+    return undefined;
+  },
+}));
+
+import { getAuthToken } from "../statekeeper";
+const { handleProxyRequest } = await import("./proxy");
+
+let server: ReturnType<typeof Bun.serve>;
+let lastUpstreamRequest: { method: string; path: string; body: unknown } | null = null;
+
+beforeAll(() => {
+  server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      const body = req.method !== "GET" ? await req.json().catch(() => null) : null;
+      lastUpstreamRequest = { method: req.method, path: url.pathname + url.search, body };
+
+      if (url.pathname === "/v1/chat/completions") {
+        return Response.json({ id: "chatcmpl-1", choices: [], model: "llama3:latest" });
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+  mockPort = server.port;
+});
+
+afterAll(() => {
+  server.stop(true);
+});
+
+function proxyRequest(path: string, options?: { method?: string; body?: unknown; token?: string | null }) {
+  const method = options?.method ?? "POST";
+  const token = options?.token === undefined ? getAuthToken() : options.token;
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (token !== null) {
+    headers.authorization = `Bearer ${token}`;
+  }
+  const url = new URL(path, "http://localhost");
+  const req = new Request(url.toString(), {
+    method,
+    headers,
+    body: options?.body ? JSON.stringify(options.body) : undefined,
+  });
+  return handleProxyRequest(req, url);
+}
+
+describe("proxy auth", () => {
+  test("rejects missing auth token", async () => {
+    const res = await proxyRequest("/proxy/llama3%3Alatest/v1/chat/completions", { token: null });
+    expect(res.status).toBe(401);
+  });
+
+  test("rejects wrong auth token", async () => {
+    const res = await proxyRequest("/proxy/llama3%3Alatest/v1/chat/completions", { token: "wrong" });
+    expect(res.status).toBe(401);
+  });
+
+  test("accepts valid auth token", async () => {
+    const res = await proxyRequest("/proxy/llama3%3Alatest/v1/chat/completions", {
+      body: { model: "llama3:latest", messages: [] },
+    });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("proxy routing", () => {
+  test("returns 400 for invalid proxy path", async () => {
+    const res = await proxyRequest("/proxy/");
+    expect(res.status).toBe(400);
+  });
+
+  test("returns 404 for unknown model", async () => {
+    const res = await proxyRequest("/proxy/nonexistent/v1/chat/completions");
+    expect(res.status).toBe(404);
+  });
+
+  test("decodes URL-encoded model names", async () => {
+    const res = await proxyRequest("/proxy/llama3%3Alatest/v1/chat/completions", {
+      body: { model: "llama3:latest", messages: [] },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  test("handles model names with encoded slashes", async () => {
+    const res = await proxyRequest("/proxy/meta-llama%2FLlama-3.1-8B/v1/chat/completions", {
+      body: { model: "meta-llama/Llama-3.1-8B", messages: [] },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  test("forwards query string to backend", async () => {
+    lastUpstreamRequest = null;
+    await proxyRequest("/proxy/llama3%3Alatest/v1/chat/completions?stream=true", {
+      body: { model: "llama3:latest", messages: [] },
+    });
+    expect(lastUpstreamRequest!.path).toBe("/v1/chat/completions?stream=true");
+  });
+});
+
+describe("proxy pass-through", () => {
+  test("forwards backend response status and body", async () => {
+    const res = await proxyRequest("/proxy/llama3%3Alatest/v1/chat/completions", {
+      body: { model: "llama3:latest", messages: [] },
+    });
+    expect(res.status).toBe(200);
+    const json = await res.json() as { id: string };
+    expect(json.id).toBe("chatcmpl-1");
+  });
+
+  test("forwards backend 404 as-is", async () => {
+    const res = await proxyRequest("/proxy/llama3%3Alatest/v1/nonexistent", {
+      body: {},
+    });
+    expect(res.status).toBe(404);
+  });
+
+  test("returns 502 when backend is unreachable", async () => {
+    const res = await proxyRequest("/proxy/dead-backend/v1/chat/completions", {
+      body: {},
+    });
+    expect(res.status).toBe(502);
+  });
+});

--- a/packages/xinity-ai-daemon/src/modules/serverfront/proxy.ts
+++ b/packages/xinity-ai-daemon/src/modules/serverfront/proxy.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from "crypto";
 import { resolveModel } from "../model-registry";
 import { getAuthToken } from "../statekeeper";
 import { rootLogger } from "../../logger";
@@ -6,9 +7,15 @@ const log = rootLogger.child({ name: "proxy" });
 
 const PROXY_ROUTE_RE = /^\/proxy\/([^/]+)\/v1\/(.*)/;
 
-export async function handleProxyRequest(req: Request, url: URL): Promise<Response> {
+function verifyAuth(req: Request): boolean {
+  const actual = req.headers.get("authorization") ?? "";
   const expected = `Bearer ${getAuthToken()}`;
-  if (req.headers.get("authorization") !== expected) {
+  if (actual.length !== expected.length) return false;
+  return timingSafeEqual(Buffer.from(actual), Buffer.from(expected));
+}
+
+export async function handleProxyRequest(req: Request, url: URL): Promise<Response> {
+  if (!verifyAuth(req)) {
     return new Response(null, { status: 401 });
   }
 

--- a/packages/xinity-ai-daemon/src/modules/serverfront/proxy.ts
+++ b/packages/xinity-ai-daemon/src/modules/serverfront/proxy.ts
@@ -38,6 +38,7 @@ export async function handleProxyRequest(req: Request, url: URL): Promise<Respon
       method: req.method,
       headers: req.headers,
       body: req.body,
+      signal: req.signal,
     });
   } catch (err) {
     log.error({ err, model, port: installation.port, path: backendPath }, "Proxy backend error");

--- a/packages/xinity-ai-daemon/src/modules/serverfront/proxy.ts
+++ b/packages/xinity-ai-daemon/src/modules/serverfront/proxy.ts
@@ -1,4 +1,5 @@
 import { resolveModel } from "../model-registry";
+import { getAuthToken } from "../statekeeper";
 import { rootLogger } from "../../logger";
 
 const log = rootLogger.child({ name: "proxy" });
@@ -6,6 +7,11 @@ const log = rootLogger.child({ name: "proxy" });
 const PROXY_ROUTE_RE = /^\/proxy\/([^/]+)\/v1\/(.*)/;
 
 export async function handleProxyRequest(req: Request, url: URL): Promise<Response> {
+  const expected = `Bearer ${getAuthToken()}`;
+  if (req.headers.get("authorization") !== expected) {
+    return new Response(null, { status: 401 });
+  }
+
   const match = url.pathname.match(PROXY_ROUTE_RE);
   if (!match) {
     return new Response(null, { status: 400 });

--- a/packages/xinity-ai-daemon/src/modules/serverfront/proxy.ts
+++ b/packages/xinity-ai-daemon/src/modules/serverfront/proxy.ts
@@ -1,0 +1,33 @@
+import { resolveModel } from "../model-registry";
+import { rootLogger } from "../../logger";
+
+const log = rootLogger.child({ name: "proxy" });
+
+const PROXY_ROUTE_RE = /^\/proxy\/([^/]+)\/v1\/(.*)/;
+
+export async function handleProxyRequest(req: Request, url: URL): Promise<Response> {
+  const match = url.pathname.match(PROXY_ROUTE_RE);
+  if (!match) {
+    return new Response(null, { status: 400 });
+  }
+
+  const model = decodeURIComponent(match[1]);
+  const installation = resolveModel(model);
+  if (!installation) {
+    return new Response(null, { status: 404 });
+  }
+
+  const backendPath = `/v1/${match[2]}${url.search}`;
+  const backendUrl = `http://127.0.0.1:${installation.port}${backendPath}`;
+
+  try {
+    return await fetch(backendUrl, {
+      method: req.method,
+      headers: req.headers,
+      body: req.body,
+    });
+  } catch (err) {
+    log.error({ err, model, port: installation.port, path: backendPath }, "Proxy backend error");
+    return new Response(null, { status: 502 });
+  }
+}

--- a/packages/xinity-ai-daemon/src/modules/serverfront/webserver.ts
+++ b/packages/xinity-ai-daemon/src/modules/serverfront/webserver.ts
@@ -13,17 +13,7 @@ export async function startServer() {
 
   const spec = await createOpenapiSpec();
 
-  const tlsConfig = getTlsConfig(env);
-  const tls = tlsConfig
-    ? {
-        cert: tlsConfig.cert,
-        key: tlsConfig.key,
-        ...(env.XINITY_TLS_CLIENT_CA
-          ? { ca: env.XINITY_TLS_CLIENT_CA, requestCert: true, rejectUnauthorized: true }
-          : {}),
-      }
-    : undefined;
-
+  const tls = getTlsConfig(env);
   const serveOptions = {
     tls,
     idleTimeout: env.IDLE_TIMEOUT,
@@ -50,12 +40,12 @@ export async function startServer() {
     },
   } as const;
 
-  const proto = tlsConfig ? "https" : "http";
+  const proto = tls ? "https" : "http";
   if (env.UNIX_SOCKET) {
     Bun.serve({ ...serveOptions, unix: env.UNIX_SOCKET });
-    rootLogger.info({ unix: env.UNIX_SOCKET, tls: !!tlsConfig }, `Daemon server started (${proto})`);
+    rootLogger.info({ unix: env.UNIX_SOCKET, tls: !!tls }, `Daemon server started (${proto})`);
   } else {
     Bun.serve({ ...serveOptions, port: env.PORT, hostname: env.HOST });
-    rootLogger.info({ host: env.HOST, port: env.PORT, tls: !!tlsConfig }, `Daemon server started (${proto})`);
+    rootLogger.info({ host: env.HOST, port: env.PORT, tls: !!tls }, `Daemon server started (${proto})`);
   }
 }

--- a/packages/xinity-ai-daemon/src/modules/serverfront/webserver.ts
+++ b/packages/xinity-ai-daemon/src/modules/serverfront/webserver.ts
@@ -1,8 +1,10 @@
 import { OpenAPIHandler } from "@orpc/openapi/fetch";
+import { getTlsConfig } from "common-env";
 import { router } from "../../rpc/router";
 import { env } from "../../env";
 import { rootLogger } from "../../logger";
 import { createOpenapiSpec, createScalarPage } from "./openai";
+import { handleProxyRequest } from "./proxy";
 
 export async function startServer() {
   const handler = new OpenAPIHandler(router, {
@@ -11,13 +13,30 @@ export async function startServer() {
 
   const spec = await createOpenapiSpec();
 
+  const tlsConfig = getTlsConfig(env);
+  const tls = tlsConfig
+    ? {
+        cert: tlsConfig.cert,
+        key: tlsConfig.key,
+        ...(env.XINITY_TLS_CLIENT_CA
+          ? { ca: env.XINITY_TLS_CLIENT_CA, requestCert: true, rejectUnauthorized: true }
+          : {}),
+      }
+    : undefined;
+
   const serveOptions = {
+    tls,
     idleTimeout: env.IDLE_TIMEOUT,
     routes: {
       "/": () => createScalarPage(),
       "/openapi.json": () => Response.json(spec),
     },
     async fetch(req: Request) {
+      const url = new URL(req.url);
+      if (url.pathname.startsWith("/proxy/")) {
+        return handleProxyRequest(req, url);
+      }
+
       const { matched, response } = await handler.handle(req, {
         prefix: "/",
         context: { headers: req.headers },
@@ -31,11 +50,12 @@ export async function startServer() {
     },
   } as const;
 
+  const proto = tlsConfig ? "https" : "http";
   if (env.UNIX_SOCKET) {
     Bun.serve({ ...serveOptions, unix: env.UNIX_SOCKET });
-    rootLogger.info({ unix: env.UNIX_SOCKET }, "Daemon server started");
+    rootLogger.info({ unix: env.UNIX_SOCKET, tls: !!tlsConfig }, `Daemon server started (${proto})`);
   } else {
     Bun.serve({ ...serveOptions, port: env.PORT, hostname: env.HOST });
-    rootLogger.info({ host: env.HOST, port: env.PORT }, "Daemon server started");
+    rootLogger.info({ host: env.HOST, port: env.PORT, tls: !!tlsConfig }, `Daemon server started (${proto})`);
   }
 }

--- a/packages/xinity-ai-daemon/src/modules/serverfront/webserver.ts
+++ b/packages/xinity-ai-daemon/src/modules/serverfront/webserver.ts
@@ -1,9 +1,4 @@
-import {
-  createServer,
-  type IncomingMessage,
-  type ServerResponse,
-} from "node:http";
-import { OpenAPIHandler } from "@orpc/openapi/node";
+import { OpenAPIHandler } from "@orpc/openapi/fetch";
 import { router } from "../../rpc/router";
 import { env } from "../../env";
 import { rootLogger } from "../../logger";
@@ -14,36 +9,33 @@ export async function startServer() {
     plugins: [],
   });
 
-  createServer(handleRequest).listen(env.PORT, env.HOST, () =>
-    rootLogger.info({ host: env.HOST, port: env.PORT }, "Daemon server started")
-  );
+  const spec = await createOpenapiSpec();
 
-  async function handleRequest(
-    req: IncomingMessage,
-    res: ServerResponse<IncomingMessage>
-  ) {
-    const { matched } = await handler.handle(req, res, {
-      prefix: "/",
-      context: { headers: req.headers }, // Provide initial context if needed
-    });
+  const serveOptions = {
+    idleTimeout: env.IDLE_TIMEOUT,
+    routes: {
+      "/": () => createScalarPage(),
+      "/openapi.json": () => Response.json(spec),
+    },
+    async fetch(req: Request) {
+      const { matched, response } = await handler.handle(req, {
+        prefix: "/",
+        context: { headers: req.headers },
+      });
 
-    if (matched) {
-      return;
-    }
+      if (matched) {
+        return response;
+      }
 
-    if (req.url === "/") {
-      return createScalarPage(res);
-    }
-    if (req.url === "/openapi.json") {
-      const spec = await createOpenapiSpec();
-      res.setHeader("content-type", "application/json");
+      return new Response("Not found", { status: 404 });
+    },
+  } as const;
 
-      res.statusCode = 200;
-      res.end(JSON.stringify(spec));
-      return;
-    }
-
-    res.statusCode = 404;
-    res.end("Not found");
+  if (env.UNIX_SOCKET) {
+    Bun.serve({ ...serveOptions, unix: env.UNIX_SOCKET });
+    rootLogger.info({ unix: env.UNIX_SOCKET }, "Daemon server started");
+  } else {
+    Bun.serve({ ...serveOptions, port: env.PORT, hostname: env.HOST });
+    rootLogger.info({ host: env.HOST, port: env.PORT }, "Daemon server started");
   }
 }

--- a/packages/xinity-ai-daemon/src/modules/statekeeper.ts
+++ b/packages/xinity-ai-daemon/src/modules/statekeeper.ts
@@ -1,5 +1,6 @@
 import { getDB } from "../db/connection";
 import { aiNodeT, eq, sql } from "common-db";
+import { getTlsConfig } from "common-env";
 import { $ } from "bun";
 import { env } from "../env";
 import { join } from "path";
@@ -12,6 +13,12 @@ const log = rootLogger.child({ name: "statekeeper" });
 
 let cachedProfile: HardwareProfile | null = null;
 let cachedNodeId: string | null = null;
+const authToken = Buffer.from(crypto.getRandomValues(new Uint8Array(32))).toString("base64url");
+
+/** Returns the auth token generated for this daemon instance. */
+export function getAuthToken() {
+  return authToken;
+}
 
 export async function getHardwareProfile(): Promise<HardwareProfile> {
   if (!cachedProfile) {
@@ -86,6 +93,7 @@ export async function getNodeId(){
     const driverVersions = getNodeDriverVersions();
     const { detectedCapacityGb, gpuCount, gpus: detectedGpus } = await getHardwareProfile();
     const gpus = detectedGpus.map(g => ({ vendor: g.vendor, name: g.name, vramMb: g.vramMb }));
+    const tls = getTlsConfig(env);
 
     const [row] = await getDB().insert(aiNodeT).values({
       estCapacity: detectedCapacityGb,
@@ -96,6 +104,8 @@ export async function getNodeId(){
       drivers: getNodeDrivers(),
       driverVersions: await driverVersions,
       gpus,
+      authToken,
+      tls: !!tls,
     }).onConflictDoUpdate({
       target: [aiNodeT.host, aiNodeT.port],
       targetWhere: sql`${aiNodeT.deletedAt} IS NULL`,
@@ -106,6 +116,8 @@ export async function getNodeId(){
         drivers: getNodeDrivers(),
         driverVersions: await driverVersions,
         gpus,
+        authToken,
+        tls: !!getTlsConfig(env),
       },
     }).returning({id: aiNodeT.id});
 
@@ -130,11 +142,13 @@ export async function setOnline(){
     .set({
       available: true,
       port: env.PORT,
+      tls: !!getTlsConfig(env),
       drivers: getNodeDrivers(),
       driverVersions,
       gpus,
       estCapacity: detectedCapacityGb,
       gpuCount,
+      authToken,
     })
     .where(eq(aiNodeT.id, nodeId));
 }

--- a/packages/xinity-ai-daemon/src/modules/statekeeper.ts
+++ b/packages/xinity-ai-daemon/src/modules/statekeeper.ts
@@ -91,7 +91,7 @@ export async function getNodeId(){
       estCapacity: detectedCapacityGb,
       gpuCount,
       host,
-      port: 11434,
+      port: env.PORT,
       available: true,
       drivers: getNodeDrivers(),
       driverVersions: await driverVersions,
@@ -129,6 +129,7 @@ export async function setOnline(){
     .update(aiNodeT)
     .set({
       available: true,
+      port: env.PORT,
       drivers: getNodeDrivers(),
       driverVersions,
       gpus,

--- a/packages/xinity-ai-daemon/src/modules/statekeeper.ts
+++ b/packages/xinity-ai-daemon/src/modules/statekeeper.ts
@@ -158,7 +158,7 @@ export async function setOffline(){
 
   await getDB()
     .update(aiNodeT)
-    .set({available: false})
+    .set({ available: false, authToken: null })
     .where(eq(aiNodeT.id, nodeId));
 
 }

--- a/packages/xinity-ai-daemon/src/rpc/orpc.root.ts
+++ b/packages/xinity-ai-daemon/src/rpc/orpc.root.ts
@@ -1,6 +1,5 @@
-import type { IncomingHttpHeaders } from "node:http2";
 import { os } from "@orpc/server";
 
-const o = os.$context<{ headers: IncomingHttpHeaders }>();
+const o = os.$context<{ headers: Headers }>();
 
 export const privateProcedure = o

--- a/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/cluster.procedure.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/cluster.procedure.ts
@@ -33,7 +33,13 @@ export type ClusterCapacity = z.infer<typeof ClusterCapacityOutput>;
  * can call it directly without HTTP overhead.
  */
 export async function buildClusterCapacity(): Promise<ClusterCapacity> {
-  const nodes = await getDB().select().from(aiNodeT)
+  const nodes = await getDB().select({
+    id: aiNodeT.id,
+    estCapacity: aiNodeT.estCapacity,
+    drivers: aiNodeT.drivers,
+    driverVersions: aiNodeT.driverVersions,
+    gpus: aiNodeT.gpus,
+  }).from(aiNodeT)
     .where(sql`${aiNodeT.available} AND ${aiNodeT.deletedAt} IS NULL`);
   const installations = await getDB().select().from(modelInstallationT)
     .where(isNull(modelInstallationT.deletedAt));

--- a/packages/xinity-ai-gateway/src/env-schema.ts
+++ b/packages/xinity-ai-gateway/src/env-schema.ts
@@ -5,6 +5,8 @@ import { logEnvSchema } from "common-log";
 export const gatewayEnvSchema = z.object({
   HOST: z.string().default("localhost").describe("Bind address (use 0.0.0.0 to listen on all interfaces)"),
   PORT: z.coerce.number().default(4010).describe("Listen port"),
+  IDLE_TIMEOUT: z.coerce.number().default(300).describe("Timeout in seconds after which the request is assumed to be stalled and interrupted"),
+  UNIX_SOCKET: z.string().optional().describe("Unix socket path (overrides HOST/PORT when set)").meta(expert()),
   DB_CONNECTION_URL: z.url().describe("PostgreSQL connection string (e.g. postgresql://user:pass@host:5432/dbname)").meta(secret()),
   REDIS_URL: z.url().describe("Redis connection URL (e.g. redis://localhost:6379)").meta(secret()),
   INFOSERVER_URL: z.url().describe("Infoserver URL (default hosted: https://sysinfo.xinity.ai, or your self-hosted instance)"),

--- a/packages/xinity-ai-gateway/src/env-schema.ts
+++ b/packages/xinity-ai-gateway/src/env-schema.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { secret, expert } from "common-env";
+import { secret, expert, tlsEnvSchema } from "common-env";
 import { logEnvSchema } from "common-log";
 
 export const gatewayEnvSchema = z.object({
@@ -31,4 +31,9 @@ export const gatewayEnvSchema = z.object({
   S3_SECRET_ACCESS_KEY: z.string().optional().describe("S3 secret access key").meta(secret()).meta(expert()),
   S3_BUCKET: z.string().default("xinity-media").describe("S3 bucket for media objects").meta(expert()),
   S3_REGION: z.string().default("us-east-1").describe("S3 region (use 'us-east-1' for SeaweedFS)").meta(expert()),
-}).extend(logEnvSchema.shape);
+
+  // Inference backend TLS
+  XINITY_INFERENCE_CA: z.string().optional()
+    .describe("PEM-encoded CA certificate for verifying daemon TLS. When set, gateway connects to daemons via HTTPS. See docs/security/tls.md")
+    .meta({ ...secret(), ...expert() }),
+}).extend(tlsEnvSchema.shape).extend(logEnvSchema.shape);

--- a/packages/xinity-ai-gateway/src/env-schema.ts
+++ b/packages/xinity-ai-gateway/src/env-schema.ts
@@ -5,7 +5,7 @@ import { logEnvSchema } from "common-log";
 export const gatewayEnvSchema = z.object({
   HOST: z.string().default("localhost").describe("Bind address (use 0.0.0.0 to listen on all interfaces)"),
   PORT: z.coerce.number().default(4010).describe("Listen port"),
-  IDLE_TIMEOUT: z.coerce.number().default(300).describe("Timeout in seconds after which the request is assumed to be stalled and interrupted"),
+  IDLE_TIMEOUT: z.coerce.number().max(255).default(255).describe("Timeout in seconds after which the request is assumed to be stalled and interrupted (max 255)"),
   UNIX_SOCKET: z.string().optional().describe("Unix socket path (overrides HOST/PORT when set)").meta(expert()),
   DB_CONNECTION_URL: z.url().describe("PostgreSQL connection string (e.g. postgresql://user:pass@host:5432/dbname)").meta(secret()),
   REDIS_URL: z.url().describe("Redis connection URL (e.g. redis://localhost:6379)").meta(secret()),

--- a/packages/xinity-ai-gateway/src/gatewayServer.ts
+++ b/packages/xinity-ai-gateway/src/gatewayServer.ts
@@ -12,6 +12,7 @@ import { handleModelsRequest } from "./llm-forward/endpoints/handle-models";
 import { handleCreateResponseRequest, handleGetOrDeleteResponseRequest } from "./llm-forward/endpoints/handle-responses";
 import { handleRerank } from "./llm-forward/endpoints/handle-rerank";
 import { handleMetrics, withMetrics } from "./metrics";
+import { getTlsConfig } from "common-env";
 
 process.on("unhandledRejection", (reason) => {
   rootLogger.error({ err: reason }, "Unhandled promise rejection");
@@ -38,7 +39,10 @@ const handler = new OpenAPIHandler(serverRouter, {
   plugins: [],
 });
 
+const tls = getTlsConfig(env);
+
 const serveOptions = {
+  tls,
   routes: {
     "/docs": createScalarPage(),
     "/openapi.json": await createOpenapiSpec(),
@@ -55,12 +59,13 @@ const serveOptions = {
   idleTimeout: env.IDLE_TIMEOUT,
 } as const;
 
+const proto = tls ? "https" : "http";
 if (env.UNIX_SOCKET) {
   Bun.serve({ ...serveOptions, unix: env.UNIX_SOCKET, idleTimeout: undefined });
-  rootLogger.info({ unix: env.UNIX_SOCKET }, "Gateway started");
+  rootLogger.info({ unix: env.UNIX_SOCKET, tls: !!tls }, `Gateway started (${proto})`);
 } else {
   Bun.serve({ ...serveOptions, port: env.PORT, hostname: env.HOST });
-  rootLogger.info({ host: env.HOST, port: env.PORT }, "Gateway started");
+  rootLogger.info({ host: env.HOST, port: env.PORT, tls: !!tls }, `Gateway started (${proto})`);
 }
 
 async function handleRequest(req: Request): Promise<Response> {

--- a/packages/xinity-ai-gateway/src/gatewayServer.ts
+++ b/packages/xinity-ai-gateway/src/gatewayServer.ts
@@ -38,7 +38,7 @@ const handler = new OpenAPIHandler(serverRouter, {
   plugins: [],
 });
 
-Bun.serve({
+const serveOptions = {
   routes: {
     "/docs": createScalarPage(),
     "/openapi.json": await createOpenapiSpec(),
@@ -52,11 +52,16 @@ Bun.serve({
     "/v1/responses/:responseId": withMetrics("/v1/responses/:responseId", handleGetOrDeleteResponseRequest),
   },
   fetch: handleRequest,
-  port: env.PORT,
-  hostname: env.HOST,
-  idleTimeout: 255,
-});
-rootLogger.info({ host: env.HOST, port: env.PORT }, "Gateway started")
+  idleTimeout: env.IDLE_TIMEOUT,
+} as const;
+
+if (env.UNIX_SOCKET) {
+  Bun.serve({ ...serveOptions, unix: env.UNIX_SOCKET, idleTimeout: undefined });
+  rootLogger.info({ unix: env.UNIX_SOCKET }, "Gateway started");
+} else {
+  Bun.serve({ ...serveOptions, port: env.PORT, hostname: env.HOST });
+  rootLogger.info({ host: env.HOST, port: env.PORT }, "Gateway started");
+}
 
 async function handleRequest(req: Request): Promise<Response> {
   const { matched, response } = await handler.handle(req, {

--- a/packages/xinity-ai-gateway/src/llm-forward/ai-sdk.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/ai-sdk.ts
@@ -5,6 +5,7 @@ import { getModelInfo } from "./model-data";
 import { errorResponse } from "./util";
 import { resolveApplicationByName } from "./application-resolver";
 import { releaseCallbacks } from "./release-registry";
+import { backendUrl, hasCustomCa, backendFetch } from "./backend-fetch";
 
 export type ResolvedModel = {
   auth: AuthResult;
@@ -81,10 +82,11 @@ export async function resolveAuthorizedModel(
 
   const provider = createOpenAICompatible({
     name: resolved.modelInfo.driver,
-    baseURL: `http://${resolved.modelInfo.host}/v1`,
-    apiKey: "not-needed",
+    baseURL: backendUrl(resolved.modelInfo.host, resolved.modelInfo.model, "/v1", resolved.modelInfo.tls),
+    apiKey: resolved.modelInfo.authToken ?? "none",
     includeUsage: true,
     supportsStructuredOutputs: resolved.modelInfo.driver === "vllm",
+    ...(hasCustomCa ? { fetch: backendFetch as typeof globalThis.fetch } : {}),
   });
 
   return { ...resolved, provider };

--- a/packages/xinity-ai-gateway/src/llm-forward/backend-fetch.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/backend-fetch.ts
@@ -1,0 +1,25 @@
+import { env } from "../env";
+
+const customCa = env.XINITY_INFERENCE_CA;
+const tlsOptions = customCa ? { ca: customCa } : undefined;
+
+export const hasCustomCa = !!customCa;
+
+/** Build the full URL for a request through the daemon proxy. */
+export function backendUrl(host: string, model: string, path: string, tls: boolean): string {
+  const protocol = tls ? "https" : "http";
+  return `${protocol}://${host}/proxy/${encodeURIComponent(model)}${path}`;
+}
+
+/** Perform a fetch to a daemon inference proxy with auth token and optional custom CA. */
+export function backendFetch(url: string | URL | Request, init?: RequestInit & { authToken?: string }): Promise<Response> {
+  const headers = new Headers(init?.headers);
+  if (init?.authToken) {
+    headers.set("authorization", `Bearer ${init.authToken}`);
+  }
+  const fetchInit = { ...init, headers };
+  if (tlsOptions) {
+    (fetchInit as Record<string, unknown>).tls = tlsOptions;
+  }
+  return fetch(url, fetchInit);
+}

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-chatCompletion.test.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-chatCompletion.test.ts
@@ -43,12 +43,20 @@ const getModelInfo = jest.fn<typeof getModelInfoT>(async () => ({
   host: `localhost:${mockPort}`,
   model: "test-model",
   driver: "vllm",
+  authToken: null,
+  tls: false,
   tags: ["tools"],
   requestParams: {},
   release: () => {},
 }))
 mock.module("../model-data", () => ({
   getModelInfo,
+}));
+
+mock.module("../backend-fetch", () => ({
+  backendUrl: (host: string, _model: string, path: string, _tls: boolean) => `http://${host}${path}`,
+  backendFetch: (url: string | URL | Request, init?: RequestInit) => fetch(url, init),
+  hasCustomCa: false,
 }));
 
 const mockLogChatStream = mock(() => Promise.resolve());
@@ -304,6 +312,8 @@ describe("handleChatCompletion", () => {
       host: `localhost:${mockPort}`,
       model: "test-model",
       driver: "ollama",
+      authToken: null,
+      tls: false,
       tags: [],
       requestParams: {},
       release: () => {},
@@ -461,6 +471,8 @@ describe("handleChatCompletion, tool calling", () => {
       host: `localhost:${mockPort}`,
       model: "test-model",
       driver: "vllm",
+      authToken: null,
+      tls: false,
       tags: [],
       requestParams: {},
       release: () => {},

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-chatCompletion.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-chatCompletion.ts
@@ -6,6 +6,7 @@ import type { ApiCallInputMessage } from "common-db";
 import { rootLogger } from "../../logger";
 import { processMessageImages, imageStore } from "../../image-store";
 import { env } from "../../env";
+import { backendFetch, backendUrl } from "../backend-fetch";
 
 const log = rootLogger.child({ name: "handle-chatCompletion" });
 
@@ -118,11 +119,12 @@ export async function handleChatCompletion(req: Request) {
       metadata: body.metadata ?? undefined,
     } as const;
 
-    const backendResponse = await fetch(`http://${modelInfo.host}/v1/chat/completions`, {
+    const backendResponse = await backendFetch(backendUrl(modelInfo.host, modelInfo.model, "/v1/chat/completions", modelInfo.tls), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(fetchBody),
       signal: AbortSignal.any([req.signal, AbortSignal.timeout(env.BACKEND_TIMEOUT_MS)]),
+      authToken: modelInfo.authToken ?? undefined,
     });
 
     if (!backendResponse.ok) {

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-completions.test.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-completions.test.ts
@@ -38,6 +38,8 @@ const getModelInfo = jest.fn<typeof getModelInfoT>(async () => ({
   host: `localhost:${mockPort}`,
   model: "test-model",
   driver: "vllm",
+  authToken: null,
+  tls: false,
   tags: [],
   requestParams: {},
   release: () => {},
@@ -45,6 +47,12 @@ const getModelInfo = jest.fn<typeof getModelInfoT>(async () => ({
 
 mock.module("../model-data", () => ({
   getModelInfo,
+}));
+
+mock.module("../backend-fetch", () => ({
+  backendUrl: (host: string, _model: string, path: string, _tls: boolean) => `http://${host}${path}`,
+  backendFetch: (url: string | URL | Request, init?: RequestInit) => fetch(url, init),
+  hasCustomCa: false,
 }));
 
 const mockLogChatStream = mock(() => Promise.resolve());

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-completions.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-completions.ts
@@ -5,6 +5,7 @@ import { BackendCompletionChunkSchema, BackendUsageSchema } from "../backend-sch
 import type { ApiCallInputMessage } from "common-db";
 import { rootLogger } from "../../logger";
 import { env } from "../../env";
+import { backendFetch, backendUrl } from "../backend-fetch";
 
 const log = rootLogger.child({ name: "handle-completions" });
 
@@ -85,11 +86,12 @@ export async function handleCompletion(req: Request): Promise<Response> {
     };
     if (body.stream) fetchBody.stream_options = { include_usage: true };
 
-    const backendResponse = await fetch(`http://${modelInfo.host}/v1/completions`, {
+    const backendResponse = await backendFetch(backendUrl(modelInfo.host, modelInfo.model, "/v1/completions", modelInfo.tls), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(fetchBody),
       signal: AbortSignal.any([req.signal, AbortSignal.timeout(env.BACKEND_TIMEOUT_MS)]),
+      authToken: modelInfo.authToken ?? undefined,
     });
 
     if (!backendResponse.ok) {

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-embeddings.test.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-embeddings.test.ts
@@ -38,6 +38,8 @@ const getModelInfo = jest.fn<typeof getModelInfoT>(async () => ({
   host: `localhost:${mockPort}`,
   model: "test-embedding",
   driver: "vllm",
+  authToken: null,
+  tls: false,
   type: "embedding",
   tags: [],
   requestParams: {},
@@ -46,6 +48,12 @@ const getModelInfo = jest.fn<typeof getModelInfoT>(async () => ({
 
 mock.module("../model-data", () => ({
   getModelInfo,
+}));
+
+mock.module("../backend-fetch", () => ({
+  backendUrl: (host: string, _model: string, path: string, _tls: boolean) => `http://${host}${path}`,
+  backendFetch: (url: string | URL | Request, init?: RequestInit) => fetch(url, init),
+  hasCustomCa: false,
 }));
 
 mock.module("../../usageRecorder", () => ({

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-embeddings.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-embeddings.ts
@@ -3,6 +3,7 @@ import { resolveModel } from "../ai-sdk";
 import { errorResponse, forwardBackendError, recordUsage, validateModelType, handleEndpointError, validationError } from "../util";
 import { rootLogger } from "../../logger";
 import { env } from "../../env";
+import { backendFetch, backendUrl } from "../backend-fetch";
 
 const log = rootLogger.child({ name: "handle-embeddings" });
 
@@ -40,11 +41,12 @@ export async function handleEmbeddingGeneration(req: Request): Promise<Response>
     if (body.dimensions != null) fetchBody.dimensions = body.dimensions;
     if (body.user != null) fetchBody.user = body.user;
 
-    const backendResponse = await fetch(`http://${modelInfo.host}/v1/embeddings`, {
+    const backendResponse = await backendFetch(backendUrl(modelInfo.host, modelInfo.model, "/v1/embeddings", modelInfo.tls), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(fetchBody),
       signal: AbortSignal.any([req.signal, AbortSignal.timeout(env.BACKEND_TIMEOUT_MS)]),
+      authToken: modelInfo.authToken ?? undefined,
     });
 
     if (!backendResponse.ok) {

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-rerank.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-rerank.ts
@@ -3,6 +3,7 @@ import { resolveModel } from "../ai-sdk";
 import { forwardBackendError, validateModelType, handleEndpointError, validationError } from "../util";
 import { rootLogger } from "../../logger";
 import { env } from "../../env";
+import { backendFetch, backendUrl } from "../backend-fetch";
 
 const log = rootLogger.child({ name: "handle-rerank" });
 
@@ -40,7 +41,7 @@ export async function handleRerank(req: Request): Promise<Response> {
     }
     const body = parseResult.data;
 
-    const backendResponse = await fetch(`http://${modelInfo.host}/v1/rerank`, {
+    const backendResponse = await backendFetch(backendUrl(modelInfo.host, modelInfo.model, "/v1/rerank", modelInfo.tls), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -51,6 +52,7 @@ export async function handleRerank(req: Request): Promise<Response> {
         return_documents: body.return_documents,
       }),
       signal: AbortSignal.any([req.signal, AbortSignal.timeout(env.BACKEND_TIMEOUT_MS)]),
+      authToken: modelInfo.authToken ?? undefined,
     });
 
     if (!backendResponse.ok) {

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-responses.test.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-responses.test.ts
@@ -34,12 +34,20 @@ const getModelInfo = jest.fn(async () => ({
   host: `localhost:${mockPort}`,
   model: "test-model",
   driver: "vllm",
+  authToken: null,
+  tls: false,
   tags: ["tools"],
   release: () => {},
 }));
 
 mock.module("../model-data", () => ({
   getModelInfo,
+}));
+
+mock.module("../backend-fetch", () => ({
+  backendUrl: (host: string, _model: string, path: string, _tls: boolean) => `http://${host}${path}`,
+  backendFetch: (url: string | URL | Request, init?: RequestInit) => fetch(url, init),
+  hasCustomCa: false,
 }));
 
 const responseStore = new Map<string, any>();

--- a/packages/xinity-ai-gateway/src/llm-forward/model-data.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/model-data.ts
@@ -42,30 +42,39 @@ async function getModelSources(modelSpecifier: string) {
   const modelLocations = await getDB().select({
     host: aiNodeT.host,
     nodePort: aiNodeT.port,
-    modelPort: modelInstallationT.port,
     driver: modelInstallationT.driver,
+    authToken: aiNodeT.authToken,
+    tls: aiNodeT.tls,
   }).from(modelInstallationT)
     .innerJoin(aiNodeT, sql`${modelInstallationT.nodeId} = ${aiNodeT.id} AND ${aiNodeT.deletedAt} IS NULL`)
     .where(sql`${modelInstallationT.model} = ${modelSpecifier} AND ${modelInstallationT.deletedAt} IS NULL`);
 
   const driverMap = new Map<string, string>();
+  const authTokenMap = new Map<string, string | null>();
+  const tlsMap = new Map<string, boolean>();
   const hosts: string[] = [];
   for (const loc of modelLocations) {
-    const key = `${loc.host}:${loc.modelPort}`;
+    const key = `${loc.host}:${loc.nodePort}`;
     driverMap.set(key, loc.driver);
+    authTokenMap.set(key, loc.authToken);
+    tlsMap.set(key, loc.tls);
     hosts.push(key);
   }
 
-  return { hosts: Array.from(new Set(hosts)), driverMap };
+  return { hosts: Array.from(new Set(hosts)), driverMap, authTokenMap, tlsMap };
 }
 
 type ModelInfo = {
-  /** host info to send completion requests to. I.e. 192.168.0.190:11434 */
+  /** Daemon host:port to route requests through. */
   host: string;
   /** origin model name. I.e. gemma3:latest */
   model: string;
   /** Inference driver for this model installation (e.g. "ollama", "vllm"). */
   driver: string;
+  /** Per-node auth token for authenticating requests to the daemon. */
+  authToken: string | null;
+  /** Whether this daemon node serves over TLS. */
+  tls: boolean;
   /** Model type from the catalog (chat, embedding, rerank). Undefined if catalog is unavailable. */
   type?: string;
   /** Model tags from the catalog (e.g. "tools", "custom_code", "vision"). */
@@ -88,7 +97,7 @@ export async function getModelInfo(orgId: string, modelSpecifier: string, keyId:
     getModelSources(accessInfo.modelSpecifier),
     accessInfo.earlyModelSpecifier
       ? getModelSources(accessInfo.earlyModelSpecifier)
-      : Promise.resolve({ hosts: [], driverMap: new Map<string, string>() }),
+      : Promise.resolve({ hosts: [], driverMap: new Map<string, string>(), authTokenMap: new Map<string, string | null>(), tlsMap: new Map<string, boolean>() }),
   ]);
 
   const result = await _deps.selectHost(env.LOAD_BALANCE_STRATEGY as LoadBalanceStrategy, {
@@ -108,10 +117,16 @@ export async function getModelInfo(orgId: string, modelSpecifier: string, keyId:
     ? accessInfo.modelSpecifier
     : (accessInfo.earlyModelSpecifier ?? accessInfo.modelSpecifier);
 
-  // Look up driver from whichever source set the host came from
+  // Look up driver and auth token from whichever source set the host came from
   const driver = finalSources.driverMap.get(result.host)
     ?? earlySources.driverMap.get(result.host)
     ?? "ollama";
+  const authToken = finalSources.authTokenMap.get(result.host)
+    ?? earlySources.authTokenMap.get(result.host)
+    ?? null;
+  const tls = finalSources.tlsMap.get(result.host)
+    ?? earlySources.tlsMap.get(result.host)
+    ?? false;
 
   const [{ type, tags }, requestParams] = await Promise.all([
     infoClient.resolveModelMeta(resolvedModel),
@@ -122,6 +137,8 @@ export async function getModelInfo(orgId: string, modelSpecifier: string, keyId:
     host: result.host,
     model: resolvedModel,
     driver,
+    authToken,
+    tls,
     type,
     tags,
     requestParams,

--- a/packages/xinity-ai-gateway/src/rpc/orpc.root.ts
+++ b/packages/xinity-ai-gateway/src/rpc/orpc.root.ts
@@ -1,15 +1,14 @@
-import type { IncomingHttpHeaders } from "node:http2";
 import { os } from "@orpc/server";
 import { z } from "zod";
 
-const o = os.$context<{ headers: IncomingHttpHeaders }>();
+const o = os.$context<{ headers: Headers }>();
 
 export const privateProcedure = o
   .errors({
     UNAUTHORIZED: { data: z.string(), status: 403 },
   })
   .use(({ context, next, errors }) => {
-    const authorization = context.headers["x-apikey"];
+    const authorization = context.headers.get("x-apikey");
     if (authorization !== Bun.env.SECRET_TOKEN) {
       throw errors.UNAUTHORIZED({ data: "Token not matching" });
     }

--- a/scripts/generate-tls-certs.sh
+++ b/scripts/generate-tls-certs.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# Generate a self-signed CA and server certificate for TLS between
+# the gateway and daemon inference proxy.
+#
+# Usage:
+#   ./scripts/generate-tls-certs.sh [output-dir] [extra-SANs...]
+#
+# Examples:
+#   ./scripts/generate-tls-certs.sh                           # output to ./certs/
+#   ./scripts/generate-tls-certs.sh /etc/xinity/certs         # custom output dir
+#   ./scripts/generate-tls-certs.sh ./certs 10.0.0.5 myhost   # extra SANs
+#
+# Output files:
+#   ca.pem            - CA certificate (give to gateway as XINITY_INFERENCE_CA)
+#   ca-key.pem        - CA private key (keep secure, only needed for signing new certs)
+#   server.pem        - Server certificate (daemon XINITY_TLS_CERT)
+#   server-key.pem    - Server private key (daemon XINITY_TLS_KEY)
+
+set -euo pipefail
+
+OUT_DIR="${1:-./certs}"
+shift || true
+
+DAYS_CA=3650
+DAYS_CERT=825
+
+mkdir -p "$OUT_DIR"
+
+# ---------------------------------------------------------------------------
+# Build SAN list: always include localhost + 127.0.0.1, plus any extra args
+# ---------------------------------------------------------------------------
+SAN="DNS:localhost,IP:127.0.0.1"
+for arg in "$@"; do
+  if [[ "$arg" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    SAN="${SAN},IP:${arg}"
+  else
+    SAN="${SAN},DNS:${arg}"
+  fi
+done
+
+echo "Generating TLS certificates in ${OUT_DIR}/"
+echo "Server SANs: ${SAN}"
+
+# ---------------------------------------------------------------------------
+# 1. Certificate Authority
+# ---------------------------------------------------------------------------
+openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 \
+  -days "$DAYS_CA" -nodes \
+  -keyout "$OUT_DIR/ca-key.pem" \
+  -out "$OUT_DIR/ca.pem" \
+  -subj "/CN=xinity-ca" \
+  2>/dev/null
+chmod 600 "$OUT_DIR/ca-key.pem"
+
+echo "  CA certificate:  ${OUT_DIR}/ca.pem"
+
+# ---------------------------------------------------------------------------
+# 2. Server certificate (for the daemon)
+# ---------------------------------------------------------------------------
+openssl req -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 \
+  -nodes \
+  -keyout "$OUT_DIR/server-key.pem" \
+  -out "$OUT_DIR/server.csr" \
+  -subj "/CN=xinity-daemon" \
+  2>/dev/null
+
+openssl x509 -req \
+  -in "$OUT_DIR/server.csr" \
+  -CA "$OUT_DIR/ca.pem" \
+  -CAkey "$OUT_DIR/ca-key.pem" \
+  -CAcreateserial \
+  -days "$DAYS_CERT" \
+  -extfile <(printf "subjectAltName=%s\nextendedKeyUsage=serverAuth" "$SAN") \
+  -out "$OUT_DIR/server.pem" \
+  2>/dev/null
+
+rm -f "$OUT_DIR/server.csr" "$OUT_DIR/ca.srl"
+chmod 600 "$OUT_DIR/server-key.pem"
+echo "  Server cert:     ${OUT_DIR}/server.pem"
+echo "  Server key:      ${OUT_DIR}/server-key.pem"
+
+echo ""
+echo "Done. Configure your services:"
+echo ""
+echo "  Daemon:"
+echo "    XINITY_TLS_CERT_FILE=${OUT_DIR}/server.pem"
+echo "    XINITY_TLS_KEY_FILE=${OUT_DIR}/server-key.pem"
+echo ""
+echo "  Gateway (only needed for self-signed certs):"
+echo "    XINITY_INFERENCE_CA_FILE=${OUT_DIR}/ca.pem"

--- a/tests/system/gateway/gateway-test-helpers.ts
+++ b/tests/system/gateway/gateway-test-helpers.ts
@@ -68,8 +68,17 @@ let gatewayProcess: Bun.Subprocess | null = null;
 let gatewayReady: Promise<void> | null = null;
 
 export async function ensureGatewayRunning(): Promise<void> {
-  if (gatewayReady) {
-    return gatewayReady;
+  // If we have a cached promise, check the process is actually still alive.
+  // Bun's test runner kills dangling child processes between test files,
+  // so we must be prepared to restart.
+  if (gatewayReady && gatewayProcess) {
+    const alive = !gatewayProcess.killed && gatewayProcess.exitCode === null;
+    if (alive) {
+      return gatewayReady;
+    }
+    // Process was killed externally, reset and restart.
+    gatewayProcess = null;
+    gatewayReady = null;
   }
 
   gatewayReady = (async () => {
@@ -104,7 +113,7 @@ export async function ensureGatewayRunning(): Promise<void> {
     const exitWait = gatewayProcess.exited.then(async (code) => {
       const output = await readProcessOutput(gatewayProcess!);
       throw new Error(
-        `Gateway exited before health check (code ${code}). stderr: ${output.stderr || "<empty>"}`
+        `Gateway exited before health check (code ${code}). stdout: ${output.stdout?.slice(-500) || "<empty>"} stderr: ${output.stderr || "<empty>"}`
       );
     });
     await Promise.race([healthWait, exitWait]);
@@ -218,7 +227,7 @@ export async function createModelInstallation(input: {
   model: string;
   port: number;
   estCapacity?: number;
-  driver?: string;
+  driver?: "ollama" | "vllm";
   deletedAt?: Date;
 }): Promise<{ id: string }> {
   const [installation] = await getDB().insert(modelInstallationT).values({
@@ -269,8 +278,32 @@ async function startMockJsonServer(defaultBody: Record<string, unknown>, respons
   return { port, stop: () => server.stop() };
 }
 
+/**
+ * Starts a mock server that acts as a daemon proxy, handling
+ * `/proxy/{model}/v1/...` paths and returning the given response body.
+ * The returned port should be used as the aiNodeT port.
+ */
+async function startMockProxyServer(defaultBody: Record<string, unknown>, responseBody?: Record<string, unknown>): Promise<{
+  port: number;
+  stop: () => void;
+}> {
+  const port = await getAvailablePort();
+  const body = responseBody ?? defaultBody;
+  const server = Bun.serve({
+    port,
+    fetch: async (req) => {
+      const url = new URL(req.url);
+      if (url.pathname.startsWith("/proxy/")) {
+        return Response.json(body);
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+  return { port, stop: () => server.stop() };
+}
+
 export async function startMockChatCompletionServer(responseBody?: Record<string, unknown>) {
-  return startMockJsonServer({
+  return startMockProxyServer({
     id: `chatcmpl_${randomUUID()}`,
     object: "chat.completion",
     created: Math.floor(Date.now() / 1000),
@@ -283,7 +316,7 @@ export async function startMockChatCompletionServer(responseBody?: Record<string
 }
 
 export async function startMockEmbeddingServer(responseBody?: Record<string, unknown>) {
-  return startMockJsonServer({
+  return startMockProxyServer({
     object: "list",
     data: [{ object: "embedding", embedding: [0.1, 0.2, 0.3], index: 0 }],
     model: "internal-test-embedding-model",

--- a/tests/system/gateway/gateway.chat.test.ts
+++ b/tests/system/gateway/gateway.chat.test.ts
@@ -111,7 +111,7 @@ describe("xinity-ai-gateway chat completion", () => {
     });
 
     const mockServer = await startMockChatCompletionServer();
-    const node = await createAiNode();
+    const node = await createAiNode({ port: mockServer.port });
     await createModelInstallation({
       nodeId: node.id,
       model: internalModel,
@@ -201,7 +201,7 @@ describe("xinity-ai-gateway chat completion", () => {
       usage: { prompt_tokens: 3, completion_tokens: 4, total_tokens: 7 },
     });
 
-    const node = await createAiNode();
+    const node = await createAiNode({ port: mockServer.port });
     await createModelInstallation({
       nodeId: node.id,
       model: internalModel,

--- a/tests/system/gateway/gateway.embeddings.test.ts
+++ b/tests/system/gateway/gateway.embeddings.test.ts
@@ -122,7 +122,7 @@ describe("xinity-ai-gateway embeddings", () => {
       usage: { prompt_tokens: 2, total_tokens: 2 },
     });
 
-    const node = await createAiNode();
+    const node = await createAiNode({ port: mockServer.port });
     await createModelInstallation({
       nodeId: node.id,
       model: internalModel,

--- a/tests/system/gateway/gateway.multimodal-s3.test.ts
+++ b/tests/system/gateway/gateway.multimodal-s3.test.ts
@@ -172,7 +172,7 @@ describe("multimodal image storage (SeaweedFS S3)", () => {
       usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
     });
 
-    const node = await createAiNode();
+    const node = await createAiNode({ port: mockServer.port });
     await createModelInstallation({ nodeId: node.id, model: internalModel, port: mockServer.port });
 
     const messages = [
@@ -253,7 +253,7 @@ describe("multimodal image storage (SeaweedFS S3)", () => {
     await createModelDeployment({ orgId, publicSpecifier, modelSpecifier: internalModel });
 
     const mockServer = await startMockChatCompletionServer();
-    const node = await createAiNode({ port: 9998 });
+    const node = await createAiNode({ port: mockServer.port });
     await createModelInstallation({ nodeId: node.id, model: internalModel, port: mockServer.port });
 
     // Send two requests with the same image
@@ -325,7 +325,7 @@ describe("multimodal image storage (SeaweedFS S3)", () => {
 
       await createModelDeployment({ orgId, publicSpecifier, modelSpecifier: internalModel });
       const mockServer = await startMockChatCompletionServer();
-      const node = await createAiNode({ port: 9997 });
+      const node = await createAiNode({ port: mockServer.port });
       await createModelInstallation({ nodeId: node.id, model: internalModel, port: mockServer.port });
 
       const res = await fetch(noS3Url("/v1/chat/completions"), {

--- a/tests/system/infoserver/infoserver-test-helpers.ts
+++ b/tests/system/infoserver/infoserver-test-helpers.ts
@@ -16,8 +16,11 @@ async function readProcessOutput(proc: Bun.Subprocess): Promise<{ stdout: string
 
 /** Starts the info server once and waits for its health endpoint. */
 export async function ensureInfoServerRunning(): Promise<void> {
-  if (infoReady) {
-    return infoReady;
+  if (infoReady && infoProcess) {
+    const alive = !infoProcess.killed && infoProcess.exitCode === null;
+    if (alive) return infoReady;
+    infoProcess = null;
+    infoReady = null;
   }
 
   infoReady = (async () => {


### PR DESCRIPTION
## Description

The daemon now acts as a reverse proxy for all inference traffic. Backends bind to localhost only and are no longer directly reachable from the network. The gateway routes requests through `/proxy/{model}/v1/...` on the daemon's existing port instead of connecting to backend ports directly.

Each daemon generates a per-node auth token on startup and stores it in the database. The gateway reads it automatically when routing requests. No manual configuration needed.

`TLS` is opt-in for daemon and gateway via `XINITY_TLS_CERT` / `XINITY_TLS_KEY`. The daemon reports its `TLS` status to the database so the gateway uses the correct protocol per node.

The daemon's HTTP server was migrated from `node:http` to `Bun.serve()` to align with the gateway and enable native `TLS` support. Both services also gained `UNIX_SOCKET` and `IDLE_TIMEOUT` configuration.

### Upgrade Notes

Database migration required. Two new columns on `ai_node`: `auth_token` and `tls`.

Backends now bind to `127.0.0.1`. Direct access to inference backends from other machines is no longer intended as the way to reach them.

## Type of change

New feature

## Testing

All potentially impacted tests pass locally.  
A test for the newly introduced proxying component in the daemon has been added

## Checklist

- [x] Tests pass locally (`bun test`), or no testable code was changed
- [x] New or changed behavior is covered by tests, or this change does not require tests
- [x] Documentation is updated, or no user-facing behavior or configuration was changed
- [x] There are no breaking changes, or they are marked with `!` in the commit type and described above
- [x] No security-sensitive changes (authentication, credentials, input handling), or they have been reviewed
- [x] No new dependencies were added, or they have been reviewed for license and maintenance status