### PR TITLE
docs: generation of documentation for nixos options

### DIFF
--- a/nix/modules/default.nix
+++ b/nix/modules/default.nix
@@ -1,5 +1,7 @@
 {
   imports = [
+    ./docs.mod.nix
+
     ./xinity-ai-database.mod.nix
     ./xinity-ai-daemon.mod.nix
     ./xinity-ai-gateway.mod.nix

--- a/nix/modules/docs.mod.nix
+++ b/nix/modules/docs.mod.nix
@@ -1,0 +1,59 @@
+{lib, self,...}: {
+  perSystem = { pkgs, self', inputs', ... }:
+    {
+      packages.options-doc = let
+        nixosStub = ({ lib, ... }: {
+              options = {
+                assertions = lib.mkOption {
+                  type = lib.types.listOf lib.types.unspecified;
+                  default = [];
+                  internal = true;
+                };
+                systemd = lib.mkOption {
+                  type = lib.types.attrsOf lib.types.unspecified;
+                  default = {};
+                  internal = true;
+                };
+                virtualisation.oci-containers.containers = lib.mkOption {
+                  type = lib.types.attrsOf lib.types.unspecified;
+                  default = {};
+                  internal = true;
+                };
+                networking = lib.mkOption {
+                  type = lib.types.attrsOf lib.types.unspecified;
+                  default = {};
+                  internal = true;
+                };
+                # External NixOS services our modules configure
+                services.caddy = lib.mkOption { type = lib.types.unspecified; default = {}; internal = true; };
+                services.postgresql = lib.mkOption { type = lib.types.unspecified; default = {}; internal = true; };
+                services.redis = lib.mkOption { type = lib.types.unspecified; default = {}; internal = true; };
+                services.searx = lib.mkOption { type = lib.types.unspecified; default = {}; internal = true; };
+                services.ollama = lib.mkOption { type = lib.types.unspecified; default = {}; internal = true; };
+              };
+            });
+        eval = lib.evalModules {
+          specialArgs = { inherit pkgs self; inherit (self) inputs; withSystem = _: _: {}; };
+          modules = with self.nixosModules; [
+            gateway
+            dashboard
+            database
+            daemon
+            infoserver
+            # caddy
+            # searxng
+            # allinone
+            # seaweedfs
+            # server
+            nixosStub
+          ];
+        };
+        optionsDoc = pkgs.nixosOptionsDoc {
+          options = builtins.removeAttrs eval.options [ "_module" ];
+          transformOptions = opt: opt // {
+            declarations = builtins.filter (d: lib.hasPrefix "xinity" (toString d)) opt.declarations;
+          };
+        };
+      in optionsDoc.optionsJSON;
+    };
+}

--- a/nix/modules/xinity-ai-allinone.mod.nix
+++ b/nix/modules/xinity-ai-allinone.mod.nix
@@ -18,16 +18,16 @@
         else "localhost:${toString config.services.xinity-infoserver.port}";
     in {
       options.services.xinity-ai-caddy = {
-        enable = lib.mkEnableOption "Caddy reverse proxy for xinity-ai services";
+        enable = lib.mkEnableOption "a Caddy reverse proxy that terminates TLS via ACME/Let's Encrypt and routes traffic to the xinity-ai dashboard, gateway, and infoserver by subdomain";
 
         domain = lib.mkOption {
           type = lib.types.str;
-          description = "Base domain (e.g. example.com). Subdomains are derived from this.";
+          description = "Base domain for the xinity-ai deployment (e.g. example.com). Each service gets a subdomain: dashboard.example.com, api.example.com, etc.";
         };
 
         acmeEmail = lib.mkOption {
           type = lib.types.str;
-          description = "Email address for ACME / Let's Encrypt certificate registration.";
+          description = "Email address registered with ACME/Let's Encrypt for certificate expiry notifications and account recovery.";
         };
 
         dashboardSubdomain = lib.mkOption {
@@ -109,18 +109,18 @@
       cfg = config.services.xinity-ai-searxng;
     in {
       options.services.xinity-ai-searxng = {
-        enable = lib.mkEnableOption "SearXNG web search engine for xinity-ai";
+        enable = lib.mkEnableOption "a bundled SearXNG metasearch engine instance that the gateway uses for web-search-augmented generation";
 
         port = lib.mkOption {
           type = lib.types.port;
           default = 8888;
-          description = "Port SearXNG listens on.";
+          description = "HTTP port SearXNG listens on. The gateway connects to this port to perform web searches.";
         };
 
         host = lib.mkOption {
           type = lib.types.str;
           default = "127.0.0.1";
-          description = "Address SearXNG binds to.";
+          description = "Address SearXNG binds to. Use 127.0.0.1 to restrict access to localhost (recommended when behind the gateway), or 0.0.0.0 to allow external access.";
         };
 
         secretKey = lib.mkOption {
@@ -146,7 +146,7 @@
         extraSettings = lib.mkOption {
           type = lib.types.attrs;
           default = { };
-          description = "Additional SearXNG settings (deep-merged into the configuration).";
+          description = "Additional SearXNG settings deep-merged into the generated configuration. Use this to enable/disable search engines, configure rate limiting, or adjust result formatting.";
         };
       };
 
@@ -184,16 +184,16 @@
       ];
 
       options.services.xinity-ai = {
-        enable = lib.mkEnableOption "xinity-ai all-in-one deployment (PostgreSQL, Redis, gateway, dashboard, infoserver, Caddy)";
+        enable = lib.mkEnableOption "the xinity-ai all-in-one deployment, which provisions and wires together all services (PostgreSQL, Redis, gateway, dashboard, infoserver, Caddy, and optionally SearXNG and SeaweedFS) on a single machine with sensible defaults";
 
         domain = lib.mkOption {
           type = lib.types.str;
-          description = "Base domain (e.g. example.com). Caddy will handle HTTPS for *.domain.";
+          description = "Base domain for the deployment (e.g. example.com). Caddy provisions TLS certificates and routes traffic for each service's subdomain under this domain.";
         };
 
         acmeEmail = lib.mkOption {
           type = lib.types.str;
-          description = "Email for ACME/Let's Encrypt certificates.";
+          description = "Email address registered with ACME/Let's Encrypt for certificate expiry notifications. Forwarded to the Caddy module.";
         };
 
         dashboardSubdomain = lib.mkOption {
@@ -250,7 +250,7 @@
           backendTimeoutMs = lib.mkOption {
             type = lib.types.int;
             default = 300000;
-            description = "Maximum time in ms to wait for a backend response.";
+            description = "Maximum time in milliseconds to wait for an inference backend to respond. Forwarded to the gateway module.";
           };
         };
 
@@ -268,7 +268,7 @@
           licenseKey = lib.mkOption {
             type = lib.types.nullOr lib.types.str;
             default = null;
-            description = "License key (WARNING: exposes in Nix store, prefer secrets.licenseKeyFile).";
+            description = "License key for unlocking paid features (Ed25519-signed token). WARNING: exposes the key in the Nix store. Prefer secrets.licenseKeyFile for production.";
           };
         };
 
@@ -307,7 +307,7 @@
           enable = lib.mkOption {
             type = lib.types.bool;
             default = true;
-            description = "Enable the bundled SearXNG instance for web search.";
+            description = "Enable the bundled SearXNG metasearch engine. When enabled, the gateway automatically uses it for web-search-augmented generation.";
           };
           port = lib.mkOption {
             type = lib.types.port;
@@ -320,7 +320,7 @@
           enable = lib.mkOption {
             type = lib.types.bool;
             default = false;
-            description = "Enable the bundled SeaweedFS instance for S3-compatible object storage.";
+            description = "Enable the bundled SeaweedFS instance for S3-compatible object storage. When enabled, the gateway and dashboard automatically use it for media uploads.";
           };
           s3Port = lib.mkOption {
             type = lib.types.port;
@@ -330,14 +330,14 @@
           s3Config = lib.mkOption {
             type = lib.types.nullOr lib.types.str;
             default = null;
-            description = "Path to S3 access config JSON for SeaweedFS.";
+            description = "Path to an S3 configuration JSON file defining access keys and permissions for SeaweedFS. When null, anonymous S3 access is allowed.";
           };
         };
 
         containerUid = lib.mkOption {
           type = lib.types.int;
           default = 6000;
-          description = "UID (and GID) the container processes run as. Secret files passed via *File options must be readable by this UID.";
+          description = "UID and GID the OCI container processes (gateway, dashboard, infoserver) run as. Secret files passed via the secrets.*File options must be readable by this UID on the host.";
         };
 
         # --- Secret file options (recommended for production) ---
@@ -411,7 +411,7 @@
         migrateOnStart = lib.mkOption {
           type = lib.types.bool;
           default = true;
-          description = "Run database migrations automatically before starting services.";
+          description = "Run Drizzle database migrations automatically at boot before starting the gateway and dashboard. Disable this if you manage schema migrations out-of-band.";
         };
 
       };

--- a/nix/modules/xinity-ai-daemon.mod.nix
+++ b/nix/modules/xinity-ai-daemon.mod.nix
@@ -1,6 +1,5 @@
 { withSystem, self, inputs, ... }: {
-  flake.nixosModules.default = self.nixosModules.server;
-  flake.nixosModules.server = { config, lib, pkgs, ... }:
+  flake.nixosModules.daemon = { config, lib, pkgs, ... }:
     let
       withHostSystem = withSystem pkgs.stdenv.hostPlatform.system;
       cfg = config.services.xinity-ai-daemon;
@@ -258,7 +257,7 @@
   flake.nixosConfigurations.container = inputs.nixpkgs.lib.nixosSystem {
     system = "x86_64-linux";
     modules = [
-      self.nixosModules.server
+      self.nixosModules.daemon
       {
         services.xinity-ai-daemon.enable = true;
         services.xinity-ai-daemon.envFiles = [ "/etc/.env" ];

--- a/nix/modules/xinity-ai-daemon.mod.nix
+++ b/nix/modules/xinity-ai-daemon.mod.nix
@@ -8,17 +8,17 @@
     in {
 
       options.services.xinity-ai-daemon = {
-        enable = lib.mkEnableOption "Enable xinity-ai-daemon service";
+        enable = lib.mkEnableOption "the xinity-ai daemon, a systemd service that manages local inference backends (Ollama, vLLM), registers the node with the gateway, and handles model lifecycle operations";
         package = lib.mkOption {
           type = lib.types.package;
 
           default = withHostSystem
             ({ config, ... }: config.packages.xinity-ai-daemon);
-          description = "The package providing the service derivation.";
+          description = "The xinity-ai-daemon package to use. Defaults to the package built from this flake for the current platform.";
         };
         envFiles = lib.mkOption {
           type = lib.types.listOf lib.types.str;
-          description = "Environment files for xinity-ai-daemon (e.g. for DB_CONNECTION_URL).";
+          description = "List of systemd EnvironmentFile paths loaded at service start. This is the recommended way to inject secrets like DB_CONNECTION_URL without exposing them in the Nix store.";
           default = [ ];
         };
 
@@ -35,49 +35,49 @@
         dbConnectionUrlFile = lib.mkOption {
           type = lib.types.nullOr lib.types.str;
           default = null;
-          description = "Path to a file containing the PostgreSQL connection URL. Uses systemd LoadCredential for secure access.";
+          description = "Path to a file containing the PostgreSQL connection URL. The file is loaded via systemd's LoadCredential mechanism and exposed to the daemon as DB_CONNECTION_URL_FILE. This is more secure than dbConnectionUrl as the secret never enters the Nix store.";
         };
 
         port = lib.mkOption {
           type = lib.types.port;
-          description = "Port for xinity-ai-daemon.";
+          description = "HTTP port the daemon API listens on. The gateway connects to this port to forward inference requests and manage models.";
           default = 4010;
         };
 
         host = lib.mkOption {
           type = lib.types.str;
           default = "0.0.0.0";
-          description = "Host address the daemon binds to.";
+          description = "Host address the daemon binds to. Use 0.0.0.0 to accept connections on all interfaces, or 127.0.0.1 to restrict to localhost.";
         };
 
         infoserverUrl = lib.mkOption {
           type = lib.types.nullOr lib.types.str;
           default = null;
-          description = "URL of the xinity-infoserver instance.";
+          description = "URL of the xinity-infoserver instance. The daemon uses this to fetch model definitions and report its own status.";
         };
 
         infoserverCacheTtlMs = lib.mkOption {
           type = lib.types.int;
           default = 30000;
-          description = "How long to cache infoserver responses locally (ms).";
+          description = "Duration in milliseconds to cache responses from the infoserver locally. Reduces repeated network calls when the daemon checks model definitions.";
         };
 
         stateDir = lib.mkOption {
           type = lib.types.str;
           default = "/var/lib/xinity-ai-daemon";
-          description = "Local state directory for the daemon.";
+          description = "Directory where the daemon persists local state such as model installation status and runtime metadata. Created automatically via systemd StateDirectory.";
         };
 
         cidrPrefix = lib.mkOption {
           type = lib.types.str;
           default = "";
-          description = "Network CIDR prefix.";
+          description = "Network CIDR prefix used to determine the daemon's advertised IP address when registering with the gateway. The daemon selects the first local address matching this prefix. Leave empty to use the default route address.";
         };
 
         syncIntervalMs = lib.mkOption {
           type = lib.types.int;
           default = 300000;
-          description = "Sync interval in milliseconds.";
+          description = "Interval in milliseconds between sync cycles. During each cycle the daemon re-registers with the gateway, reports GPU/model health, and reconciles desired model state.";
         };
 
         # --- Ollama settings ---
@@ -85,7 +85,7 @@
         ollamaEndpoint = lib.mkOption {
           type = lib.types.nullOr lib.types.str;
           default = null;
-          description = "Ollama API endpoint (enables ollama driver). If null and services.ollama is enabled, derived automatically.";
+          description = "Ollama API endpoint URL (e.g. http://127.0.0.1:11434). Setting this enables the Ollama inference driver. If left null and the NixOS services.ollama module is enabled, the endpoint is derived automatically from its host and port settings.";
         };
 
         # --- vLLM settings ---
@@ -93,61 +93,63 @@
         vllmBackend = lib.mkOption {
           type = lib.types.enum [ "systemd" "docker" ];
           default = "systemd";
-          description = "vLLM backend type.";
+          description = ''
+            How vLLM instances are managed. "systemd" launches vLLM as systemd template units (requires vllmPath). "docker" runs vLLM in OCI containers (requires vllmDockerImage).
+          '';
         };
 
         vllmEnvDir = lib.mkOption {
           type = lib.types.str;
           default = "/etc/vllm";
-          description = "vLLM environment config directory.";
+          description = "Directory containing per-model environment files for vLLM. Each file is named after the model and contains environment variable overrides (e.g. GPU_MEMORY_UTILIZATION, TENSOR_PARALLEL_SIZE).";
         };
 
         vllmTemplateUnitPath = lib.mkOption {
           type = lib.types.str;
           default = "/etc/systemd/system/vllm-driver@.service";
-          description = "vLLM systemd template unit path.";
+          description = "Path to the vLLM systemd template unit file (vllm-driver@.service). The daemon instantiates this template for each model it manages.";
         };
 
         vllmPath = lib.mkOption {
           type = lib.types.nullOr lib.types.str;
           default = null;
-          description = "Path to vllm binary (enables vllm-systemd driver).";
+          description = "Absolute path to the vllm binary. Setting this enables the vllm-systemd driver. Required when vllmBackend is set to \"systemd\".";
         };
 
         vllmDockerImage = lib.mkOption {
           type = lib.types.nullOr lib.types.str;
           default = null;
-          description = "vLLM Docker image (enables vllm-docker driver).";
+          description = "OCI image reference for vLLM (e.g. vllm/vllm-openai:latest). Setting this enables the vllm-docker driver. Required when vllmBackend is set to \"docker\".";
         };
 
         vllmHfCacheDir = lib.mkOption {
           type = lib.types.str;
           default = "/var/lib/vllm/hf-cache";
-          description = "HuggingFace cache directory for vLLM.";
+          description = "Directory where vLLM caches downloaded HuggingFace model weights. Shared across all vLLM instances to avoid redundant downloads.";
         };
 
         vllmTritonCacheDir = lib.mkOption {
           type = lib.types.str;
           default = "/var/lib/vllm/triton-cache";
-          description = "Triton cache directory for vLLM.";
+          description = "Directory where vLLM stores compiled Triton GPU kernels. Persisting this cache avoids recompilation on service restarts.";
         };
 
         vllmHealthTimeoutMs = lib.mkOption {
           type = lib.types.int;
           default = 3600000;
-          description = "vLLM health check timeout in milliseconds.";
+          description = "Maximum time in milliseconds to wait for a newly started vLLM instance to become healthy. Large models on slow storage may need a higher value as weight loading can take significant time.";
         };
 
         vllmHealthPollIntervalMs = lib.mkOption {
           type = lib.types.int;
           default = 5000;
-          description = "vLLM health check poll interval in milliseconds.";
+          description = "Interval in milliseconds between health check polls while waiting for a vLLM instance to become ready.";
         };
 
         vllmMaxRestartCount = lib.mkOption {
           type = lib.types.int;
           default = 3;
-          description = "Max container restarts before marking installation as permanently failed.";
+          description = "Maximum number of times a vLLM container is restarted after a crash before the daemon marks the model installation as permanently failed and stops retrying.";
         };
 
         # --- TLS ---
@@ -169,19 +171,19 @@
         logLevel = lib.mkOption {
           type = lib.types.enum [ "fatal" "error" "warn" "info" "debug" "trace" ];
           default = "info";
-          description = "Pino log level.";
+          description = "Pino log level. Controls the verbosity of structured JSON logs emitted by the daemon.";
         };
 
         logDir = lib.mkOption {
           type = lib.types.nullOr lib.types.str;
           default = null;
-          description = "Directory for log files. If null, only stdout logging is used.";
+          description = "Directory for persistent log files. When set, the daemon writes structured JSON logs to this directory in addition to stdout/journald. If null, only stdout logging is used.";
         };
 
         extraEnvironment = lib.mkOption {
           type = lib.types.attrsOf lib.types.str;
           default = { };
-          description = "Additional environment variables to pass to the service.";
+          description = "Additional environment variables passed to the systemd service. Use this for driver-specific tuning or feature flags not covered by dedicated options.";
         };
       };
 

--- a/nix/modules/xinity-ai-dashboard.mod.nix
+++ b/nix/modules/xinity-ai-dashboard.mod.nix
@@ -7,18 +7,18 @@ in {
       cfg = config.services.xinity-ai-dashboard;
     in {
       options.services.xinity-ai-dashboard = {
-        enable = lib.mkEnableOption "xinity-ai-dashboard OCI container";
+        enable = lib.mkEnableOption "the xinity-ai dashboard, a SvelteKit web application that provides the admin UI for managing organizations, API keys, model routing, and user accounts";
 
         image = lib.mkOption {
           type = lib.types.str;
           default = "ghcr.io/xinity-ai/xinity-ai-dashboard:${version}";
-          description = "OCI image for the dashboard.";
+          description = "OCI image reference for the dashboard container. Override this to pin a specific version or use a private registry.";
         };
 
         port = lib.mkOption {
           type = lib.types.port;
           default = 5121;
-          description = "Port the dashboard listens on.";
+          description = "HTTP port the dashboard listens on inside the container. This port is also published to the host.";
         };
 
         # --- Required settings ---
@@ -46,25 +46,25 @@ in {
         betterAuthUrl = lib.mkOption {
           type = lib.types.nullOr lib.types.str;
           default = null;
-          description = "Public URL of the auth service (e.g. https://dashboard.example.com).";
+          description = "Public URL of the auth service (e.g. https://dashboard.example.com). Used by Better Auth for OAuth callbacks and session cookie domains.";
         };
 
         origin = lib.mkOption {
           type = lib.types.str;
           default = "http://localhost:5173";
-          description = "Allowed origin for CORS / SvelteKit ORIGIN.";
+          description = "Allowed origin for CORS headers and SvelteKit's ORIGIN check. Must match the URL users visit in their browser, including the scheme (e.g. https://dashboard.example.com).";
         };
 
         infoserverUrl = lib.mkOption {
           type = lib.types.nullOr lib.types.str;
           default = "https://sysinfo.xinity.at";
-          description = "URL of the xinity-infoserver instance.";
+          description = "Internal URL of the xinity-infoserver instance. The dashboard uses this server-side to fetch available model information.";
         };
 
-        publicLlmApiUrl = lib.mkOption {  
+        publicLlmApiUrl = lib.mkOption {
           type = lib.types.str;
           default = "http://localhost:4121";
-          description = "Gateway base URL shown to users in docs and code examples (GATEWAY_URL).";
+          description = "Public-facing gateway base URL shown to users in documentation and code examples. This is the URL end-users will use in their API clients to reach the LLM gateway.";
         };
 
         # --- Optional settings ---
@@ -78,55 +78,55 @@ in {
         signupEnabled = lib.mkOption {
           type = lib.types.bool;
           default = true;
-          description = "Whether user self-registration is enabled.";
+          description = "Whether user self-registration is enabled. When disabled, only existing users or those invited by an admin can sign in.";
         };
 
         computeManagementEnabled = lib.mkOption {
           type = lib.types.bool;
           default = true;
-          description = "Enable compute management features.";
+          description = "Enable the compute management UI, which allows administrators to register, monitor, and manage inference nodes directly from the dashboard.";
         };
 
         notificationsEnabled = lib.mkOption {
           type = lib.types.bool;
           default = true;
-          description = "Enable the notification scheduler.";
+          description = "Enable the background notification scheduler that sends email alerts for events such as usage limits, node health changes, and system announcements.";
         };
 
         multiTenantMode = lib.mkOption {
           type = lib.types.bool;
           default = false;
-          description = "Allow any authenticated user to create organizations.";
+          description = "When enabled, any authenticated user can create new organizations. When disabled, only instance administrators can create organizations, and regular users must be invited.";
         };
 
         infoserverCacheTtlMs = lib.mkOption {
           type = lib.types.int;
           default = 30000;
-          description = "How long to cache infoserver responses locally (ms).";
+          description = "Duration in milliseconds to cache responses from the infoserver. Reduces load on the infoserver when the dashboard frequently queries model availability.";
         };
 
         nodeEnv = lib.mkOption {
           type = lib.types.enum [ "production" "development" "test" ];
           default = "production";
-          description = "Node environment.";
+          description = "Node.js runtime environment. Use \"production\" for optimized builds, \"development\" for verbose error pages and hot-reload support.";
         };
 
         logLevel = lib.mkOption {
           type = lib.types.str;
           default = "debug";
-          description = "Pino log level.";
+          description = "Pino log level. Valid values from most to least verbose: trace, debug, info, warn, error, fatal.";
         };
 
         logDir = lib.mkOption {
           type = lib.types.nullOr lib.types.str;
           default = null;
-          description = "Directory for log files inside the container. If null, only stdout logging is used.";
+          description = "Directory for persistent log files inside the container. When set, the dashboard writes structured JSON logs to this directory in addition to stdout. If null, only stdout logging is used.";
         };
 
         mountLogDir = lib.mkOption {
           type = lib.types.bool;
           default = false;
-          description = "Whether to mount logDir as a volume from the host. Requires logDir to be set and an absolute path.";
+          description = "Whether to bind-mount logDir from the host into the container, making log files accessible outside the container. Requires logDir to be set to an absolute path. A systemd-tmpfiles rule is created to ensure the directory exists on the host.";
         };
 
         mailUrl = lib.mkOption {
@@ -186,19 +186,19 @@ in {
         s3Bucket = lib.mkOption {
           type = lib.types.str;
           default = "xinity-media";
-          description = "S3 bucket for media objects.";
+          description = "S3 bucket name used for storing uploaded media objects such as user avatars and organization logos.";
         };
 
         s3Region = lib.mkOption {
           type = lib.types.str;
           default = "us-east-1";
-          description = "S3 region (use 'us-east-1' for SeaweedFS).";
+          description = "S3 region for the object storage endpoint. For SeaweedFS or MinIO, the conventional value is 'us-east-1'.";
         };
 
         mcpEnabled = lib.mkOption {
           type = lib.types.bool;
           default = true;
-          description = "Enable the /mcp Model Context Protocol endpoint.";
+          description = "Enable the /mcp endpoint implementing the Model Context Protocol (MCP). This allows AI coding assistants and other MCP-compatible clients to interact with the dashboard programmatically.";
         };
 
         licenseKey = lib.mkOption {
@@ -214,7 +214,7 @@ in {
         instanceAdminEmails = lib.mkOption {
           type = lib.types.nullOr lib.types.str;
           default = null;
-          description = "Comma-separated list of instance admin emails (enables single-tenant mode).";
+          description = "Comma-separated list of email addresses that are granted instance-admin privileges. Setting this enables single-tenant mode, where these users have full control and no organizations are needed.";
         };
 
         # --- Secret file options (recommended for production) ---
@@ -284,19 +284,19 @@ in {
         containerUid = lib.mkOption {
           type = lib.types.int;
           default = 6000;
-          description = "UID (and GID) the container process runs as. Secret files passed via *File options must be readable by this UID.";
+          description = "UID and GID the container process runs as. The container is started with --user=UID:UID. Any secret files passed via the *File options must be readable by this UID on the host.";
         };
 
         extraOptions = lib.mkOption {
           type = lib.types.listOf lib.types.str;
           default = [ "--network=host" ];
-          description = "Extra options to pass to the container runtime.";
+          description = "Extra command-line options passed to the container runtime (podman/docker). Defaults to host networking; override with an empty list to use bridge networking.";
         };
 
         volumes = lib.mkOption {
           type = lib.types.listOf lib.types.str;
           default = [ ];
-          description = "Extra volume mounts (e.g. ./logs:/usr/src/app/packages/xinity-ai-dashboard/logs).";
+          description = "Extra OCI volume mounts in host:container[:options] format (e.g. /srv/logs:/usr/src/app/logs:ro). Secret file mounts are added automatically when *File options are set.";
         };
       };
 

--- a/nix/modules/xinity-ai-database.mod.nix
+++ b/nix/modules/xinity-ai-database.mod.nix
@@ -43,19 +43,18 @@
         "${resolvedAddress} 127.0.0.1";
     in {
       options.services.xinity-ai-database = {
-        enable = lib.mkEnableOption
-          "xinity-ai database stack (PostgreSQL, Redis, migrations)";
+        enable = lib.mkEnableOption "the xinity-ai database stack, which provisions a PostgreSQL 17 instance for persistent data and a Redis instance for caching and rate limiting";
 
         name = lib.mkOption {
           type = lib.types.str;
           default = "xinity";
-          description = "PostgreSQL database name.";
+          description = "Name of the PostgreSQL database created for xinity-ai. Used in connection strings and pg_hba rules.";
         };
 
         user = lib.mkOption {
           type = lib.types.str;
           default = "xinity";
-          description = "PostgreSQL user.";
+          description = "PostgreSQL role name created for xinity-ai. This user is granted ownership of the database and is used in connection strings by the gateway and dashboard.";
         };
 
         listenMode = lib.mkOption {
@@ -74,7 +73,7 @@
           port = lib.mkOption {
             type = lib.types.port;
             default = 5432;
-            description = "Port for the PostgreSQL instance.";
+            description = "TCP port PostgreSQL listens on. Opened in the firewall automatically when listenMode is not \"local\".";
           };
         };
 
@@ -82,22 +81,20 @@
           port = lib.mkOption {
             type = lib.types.port;
             default = 6379;
-            description = "Port for the Redis instance.";
+            description = "TCP port Redis listens on. Opened in the firewall automatically when listenMode is not \"local\".";
           };
         };
 
         pgPasswordFile = lib.mkOption {
           type = lib.types.nullOr lib.types.str;
           default = null;
-          description =
-            "Path to a file containing the password for the PostgreSQL database user.";
+          description = "Path to a file containing the password for the PostgreSQL database user. When set, a one-shot systemd service runs after PostgreSQL starts to set the password via ALTER USER. The file is loaded securely through systemd's LoadCredential mechanism.";
         };
 
         redisPasswordFile = lib.mkOption {
           type = lib.types.nullOr lib.types.str;
           default = null;
-          description =
-            "Path to a file containing the password for the Redis instance.";
+          description = "Path to a file containing the password for the Redis instance. Passed directly to the Redis requirePassFile option. When null, Redis runs without authentication.";
         };
       };
 
@@ -180,27 +177,25 @@
       dbCfg = config.services.xinity-ai-database;
     in {
       options.services.xinity-ai-db-init = {
-        enable = lib.mkEnableOption "xinity-ai database migrations";
+        enable = lib.mkEnableOption "automatic xinity-ai database migrations. When enabled, a one-shot systemd service runs after PostgreSQL is ready, applies schema migrations, and grants the database user full privileges on all schemas";
 
         databaseName = lib.mkOption {
           type = lib.types.str;
           default = dbCfg.name;
-          description =
-            "PostgreSQL database name (defaults to xinity-ai-database.name).";
+          description = "PostgreSQL database name to run migrations against. Defaults to the value of services.xinity-ai-database.name.";
         };
 
         databaseUser = lib.mkOption {
           type = lib.types.str;
           default = dbCfg.user;
-          description =
-            "PostgreSQL user (defaults to xinity-ai-database.user).";
+          description = "PostgreSQL role that is granted privileges on all migrated schemas and tables. Defaults to the value of services.xinity-ai-database.user.";
         };
 
         migratePackage = lib.mkOption {
           type = lib.types.package;
           default =
             withHostSystem ({ config, ... }: config.packages.xinity-db-migrate);
-          description = "The xinity-db-migrate package to use.";
+          description = "The xinity-db-migrate package containing the Drizzle migration runner. Defaults to the package built from this flake for the current platform.";
         };
       };
 

--- a/nix/modules/xinity-ai-gateway.mod.nix
+++ b/nix/modules/xinity-ai-gateway.mod.nix
@@ -7,24 +7,24 @@ in {
       cfg = config.services.xinity-ai-gateway;
     in {
       options.services.xinity-ai-gateway = {
-        enable = lib.mkEnableOption "xinity-ai-gateway OCI container";
+        enable = lib.mkEnableOption "the xinity-ai gateway, an OpenAI-compatible API proxy that handles authentication, rate limiting, load balancing, and request routing across inference nodes";
 
         image = lib.mkOption {
           type = lib.types.str;
           default = "ghcr.io/xinity-ai/xinity-ai-gateway:${version}";
-          description = "OCI image for the gateway.";
+          description = "OCI image reference for the gateway container. Override this to pin a specific version or use a private registry.";
         };
 
         port = lib.mkOption {
           type = lib.types.port;
           default = 4121;
-          description = "Port the gateway listens on.";
+          description = "HTTP port the gateway listens on. This is the port clients send OpenAI-compatible API requests to.";
         };
 
         host = lib.mkOption {
           type = lib.types.str;
           default = "0.0.0.0";
-          description = "Host address the gateway binds to.";
+          description = "Host address the gateway binds to. Use 0.0.0.0 to accept connections on all interfaces, or 127.0.0.1 to restrict to localhost.";
         };
 
         dbConnectionUrl = lib.mkOption {
@@ -50,31 +50,36 @@ in {
         webSearchEngineUrl = lib.mkOption {
           type = lib.types.nullOr lib.types.str;
           default = null;
-          description = "URL to a web search engine (e.g. SearXNG).";
+          description = "URL of a web search engine instance (e.g. a SearXNG endpoint). When set, the gateway exposes web-search-augmented generation capabilities to clients.";
         };
 
         responseCacheTtlSeconds = lib.mkOption {
           type = lib.types.int;
           default = 3600;
-          description = "TTL in seconds for response caching.";
+          description = "Time-to-live in seconds for cached LLM responses. Identical requests within this window are served from cache without hitting the inference backend. Set to 0 to disable caching.";
         };
 
         infoserverUrl = lib.mkOption {
           type = lib.types.nullOr lib.types.str;
           default = null;
-          description = "URL of the xinity-infoserver instance.";
+          description = "Internal URL of the xinity-infoserver instance. The gateway queries this to discover available models and their routing information.";
         };
 
         infoserverCacheTtlMs = lib.mkOption {
           type = lib.types.int;
           default = 30000;
-          description = "How long to cache infoserver responses locally (ms).";
+          description = "Duration in milliseconds to cache responses from the infoserver. Reduces load on the infoserver when the gateway frequently queries model availability.";
         };
 
         loadBalanceStrategy = lib.mkOption {
           type = lib.types.enum [ "random" "round-robin" "least-connections" ];
           default = "least-connections";
-          description = "Load balancing strategy for inference nodes.";
+          description = ''
+            Strategy used to distribute requests across inference nodes.
+            - "random": pick a random healthy node for each request.
+            - "round-robin": cycle through healthy nodes in order.
+            - "least-connections": route to the node with the fewest active requests (recommended for heterogeneous hardware).
+          '';
         };
 
         metricsAuth = lib.mkOption {
@@ -90,7 +95,7 @@ in {
         logLevel = lib.mkOption {
           type = lib.types.enum [ "fatal" "error" "warn" "info" "debug" "trace" ];
           default = "info";
-          description = "Pino log level.";
+          description = "Pino log level. Controls the verbosity of structured JSON logs emitted by the gateway.";
         };
 
         logDir = lib.mkOption {
@@ -102,7 +107,7 @@ in {
         backendTimeoutMs = lib.mkOption {
           type = lib.types.int;
           default = 300000;
-          description = "Maximum time in ms to wait for a backend response.";
+          description = "Maximum time in milliseconds to wait for an inference backend to respond before the gateway returns a timeout error to the client. Increase this for models with long generation times.";
         };
 
         # --- S3 / SeaweedFS settings ---
@@ -110,7 +115,7 @@ in {
         s3Endpoint = lib.mkOption {
           type = lib.types.nullOr lib.types.str;
           default = null;
-          description = "SeaweedFS / S3-compatible endpoint URL.";
+          description = "URL of the SeaweedFS or S3-compatible object storage endpoint. Used for storing and retrieving media files attached to conversations.";
         };
 
         s3AccessKeyId = lib.mkOption {
@@ -118,7 +123,7 @@ in {
           default = null;
           description = ''
             S3 access key ID.
-            WARNING: DO NOT USE IN PRODUCTION. Use environmentFiles instead to keep credentials secure.
+            WARNING: DO NOT USE IN PRODUCTION. Use environmentFiles or s3AccessKeyIdFile instead to keep credentials secure.
             This option exposes secrets in the Nix store.
           '';
         };
@@ -128,7 +133,7 @@ in {
           default = null;
           description = ''
             S3 secret access key.
-            WARNING: DO NOT USE IN PRODUCTION. Use environmentFiles instead to keep credentials secure.
+            WARNING: DO NOT USE IN PRODUCTION. Use environmentFiles or s3SecretAccessKeyFile instead to keep credentials secure.
             This option exposes secrets in the Nix store.
           '';
         };
@@ -136,13 +141,13 @@ in {
         s3Bucket = lib.mkOption {
           type = lib.types.str;
           default = "xinity-media";
-          description = "S3 bucket for media objects.";
+          description = "S3 bucket name used for storing uploaded media objects such as conversation attachments.";
         };
 
         s3Region = lib.mkOption {
           type = lib.types.str;
           default = "us-east-1";
-          description = "S3 region (use 'us-east-1' for SeaweedFS).";
+          description = "S3 region for the object storage endpoint. For SeaweedFS or MinIO, the conventional value is 'us-east-1'.";
         };
 
         # --- TLS settings ---
@@ -162,7 +167,7 @@ in {
         inferenceCaFile = lib.mkOption {
           type = lib.types.nullOr lib.types.str;
           default = null;
-          description = "Path to a file containing the PEM CA certificate for verifying daemon TLS (for self-signed certs).";
+          description = "Path to a PEM-encoded CA certificate file used to verify TLS connections to inference daemons. Required when daemons use self-signed certificates.";
         };
 
         # --- Secret file options (recommended for production) ---
@@ -218,13 +223,13 @@ in {
         containerUid = lib.mkOption {
           type = lib.types.int;
           default = 6000;
-          description = "UID (and GID) the container process runs as. Secret files passed via *File options must be readable by this UID.";
+          description = "UID and GID the container process runs as. The container is started with --user=UID:UID. Any secret files passed via the *File options must be readable by this UID on the host.";
         };
 
         extraOptions = lib.mkOption {
           type = lib.types.listOf lib.types.str;
           default = [ "--network=host" ];
-          description = "Extra options to pass to the container runtime.";
+          description = "Extra command-line options passed to the container runtime (podman/docker). Defaults to host networking; override with an empty list to use bridge networking.";
         };
       };
 

--- a/nix/modules/xinity-ai-seaweedfs.mod.nix
+++ b/nix/modules/xinity-ai-seaweedfs.mod.nix
@@ -1,57 +1,57 @@
-{ self, ... }: {
+{ ... }: {
   flake.nixosModules.seaweedfs = { config, lib, pkgs, ... }:
     let
       cfg = config.services.xinity-ai-seaweedfs;
     in {
       options.services.xinity-ai-seaweedfs = {
-        enable = lib.mkEnableOption "SeaweedFS S3-compatible object storage for xinity-ai";
+        enable = lib.mkEnableOption "a bundled SeaweedFS instance providing S3-compatible object storage for xinity-ai media uploads (avatars, attachments, etc.)";
 
         package = lib.mkOption {
           type = lib.types.package;
           default = pkgs.seaweedfs;
-          description = "The SeaweedFS package to use.";
+          description = "The SeaweedFS package to use. Override this to pin a specific version or use a custom build.";
         };
 
         s3Port = lib.mkOption {
           type = lib.types.port;
           default = 8333;
-          description = "Port for the S3 API endpoint.";
+          description = "Port for the S3-compatible API endpoint. The gateway and dashboard connect to this port to store and retrieve media objects.";
         };
 
         masterPort = lib.mkOption {
           type = lib.types.port;
           default = 9333;
-          description = "Port for the SeaweedFS master.";
+          description = "Port for the SeaweedFS master server, which manages volume placement and cluster topology.";
         };
 
         volumePort = lib.mkOption {
           type = lib.types.port;
           default = 8080;
-          description = "Port for the SeaweedFS volume server.";
+          description = "Port for the SeaweedFS volume server, which handles the actual blob storage and retrieval.";
         };
 
         filerPort = lib.mkOption {
           type = lib.types.port;
           default = 8889;
-          description = "Port for the SeaweedFS filer (default 8889 to avoid conflict with SearXNG).";
+          description = "Port for the SeaweedFS filer, which provides a file-system-like interface on top of blob storage. Defaults to 8889 to avoid conflicting with SearXNG's default port.";
         };
 
         dataDir = lib.mkOption {
           type = lib.types.str;
           default = "/var/lib/seaweedfs";
-          description = "Directory for SeaweedFS data persistence.";
+          description = "Directory for SeaweedFS data persistence. All volume data, filer metadata, and master state are stored here. A systemd-tmpfiles rule ensures this directory exists with correct ownership.";
         };
 
         s3Config = lib.mkOption {
           type = lib.types.nullOr lib.types.str;
           default = null;
-          description = "Path to S3 config JSON file (for access keys). If null, anonymous access is allowed.";
+          description = "Path to an S3 configuration JSON file that defines access keys and permissions. When null, the S3 endpoint allows anonymous access. See the SeaweedFS documentation for the config file format.";
         };
 
         extraArgs = lib.mkOption {
           type = lib.types.listOf lib.types.str;
           default = [ ];
-          description = "Additional arguments to pass to 'weed server'.";
+          description = "Additional command-line arguments appended to the 'weed server' invocation. Useful for tuning replication, compaction, or enabling additional sub-services.";
         };
       };
 

--- a/nix/modules/xinity-infoserver.mod.nix
+++ b/nix/modules/xinity-infoserver.mod.nix
@@ -47,7 +47,7 @@ in {
 
         logLevel = lib.mkOption {
           type = lib.types.enum [ "fatal" "error" "warn" "info" "debug" "trace" ];
-          default = "info";
+          default = "debug";
           description = "Pino log level. Controls the verbosity of structured JSON logs emitted by the infoserver.";
         };
 

--- a/nix/modules/xinity-infoserver.mod.nix
+++ b/nix/modules/xinity-infoserver.mod.nix
@@ -7,18 +7,18 @@ in {
       cfg = config.services.xinity-infoserver;
     in {
       options.services.xinity-infoserver = {
-        enable = lib.mkEnableOption "xinity-infoserver OCI container";
+        enable = lib.mkEnableOption "the xinity-infoserver, a lightweight service that reads a YAML model definition file and serves model metadata (pricing, capabilities, routing) to the gateway and dashboard";
 
         image = lib.mkOption {
           type = lib.types.str;
           default = "ghcr.io/xinity-ai/xinity-infoserver:${version}";
-          description = "OCI image for the infoserver.";
+          description = "OCI image reference for the infoserver container. Override this to pin a specific version or use a private registry.";
         };
 
         port = lib.mkOption {
           type = lib.types.port;
           default = 8090;
-          description = "Port the infoserver listens on.";
+          description = "HTTP port the infoserver listens on inside the container. This port is also published to the host.";
         };
 
         modelInfoFile = lib.mkOption {
@@ -36,25 +36,25 @@ in {
         refreshIntervalMs = lib.mkOption {
           type = lib.types.int;
           default = 300000;
-          description = "How often to re-read model file and re-fetch includes (ms).";
+          description = "Interval in milliseconds between automatic refreshes. On each cycle the infoserver re-reads the model YAML file from disk and re-fetches any remote include URLs, picking up changes without a restart.";
         };
 
         maxIncludeDepth = lib.mkOption {
           type = lib.types.int;
           default = 10;
-          description = "Maximum recursion depth when resolving include URLs.";
+          description = "Maximum recursion depth when resolving remote include URLs in the model YAML. Prevents infinite loops if included files reference each other. Increase only if you have a deeply nested include hierarchy.";
         };
 
         logLevel = lib.mkOption {
           type = lib.types.enum [ "fatal" "error" "warn" "info" "debug" "trace" ];
           default = "info";
-          description = "Pino log level.";
+          description = "Pino log level. Controls the verbosity of structured JSON logs emitted by the infoserver.";
         };
 
         logDir = lib.mkOption {
           type = lib.types.nullOr lib.types.str;
           default = null;
-          description = "Directory for log files. If null, only stdout logging is used.";
+          description = "Directory for persistent log files. When set, the infoserver writes structured JSON logs to this directory in addition to stdout. If null, only stdout logging is used.";
         };
 
         environmentFiles = lib.mkOption {
@@ -76,7 +76,7 @@ in {
         extraOptions = lib.mkOption {
           type = lib.types.listOf lib.types.str;
           default = [ "--network=host" ];
-          description = "Extra options to pass to the container runtime.";
+          description = "Extra command-line options passed to the container runtime (podman/docker). Defaults to host networking; override with an empty list to use bridge networking.";
         };
       };
 


### PR DESCRIPTION
## Description

This branch adds a docs.mod.nix module that uses nixosOptionsDoc to generate a JSON reference from the NixOS module options, and improves the descriptions across all service modules (daemon, gateway, dashboard, database, infoserver, seaweedfs, allinone) so they explain what each option does, how it relates to other services, and when to change defaults. It also renames nixosModules.server to nixosModules.daemon to match the actual service name

## Type of change

Documentation

## Testing

No tests impacted

## Checklist

- [x] Tests pass locally (`bun test`), or no testable code was changed
- [x] New or changed behavior is covered by tests, or this change does not require tests
- [x] Documentation is updated, or no user-facing behavior or configuration was changed
- [x] There are no breaking changes, or they are marked with `!` in the commit type and described above
- [x] No security-sensitive changes (authentication, credentials, input handling), or they have been reviewed
- [x] No new dependencies were added, or they have been reviewed for license and maintenance status