### PR TITLE
feat(infoserver): model-info directory

### DIFF
--- a/nix/modules/xinity-ai-allinone.mod.nix
+++ b/nix/modules/xinity-ai-allinone.mod.nix
@@ -281,12 +281,12 @@
           modelInfoFile = lib.mkOption {
             type = lib.types.nullOr lib.types.path;
             default = null;
-            description = "Path to the models YAML file on the host.";
+            description = "Deprecated: use modelInfoDir instead. Path to a single models YAML file. Will be removed in 1.0.0.";
           };
           modelInfoDir = lib.mkOption {
             type = lib.types.nullOr lib.types.path;
             default = null;
-            description = "Path to a directory of additional model YAML files on the host.";
+            description = "Path to a directory of model YAML files on the host.";
           };
         };
 

--- a/nix/modules/xinity-ai-allinone.mod.nix
+++ b/nix/modules/xinity-ai-allinone.mod.nix
@@ -279,8 +279,14 @@
             description = "Port for the infoserver.";
           };
           modelInfoFile = lib.mkOption {
-            type = lib.types.path;
+            type = lib.types.nullOr lib.types.path;
+            default = null;
             description = "Path to the models YAML file on the host.";
+          };
+          modelInfoDir = lib.mkOption {
+            type = lib.types.nullOr lib.types.path;
+            default = null;
+            description = "Path to a directory of additional model YAML files on the host.";
           };
         };
 
@@ -500,6 +506,7 @@
             enable = true;
             port = lib.mkDefault cfg.infoserver.port;
             modelInfoFile = lib.mkDefault cfg.infoserver.modelInfoFile;
+            modelInfoDir = lib.mkDefault cfg.infoserver.modelInfoDir;
             environmentFiles = lib.mkDefault envFiles;
             extraOptions = lib.mkDefault networkOptions;
           };

--- a/nix/modules/xinity-infoserver.mod.nix
+++ b/nix/modules/xinity-infoserver.mod.nix
@@ -24,13 +24,13 @@ in {
         modelInfoFile = lib.mkOption {
           type = lib.types.nullOr lib.types.path;
           default = null;
-          description = "Path to the models YAML file on the host. Will be mounted into the container.";
+          description = "Deprecated: use modelInfoDir instead. Path to a single models YAML file on the host. Will be removed in 1.0.0.";
         };
 
         modelInfoDir = lib.mkOption {
           type = lib.types.nullOr lib.types.path;
           default = null;
-          description = "Path to a directory of additional model YAML files on the host. Will be mounted into the container at /data/models.d/.";
+          description = "Path to a directory of model YAML files on the host. Mounted into the container at /data/models.d/. This is the preferred way to configure model sources.";
         };
 
         refreshIntervalMs = lib.mkOption {
@@ -83,7 +83,7 @@ in {
       config = lib.mkIf cfg.enable {
         assertions = [{
           assertion = cfg.modelInfoFile != null || cfg.modelInfoDir != null;
-          message = "services.xinity-infoserver: at least one of modelInfoFile or modelInfoDir must be set.";
+          message = "services.xinity-infoserver: modelInfoDir must be set (or the deprecated modelInfoFile).";
         }];
 
         virtualisation.oci-containers.containers.xinity-infoserver = {

--- a/nix/modules/xinity-infoserver.mod.nix
+++ b/nix/modules/xinity-infoserver.mod.nix
@@ -22,8 +22,15 @@ in {
         };
 
         modelInfoFile = lib.mkOption {
-          type = lib.types.path;
+          type = lib.types.nullOr lib.types.path;
+          default = null;
           description = "Path to the models YAML file on the host. Will be mounted into the container.";
+        };
+
+        modelInfoDir = lib.mkOption {
+          type = lib.types.nullOr lib.types.path;
+          default = null;
+          description = "Path to a directory of additional model YAML files on the host. Will be mounted into the container at /data/models.d/.";
         };
 
         refreshIntervalMs = lib.mkOption {
@@ -74,22 +81,34 @@ in {
       };
 
       config = lib.mkIf cfg.enable {
+        assertions = [{
+          assertion = cfg.modelInfoFile != null || cfg.modelInfoDir != null;
+          message = "services.xinity-infoserver: at least one of modelInfoFile or modelInfoDir must be set.";
+        }];
+
         virtualisation.oci-containers.containers.xinity-infoserver = {
           image = cfg.image;
           ports = [ "${toString cfg.port}:${toString cfg.port}" ];
           environment = {
             PORT = toString cfg.port;
-            MODEL_INFO_FILE = "/data/models.yaml";
             REFRESH_INTERVAL_MS = toString cfg.refreshIntervalMs;
             MAX_INCLUDE_DEPTH = toString cfg.maxIncludeDepth;
             LOG_LEVEL = cfg.logLevel;
           }
+          // lib.optionalAttrs (cfg.modelInfoFile != null) {
+            MODEL_INFO_FILE = "/data/models.yaml";
+          }
           // lib.optionalAttrs (cfg.logDir != null) {
             LOG_DIR = cfg.logDir;
           }
+          // lib.optionalAttrs (cfg.modelInfoDir != null) {
+            MODEL_INFO_DIR = "/data/models.d";
+          }
           // cfg.extraEnvironment;
-          volumes = [
+          volumes = lib.optionals (cfg.modelInfoFile != null) [
             "${cfg.modelInfoFile}:/data/models.yaml:ro"
+          ] ++ lib.optionals (cfg.modelInfoDir != null) [
+            "${cfg.modelInfoDir}:/data/models.d:ro"
           ];
           environmentFiles = cfg.environmentFiles;
           extraOptions = cfg.extraOptions;

--- a/packages/xinity-infoserver/Dockerfile
+++ b/packages/xinity-infoserver/Dockerfile
@@ -50,6 +50,6 @@ WORKDIR /usr/src/app/packages/xinity-infoserver
 COPY --from=build /usr/src/app/packages/xinity-infoserver/dist ./dist
 
 USER bun
-ENV MODEL_INFO_FILE=/data/models.yaml PORT=8090
+ENV MODEL_INFO_DIR=/data/models.d PORT=8090
 EXPOSE 8090/tcp
 CMD [ "bun", "run", "dist/server.js" ]

--- a/packages/xinity-infoserver/README.md
+++ b/packages/xinity-infoserver/README.md
@@ -111,7 +111,7 @@ models:
     # ... your model definition
 ```
 
-Models from included sources are merged. If the same specifier appears in multiple sources, later entries override earlier ones. Recursive includes are supported with cycle detection.
+Models from included sources are merged. Local models (from the main file or `MODEL_INFO_DIR`) take precedence over remote includes with the same specifier. Recursive includes are supported with cycle detection.
 
 ## Self-hosting
 
@@ -121,12 +121,14 @@ Most deployments use the public registry and don't need this section. Self-host 
 
 ```bash
 docker run -d \
-  -v /path/to/your/models.yaml:/data/models.yaml:ro \
-  -e MODEL_INFO_FILE=/data/models.yaml \
+  -v /path/to/models.d:/data/models.d:ro \
+  -e MODEL_INFO_DIR=/data/models.d \
   -e PORT=8090 \
   -p 8090:8090 \
   ghcr.io/xinity-ai/xinity-infoserver:latest
 ```
+
+> **Deprecation notice:** `MODEL_INFO_FILE` (single-file mode) is deprecated and will be removed in 1.0.0. Migrate to `MODEL_INFO_DIR` by placing your YAML files in a directory. Both options still work during the transition period, and when both are set, models from all sources are merged with local definitions taking precedence over remote includes.
 
 ### Pointing the cluster at your registry
 
@@ -161,7 +163,7 @@ curl http://localhost:8090/api/v1/models/my-private-model
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
-| `/health` | GET | Health check |
+| `/health` | GET | Health check (includes model count, last refresh time, last error) |
 | `/version.json` | GET | Server version info |
 | `/api/v1/models` | GET | Paginated model list (query: `page`, `pageSize`, `type`, `family`, `tag`) |
 | `/api/v1/models/:specifier` | GET | Single model lookup |
@@ -187,7 +189,7 @@ All four checks must pass on a single node. If no node qualifies, the model stay
 Run the HTTP server locally:
 
 ```bash
-MODEL_INFO_FILE=./models.yaml bun run start
+MODEL_INFO_DIR=./models.d bun run start
 ```
 
 Export the JSON Schema to stdout:

--- a/packages/xinity-infoserver/client.test.ts
+++ b/packages/xinity-infoserver/client.test.ts
@@ -4,6 +4,7 @@ import type { ModelWithSpecifier } from "./definitions/model-definition";
 
 const testModel: ModelWithSpecifier = {
   publicSpecifier: "llama-3.3-70b",
+  _source: "test",
   name: "Test Llama",
   description: "A test model",
   weight: 10,
@@ -19,6 +20,7 @@ const testModel: ModelWithSpecifier = {
 
 const embedModel: ModelWithSpecifier = {
   publicSpecifier: "nomic-embed",
+  _source: "test",
   name: "Nomic Embed",
   description: "An embedding model",
   weight: 5,

--- a/packages/xinity-infoserver/definitions/model-definition.ts
+++ b/packages/xinity-infoserver/definitions/model-definition.ts
@@ -126,7 +126,7 @@ export const ModelSchema = z.looseObject({
   }).optional().describe("Info for fine tuned custom models"),
 });
 export type Model = z.infer<typeof ModelSchema>;
-export type ModelWithSpecifier = Model & { publicSpecifier: string };
+export type ModelWithSpecifier = Model & { publicSpecifier: string; _source: string };
 
 export const ModelFileDefinitionSchema = z.object({
   includes: z.url().array().describe([

--- a/packages/xinity-infoserver/docs/model-fields.md
+++ b/packages/xinity-infoserver/docs/model-fields.md
@@ -87,5 +87,5 @@ These appear at the top level of the YAML file, not inside a model definition.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `includes` | URL[] | List of remote model source URLs to merge. Later entries override earlier ones with the same specifier. Recursive includes are supported with cycle detection |
+| `includes` | URL[] | List of remote model source URLs to merge. Local models take precedence over remote includes with the same specifier. Recursive includes are supported with cycle detection |
 | `models` | Record\<string, Model\> | Map of public specifier to model definition |

--- a/packages/xinity-infoserver/env-schema.ts
+++ b/packages/xinity-infoserver/env-schema.ts
@@ -3,7 +3,8 @@ import { expert } from "common-env";
 import { logEnvSchema } from "common-log";
 
 export const infoserverEnvSchema = z.object({
-  MODEL_INFO_FILE: z.string().describe("Path to the model info YAML file (defines available models and their metadata)"),
+  MODEL_INFO_FILE: z.string().optional().describe("Path to the model info YAML file (defines available models and their metadata)"),
+  MODEL_INFO_DIR: z.string().optional().describe("Directory of additional model YAML files to load alongside the main model file"),
   PORT: z.coerce.number().default(8090).describe("Listen port"),
   REFRESH_INTERVAL_MS: z.coerce.number().default(5 * 60_000).describe("How often to re-read model file and re-fetch includes (ms)").meta(expert()),
   MAX_INCLUDE_DEPTH: z.coerce.number().default(10).describe("Maximum recursion depth when resolving include URLs").meta(expert()),

--- a/packages/xinity-infoserver/env-schema.ts
+++ b/packages/xinity-infoserver/env-schema.ts
@@ -3,8 +3,8 @@ import { expert } from "common-env";
 import { logEnvSchema } from "common-log";
 
 export const infoserverEnvSchema = z.object({
-  MODEL_INFO_FILE: z.string().optional().describe("Path to the model info YAML file (defines available models and their metadata)"),
-  MODEL_INFO_DIR: z.string().optional().describe("Directory of additional model YAML files to load alongside the main model file"),
+  MODEL_INFO_FILE: z.string().optional().describe("Deprecated: use MODEL_INFO_DIR instead. Path to a single model info YAML file. Will be removed in 1.0.0"),
+  MODEL_INFO_DIR: z.string().optional().describe("Directory of model YAML files (*.yaml, *.yml) to load. This is the preferred way to configure model sources"),
   PORT: z.coerce.number().default(8090).describe("Listen port"),
   REFRESH_INTERVAL_MS: z.coerce.number().default(5 * 60_000).describe("How often to re-read model file and re-fetch includes (ms)").meta(expert()),
   MAX_INCLUDE_DEPTH: z.coerce.number().default(10).describe("Maximum recursion depth when resolving include URLs").meta(expert()),

--- a/packages/xinity-infoserver/example.env
+++ b/packages/xinity-infoserver/example.env
@@ -1,2 +1,4 @@
-MODEL_INFO_FILE=./models.yaml
+MODEL_INFO_DIR=.
+# Deprecated: use MODEL_INFO_DIR instead. Will be removed in 1.0.0
+# MODEL_INFO_FILE=./models.yaml
 PORT=8393

--- a/packages/xinity-infoserver/server-catalog.test.ts
+++ b/packages/xinity-infoserver/server-catalog.test.ts
@@ -39,6 +39,7 @@ const {
   getAll,
   getByFamily,
   getMergedData,
+  getCatalogHealth,
   stopAutoRefresh,
 } = await import("./server-catalog");
 
@@ -100,7 +101,7 @@ describe("server-catalog", () => {
         "nomic-embed-text": embeddingModel,
       });
       const path = await writeYamlFile(yaml, fileIndex++);
-      configure(path);
+      configure(10, path);
       await refresh();
     });
 
@@ -170,7 +171,7 @@ describe("server-catalog", () => {
     it("later entry overwrites earlier with same specifier", async () => {
       const yaml = makeModelYaml({ "llama-3.3-70b": baseModel });
       const path = await writeYamlFile(yaml, fileIndex++);
-      configure(path);
+      configure(10, path);
       await refresh();
       expect(get("llama-3.3-70b")?.name).toBe("Test Llama");
     });
@@ -205,7 +206,7 @@ describe("server-catalog", () => {
         [`http://localhost:${includeServer.port}/models.yaml`],
       );
       const path = await writeYamlFile(localYaml, fileIndex++);
-      configure(path);
+      configure(10, path);
       await refresh();
 
       expect(get("local-model")).toBeDefined();
@@ -231,7 +232,7 @@ describe("server-catalog", () => {
         [`http://localhost:${includeServer.port}/self.yaml`],
       );
       const path = await writeYamlFile(localYaml, fileIndex++);
-      configure(path);
+      configure(10, path);
       await refresh();
 
       expect(get("local-model")).toBeDefined();
@@ -258,7 +259,7 @@ describe("server-catalog", () => {
         [`http://localhost:${includeServer.port}/start.yaml`],
       );
       const path = await writeYamlFile(localYaml, fileIndex++);
-      configure(path, 2);
+      configure(2, path);
       await refresh();
 
       expect(get("root-model")).toBeDefined();
@@ -276,7 +277,7 @@ describe("server-catalog", () => {
         [`http://localhost:${includeServer.port}/bad.yaml`],
       );
       const path = await writeYamlFile(localYaml, fileIndex++);
-      configure(path);
+      configure(10, path);
       await refresh();
 
       expect(get("local-model")).toBeDefined();
@@ -286,14 +287,186 @@ describe("server-catalog", () => {
   describe("validation", () => {
     it("throws on invalid YAML that fails parsing", async () => {
       const path = await writeYamlFile("not: valid: model: file:", fileIndex++);
-      configure(path);
+      configure(10, path);
       await expect(refresh()).rejects.toThrow();
     });
 
     it("throws when YAML is valid but fails schema validation", async () => {
       const path = await writeYamlFile("someKey: someValue\n", fileIndex++);
-      configure(path);
-      await expect(refresh()).rejects.toThrow("Failed to validate model file");
+      configure(10, path);
+      await expect(refresh()).rejects.toThrow("Model file validation failed");
+    });
+  });
+
+  describe("directory loading", () => {
+    it("loads models from a directory of YAML files", async () => {
+      const dirPath = join(testDir, `dir-${fileIndex++}`);
+      await Bun.write(join(dirPath, "a-models.yaml"), makeModelYaml({ "dir-model-a": baseModel }));
+      await Bun.write(join(dirPath, "b-models.yaml"), makeModelYaml({ "dir-model-b": embeddingModel }));
+
+      configure(10, undefined, dirPath);
+      await refresh();
+
+      expect(get("dir-model-a")).toBeDefined();
+      expect(get("dir-model-b")).toBeDefined();
+      expect(getAll()).toHaveLength(2);
+    });
+
+    it("ignores non-yaml files in the directory", async () => {
+      const dirPath = join(testDir, `dir-${fileIndex++}`);
+      await Bun.write(join(dirPath, "valid.yaml"), makeModelYaml({ "yaml-model": baseModel }));
+      await Bun.write(join(dirPath, "readme.txt"), "not yaml");
+      await Bun.write(join(dirPath, "config.json"), "{}");
+
+      configure(10, undefined, dirPath);
+      await refresh();
+
+      expect(getAll()).toHaveLength(1);
+      expect(get("yaml-model")).toBeDefined();
+    });
+
+    it("skips invalid files and continues loading valid ones", async () => {
+      const dirPath = join(testDir, `dir-${fileIndex++}`);
+      await Bun.write(join(dirPath, "a-bad.yaml"), "someKey: someValue\n");
+      await Bun.write(join(dirPath, "b-good.yaml"), makeModelYaml({ "good-model": baseModel }));
+
+      configure(10, undefined, dirPath);
+      await refresh();
+
+      expect(get("good-model")).toBeDefined();
+      expect(getAll()).toHaveLength(1);
+    });
+
+    it("combines main file and directory models", async () => {
+      const mainYaml = makeModelYaml({ "main-model": baseModel });
+      const mainPath = await writeYamlFile(mainYaml, fileIndex++);
+
+      const dirPath = join(testDir, `dir-${fileIndex++}`);
+      await Bun.write(join(dirPath, "extra.yaml"), makeModelYaml({ "dir-model": embeddingModel }));
+
+      configure(10, mainPath, dirPath);
+      await refresh();
+
+      expect(get("main-model")).toBeDefined();
+      expect(get("dir-model")).toBeDefined();
+      expect(getAll()).toHaveLength(2);
+    });
+
+    it("gracefully handles missing directory", async () => {
+      const mainYaml = makeModelYaml({ "main-model": baseModel });
+      const mainPath = await writeYamlFile(mainYaml, fileIndex++);
+
+      configure(10, mainPath, "/nonexistent/dir/path");
+      await refresh();
+
+      expect(get("main-model")).toBeDefined();
+    });
+  });
+
+  describe("precedence", () => {
+    let includeServer: ReturnType<typeof Bun.serve>;
+
+    afterEach(() => {
+      includeServer?.stop(true);
+    });
+
+    it("local models are not overwritten by remote includes", async () => {
+      const remoteModel = { ...baseModel, name: "Remote Version" };
+      const remoteYaml = makeModelYaml({ "shared-model": remoteModel });
+
+      includeServer = Bun.serve({
+        port: 0,
+        fetch: () => new Response(remoteYaml, { headers: { "Content-Type": "text/yaml" } }),
+      });
+
+      const localModel = { ...baseModel, name: "Local Version" };
+      const localYaml = makeModelYaml(
+        { "shared-model": localModel },
+        [`http://localhost:${includeServer.port}/models.yaml`],
+      );
+      const path = await writeYamlFile(localYaml, fileIndex++);
+      configure(10, path);
+      await refresh();
+
+      expect(get("shared-model")!.name).toBe("Local Version");
+    });
+
+    it("directory files are not overwritten by their own remote includes", async () => {
+      const remoteModel = { ...baseModel, name: "Remote Override" };
+      const remoteYaml = makeModelYaml({ "dir-local": remoteModel });
+
+      includeServer = Bun.serve({
+        port: 0,
+        fetch: () => new Response(remoteYaml, { headers: { "Content-Type": "text/yaml" } }),
+      });
+
+      const dirModel = { ...baseModel, name: "Dir Local" };
+      const dirPath = join(testDir, `dir-${fileIndex++}`);
+      await Bun.write(
+        join(dirPath, "models.yaml"),
+        makeModelYaml({ "dir-local": dirModel }, [`http://localhost:${includeServer.port}/models.yaml`]),
+      );
+
+      configure(10, undefined, dirPath);
+      await refresh();
+
+      expect(get("dir-local")!.name).toBe("Dir Local");
+    });
+  });
+
+  describe("_source tracking", () => {
+    it("tracks source file path for locally loaded models", async () => {
+      const yaml = makeModelYaml({ "tracked-model": baseModel });
+      const path = await writeYamlFile(yaml, fileIndex++);
+      configure(10, path);
+      await refresh();
+
+      expect(get("tracked-model")!._source).toBe(path);
+    });
+
+    it("tracks source URL for remotely included models", async () => {
+      const remoteModel = { ...baseModel, name: "Remote Tracked" };
+      const remoteYaml = makeModelYaml({ "remote-tracked": remoteModel });
+
+      const includeServer = Bun.serve({
+        port: 0,
+        fetch: () => new Response(remoteYaml, { headers: { "Content-Type": "text/yaml" } }),
+      });
+
+      const includeUrl = `http://localhost:${includeServer.port}/models.yaml`;
+      const localYaml = makeModelYaml({ "local-tracked": baseModel }, [includeUrl]);
+      const path = await writeYamlFile(localYaml, fileIndex++);
+      configure(10, path);
+      await refresh();
+
+      expect(get("remote-tracked")!._source).toBe(includeUrl);
+      expect(get("local-tracked")!._source).toBe(path);
+
+      includeServer.stop(true);
+    });
+  });
+
+  describe("catalog health", () => {
+    it("reports model count and refresh time after successful load", async () => {
+      const yaml = makeModelYaml({ "health-model": baseModel });
+      const path = await writeYamlFile(yaml, fileIndex++);
+      configure(10, path);
+      await refresh();
+
+      const health = getCatalogHealth();
+      expect(health.modelCount).toBe(1);
+      expect(health.lastRefreshAt).toBeTruthy();
+      expect(health.lastRefreshError).toBeNull();
+    });
+
+    it("records error message on failed refresh", async () => {
+      const path = await writeYamlFile("someKey: someValue\n", fileIndex++);
+      configure(10, path);
+
+      try { await refresh(); } catch {}
+
+      const health = getCatalogHealth();
+      expect(health.lastRefreshError).toContain("Model file validation failed");
     });
   });
 });

--- a/packages/xinity-infoserver/server-catalog.ts
+++ b/packages/xinity-infoserver/server-catalog.ts
@@ -4,7 +4,7 @@
  * in-memory index for the API endpoints.
  */
 import { type Model, type ModelWithSpecifier, ModelFileDefinitionSchema } from "./definitions/model-definition";
-import { readdirSync } from "node:fs";
+import { readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { rootLogger } from "./logger";
 
@@ -121,7 +121,7 @@ async function loadDirectoryFiles(
 ): Promise<void> {
   let entries: string[];
   try {
-    entries = readdirSync(dirPath)
+    entries = (await readdir(dirPath))
       .filter(f => f.endsWith(".yaml") || f.endsWith(".yml"))
       .sort();
   } catch (err) {

--- a/packages/xinity-infoserver/server-catalog.ts
+++ b/packages/xinity-infoserver/server-catalog.ts
@@ -4,6 +4,8 @@
  * in-memory index for the API endpoints.
  */
 import { type Model, type ModelWithSpecifier, ModelFileDefinitionSchema } from "./definitions/model-definition";
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
 import { rootLogger } from "./logger";
 
 const log = rootLogger.child({ name: "catalog" });
@@ -15,14 +17,16 @@ let providerModelIndex = new Map<string, string>();
 let mergedData: { models: Record<string, Model> } = { models: {} };
 let refreshTimer: ReturnType<typeof setInterval> | null = null;
 
-let configuredFilePath: string;
+let configuredFilePath: string | undefined;
 let configuredMaxDepth: number;
+let configuredDirPath: string | undefined;
 
 // ── Init ───────────────────────────────────────────────────────────────
 
-export function configure(modelFilePath: string, maxIncludeDepth = 10) {
+export function configure(maxIncludeDepth = 10, modelFilePath?: string, modelDirPath?: string) {
   configuredFilePath = modelFilePath;
   configuredMaxDepth = maxIncludeDepth;
+  configuredDirPath = modelDirPath;
 }
 
 // ── Refresh ────────────────────────────────────────────────────────────
@@ -36,18 +40,25 @@ export async function refresh(): Promise<void> {
   const newProviderIndex = new Map<string, string>();
   const newMerged: Record<string, Model> = {};
 
-  const yamlText = await Bun.file(configuredFilePath).text();
-  const yamlData = Bun.YAML.parse(yamlText);
-  const { success, data } = ModelFileDefinitionSchema.safeParse(yamlData);
-  if (!success) {
-    throw new Error("Failed to validate model file during refresh");
+  const visited = new Set<string>();
+
+  if (configuredFilePath) {
+    const yamlText = await Bun.file(configuredFilePath).text();
+    const yamlData = Bun.YAML.parse(yamlText);
+    const { success, data } = ModelFileDefinitionSchema.safeParse(yamlData);
+    if (!success) {
+      throw new Error("Failed to validate model file during refresh");
+    }
+
+    indexModels(data.models, newModels, newProviderIndex, newMerged);
+
+    for (const includeUrl of data.includes ?? []) {
+      await resolveIncludes(includeUrl, visited, 0, newModels, newProviderIndex, newMerged);
+    }
   }
 
-  indexModels(data.models, newModels, newProviderIndex, newMerged);
-
-  const visited = new Set<string>();
-  for (const includeUrl of data.includes ?? []) {
-    await resolveIncludes(includeUrl, visited, 0, newModels, newProviderIndex, newMerged);
+  if (configuredDirPath) {
+    await loadDirectoryFiles(configuredDirPath, visited, newModels, newProviderIndex, newMerged);
   }
 
   // Atomic swap
@@ -98,6 +109,51 @@ async function resolveIncludes(
     }
   } catch (err) {
     log.warn({ url, err }, "Include fetch error");
+  }
+}
+
+async function loadDirectoryFiles(
+  dirPath: string,
+  visited: Set<string>,
+  models: Map<string, ModelWithSpecifier>,
+  providerIndex: Map<string, string>,
+  merged: Record<string, Model>,
+): Promise<void> {
+  let entries: string[];
+  try {
+    entries = readdirSync(dirPath)
+      .filter(f => f.endsWith(".yaml") || f.endsWith(".yml"))
+      .sort();
+  } catch (err) {
+    log.warn({ dirPath, err }, "Could not read model info directory, skipping");
+    return;
+  }
+
+  if (entries.length === 0) {
+    log.debug({ dirPath }, "Model info directory is empty");
+    return;
+  }
+
+  for (const filename of entries) {
+    const filePath = join(dirPath, filename);
+    try {
+      const yamlText = await Bun.file(filePath).text();
+      const yamlData = Bun.YAML.parse(yamlText);
+      const { success, data } = ModelFileDefinitionSchema.safeParse(yamlData);
+      if (!success) {
+        log.warn({ filePath }, "Model file validation failed, skipping");
+        continue;
+      }
+
+      log.info({ filePath, modelCount: Object.keys(data.models).length }, "Loaded model file from directory");
+      indexModels(data.models, models, providerIndex, merged);
+
+      for (const includeUrl of data.includes ?? []) {
+        await resolveIncludes(includeUrl, visited, 0, models, providerIndex, merged);
+      }
+    } catch (err) {
+      log.warn({ filePath, err }, "Failed to load model file from directory, skipping");
+    }
   }
 }
 

--- a/packages/xinity-infoserver/server-catalog.ts
+++ b/packages/xinity-infoserver/server-catalog.ts
@@ -165,10 +165,15 @@ function indexModels(
 ): void {
   for (const [specifier, model] of Object.entries(source)) {
     if (map.has(specifier)) {
-      log.warn({ specifier }, "Duplicate model specifier, overwriting with later entry");
+      if (localSpecifiers.has(specifier) && !isLocal) {
+        log.debug({ specifier, source: sourceLabel }, "Remote model skipped: local entry takes precedence");
+        continue;
+      }
+      const existing = map.get(specifier)!;
+      log.warn({ specifier, existingSource: existing._source, newSource: sourceLabel }, "Duplicate model specifier, overwriting");
     }
 
-    const entry: ModelWithSpecifier = { publicSpecifier: specifier, ...model };
+    const entry: ModelWithSpecifier = { publicSpecifier: specifier, _source: sourceLabel, ...model };
     map.set(specifier, entry);
     merged[specifier] = model;
 

--- a/packages/xinity-infoserver/server-catalog.ts
+++ b/packages/xinity-infoserver/server-catalog.ts
@@ -21,6 +21,9 @@ let configuredFilePath: string | undefined;
 let configuredMaxDepth: number;
 let configuredDirPath: string | undefined;
 
+let lastRefreshAt: Date | null = null;
+let lastRefreshError: string | null = null;
+
 // ── Init ───────────────────────────────────────────────────────────────
 
 export function configure(maxIncludeDepth = 10, modelFilePath?: string, modelDirPath?: string) {
@@ -39,32 +42,39 @@ export async function refresh(): Promise<void> {
   const newModels = new Map<string, ModelWithSpecifier>();
   const newProviderIndex = new Map<string, string>();
   const newMerged: Record<string, Model> = {};
-
+  const localSpecifiers = new Set<string>();
   const visited = new Set<string>();
 
-  if (configuredFilePath) {
-    const yamlText = await Bun.file(configuredFilePath).text();
-    const yamlData = Bun.YAML.parse(yamlText);
-    const { success, data } = ModelFileDefinitionSchema.safeParse(yamlData);
-    if (!success) {
-      throw new Error("Failed to validate model file during refresh");
+  try {
+    if (configuredFilePath) {
+      const yamlText = await Bun.file(configuredFilePath).text();
+      const yamlData = Bun.YAML.parse(yamlText);
+      const result = ModelFileDefinitionSchema.safeParse(yamlData);
+      if (!result.success) {
+        throw new Error(`Model file validation failed (${configuredFilePath}): ${result.error.message}`);
+      }
+
+      indexModels(result.data.models, newModels, newProviderIndex, newMerged, configuredFilePath, true, localSpecifiers);
+
+      for (const includeUrl of result.data.includes ?? []) {
+        await resolveIncludes(includeUrl, visited, 0, newModels, newProviderIndex, newMerged, localSpecifiers);
+      }
     }
 
-    indexModels(data.models, newModels, newProviderIndex, newMerged);
-
-    for (const includeUrl of data.includes ?? []) {
-      await resolveIncludes(includeUrl, visited, 0, newModels, newProviderIndex, newMerged);
+    if (configuredDirPath) {
+      await loadDirectoryFiles(configuredDirPath, visited, newModels, newProviderIndex, newMerged, localSpecifiers);
     }
-  }
 
-  if (configuredDirPath) {
-    await loadDirectoryFiles(configuredDirPath, visited, newModels, newProviderIndex, newMerged);
+    // Atomic swap
+    modelData = newModels;
+    providerModelIndex = newProviderIndex;
+    mergedData = { models: newMerged };
+    lastRefreshAt = new Date();
+    lastRefreshError = null;
+  } catch (err) {
+    lastRefreshError = err instanceof Error ? err.message : String(err);
+    throw err;
   }
-
-  // Atomic swap
-  modelData = newModels;
-  providerModelIndex = newProviderIndex;
-  mergedData = { models: newMerged };
 }
 
 async function resolveIncludes(
@@ -74,6 +84,7 @@ async function resolveIncludes(
   models: Map<string, ModelWithSpecifier>,
   providerIndex: Map<string, string>,
   merged: Record<string, Model>,
+  localSpecifiers: Set<string>,
 ): Promise<void> {
   if (depth >= configuredMaxDepth) {
     log.warn({ url, maxDepth: configuredMaxDepth }, "Max include depth reached, skipping");
@@ -96,16 +107,16 @@ async function resolveIncludes(
 
     const text = await response.text();
     const yamlData = Bun.YAML.parse(text);
-    const { success, data } = ModelFileDefinitionSchema.safeParse(yamlData);
-    if (!success) {
-      log.warn({ url }, "Include validation failed");
+    const result = ModelFileDefinitionSchema.safeParse(yamlData);
+    if (!result.success) {
+      log.warn({ url, issues: result.error.issues }, "Include validation failed");
       return;
     }
 
-    indexModels(data.models, models, providerIndex, merged);
+    indexModels(result.data.models, models, providerIndex, merged, url, false, localSpecifiers);
 
-    for (const nestedUrl of data.includes ?? []) {
-      await resolveIncludes(nestedUrl, visited, depth + 1, models, providerIndex, merged);
+    for (const nestedUrl of result.data.includes ?? []) {
+      await resolveIncludes(nestedUrl, visited, depth + 1, models, providerIndex, merged, localSpecifiers);
     }
   } catch (err) {
     log.warn({ url, err }, "Include fetch error");
@@ -118,6 +129,7 @@ async function loadDirectoryFiles(
   models: Map<string, ModelWithSpecifier>,
   providerIndex: Map<string, string>,
   merged: Record<string, Model>,
+  localSpecifiers: Set<string>,
 ): Promise<void> {
   let entries: string[];
   try {
@@ -139,17 +151,17 @@ async function loadDirectoryFiles(
     try {
       const yamlText = await Bun.file(filePath).text();
       const yamlData = Bun.YAML.parse(yamlText);
-      const { success, data } = ModelFileDefinitionSchema.safeParse(yamlData);
-      if (!success) {
-        log.warn({ filePath }, "Model file validation failed, skipping");
+      const result = ModelFileDefinitionSchema.safeParse(yamlData);
+      if (!result.success) {
+        log.warn({ filePath, issues: result.error.issues }, "Model file validation failed, skipping");
         continue;
       }
 
-      log.info({ filePath, modelCount: Object.keys(data.models).length }, "Loaded model file from directory");
-      indexModels(data.models, models, providerIndex, merged);
+      log.info({ filePath, modelCount: Object.keys(result.data.models).length }, "Loaded model file from directory");
+      indexModels(result.data.models, models, providerIndex, merged, filePath, true, localSpecifiers);
 
-      for (const includeUrl of data.includes ?? []) {
-        await resolveIncludes(includeUrl, visited, 0, models, providerIndex, merged);
+      for (const includeUrl of result.data.includes ?? []) {
+        await resolveIncludes(includeUrl, visited, 0, models, providerIndex, merged, localSpecifiers);
       }
     } catch (err) {
       log.warn({ filePath, err }, "Failed to load model file from directory, skipping");
@@ -162,6 +174,9 @@ function indexModels(
   map: Map<string, ModelWithSpecifier>,
   providerIndex: Map<string, string>,
   merged: Record<string, Model>,
+  sourceLabel: string,
+  isLocal: boolean,
+  localSpecifiers: Set<string>,
 ): void {
   for (const [specifier, model] of Object.entries(source)) {
     if (map.has(specifier)) {
@@ -176,6 +191,8 @@ function indexModels(
     const entry: ModelWithSpecifier = { publicSpecifier: specifier, _source: sourceLabel, ...model };
     map.set(specifier, entry);
     merged[specifier] = model;
+
+    if (isLocal) localSpecifiers.add(specifier);
 
     for (const providerModel of Object.values(model.providers)) {
       if (providerModel) {
@@ -235,4 +252,12 @@ export function stopAutoRefresh(): void {
     clearInterval(refreshTimer);
     refreshTimer = null;
   }
+}
+
+export function getCatalogHealth() {
+  return {
+    modelCount: modelData.size,
+    lastRefreshAt: lastRefreshAt?.toISOString() ?? null,
+    lastRefreshError,
+  };
 }

--- a/packages/xinity-infoserver/server.ts
+++ b/packages/xinity-infoserver/server.ts
@@ -20,7 +20,10 @@ catalog.startAutoRefresh(env.REFRESH_INTERVAL_MS);
 const server = Bun.serve({
   port,
   routes: {
-    "/health": Response.json({ ok: true }),
+    "/health": () => {
+      const health = catalog.getCatalogHealth();
+      return Response.json({ ok: health.modelCount > 0, catalog: health });
+    },
     "/version.json": Response.json({ version }),
     "/models/v1.yaml": () => new Response(Bun.YAML.stringify(catalog.getMergedData()), {
       headers: { "Content-Type": "application/yaml" },

--- a/packages/xinity-infoserver/server.ts
+++ b/packages/xinity-infoserver/server.ts
@@ -10,7 +10,11 @@ const modelDir = env.MODEL_INFO_DIR;
 const port = env.PORT;
 
 if (!modelFile && !modelDir) {
-  throw new Error("At least one of MODEL_INFO_FILE or MODEL_INFO_DIR must be set");
+  throw new Error("MODEL_INFO_DIR must be set (or the deprecated MODEL_INFO_FILE)");
+}
+
+if (modelFile) {
+  rootLogger.warn("MODEL_INFO_FILE is deprecated and will be removed in 1.0.0. Migrate to MODEL_INFO_DIR instead");
 }
 
 catalog.configure(env.MAX_INCLUDE_DEPTH, modelFile, modelDir);

--- a/packages/xinity-infoserver/server.ts
+++ b/packages/xinity-infoserver/server.ts
@@ -6,9 +6,14 @@ import * as catalog from "./server-catalog";
 import { handleModelList, handleModelsByFamily, handleModelBySpecifier, handleBatchResolve } from "./api-handlers";
 
 const modelFile = env.MODEL_INFO_FILE;
+const modelDir = env.MODEL_INFO_DIR;
 const port = env.PORT;
 
-catalog.configure(modelFile, env.MAX_INCLUDE_DEPTH);
+if (!modelFile && !modelDir) {
+  throw new Error("At least one of MODEL_INFO_FILE or MODEL_INFO_DIR must be set");
+}
+
+catalog.configure(env.MAX_INCLUDE_DEPTH, modelFile, modelDir);
 await catalog.refresh();
 catalog.startAutoRefresh(env.REFRESH_INTERVAL_MS);
 

--- a/tests/system/infoserver/infoserver.test.ts
+++ b/tests/system/infoserver/infoserver.test.ts
@@ -14,8 +14,12 @@ describe("xinity-infoserver", () => {
   it("responds with health status", async () => {
     const res = await fetch(infoServerUrl("/health"));
     expect(res.ok).toBe(true);
-    const body = await res.json();
-    expect(body).toEqual({ ok: true });
+    const body = await res.json() as any;
+    expect(body.ok).toBe(true);
+    expect(body.catalog).toBeDefined();
+    expect(body.catalog.modelCount).toBeGreaterThanOrEqual(0);
+    expect(body.catalog.lastRefreshAt).toBeTruthy();
+    expect(body.catalog.lastRefreshError).toBeNull();
   });
 
   it("returns the current version", async () => {


### PR DESCRIPTION
## Description

Add support for loading model definitions from a directory (`MODEL_INFO_DIR`) alongside the existing single-file path (`MODEL_INFO_FILE`). Either or both may be configured. Also hardens the catalog with local-over-remote precedence, source tracking, async I/O, better validation errors, and a richer health endpoint.
`MODEL_INFO_FILE` was marked as deprecated, to be removed in version 1.0.0 

## Type of change

New feature

## Testing

- Fixed all existing server-catalog tests (14 were broken due to configure() signature change)
- Added 11 new tests covering: directory loading (4), local-over-remote precedence (2), _source tracking (2), catalog health (2), client fixture update (1)
- Full infoserver suite passes: 101 tests, 0 failures

## Checklist

- [x] Tests pass locally (`bun test`), or no testable code was changed
- [x] New or changed behavior is covered by tests, or this change does not require tests
- [x] Documentation is updated, or no user-facing behavior or configuration was changed
- [x] There are no breaking changes, or they are marked with `!` in the commit type and described above
- [x] No security-sensitive changes (authentication, credentials, input handling), or they have been reviewed
- [x] No new dependencies were added, or they have been reviewed for license and maintenance status