### PR TITLE
feat(license): add optional instanceId binding

### DIFF
--- a/packages/common-db/db-migration/0006_absurd_dagger.sql
+++ b/packages/common-db/db-migration/0006_absurd_dagger.sql
@@ -1,0 +1,6 @@
+CREATE TABLE "deployment_config" (
+	"singleton" integer PRIMARY KEY DEFAULT 1 NOT NULL,
+	"instance_id" uuid DEFAULT gen_random_uuid() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "deployment_config_singleton_check" CHECK ("deployment_config"."singleton" = 1)
+);

--- a/packages/common-db/db-migration/meta/0006_snapshot.json
+++ b/packages/common-db/db-migration/meta/0006_snapshot.json
@@ -1,0 +1,3125 @@
+{
+  "id": "54af5a8a-12eb-4cc1-96db-73ffc2a62786",
+  "prevId": "66c53d0f-9ffe-49f6-a8d2-8e3a56032f29",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ai_api_key": {
+      "name": "ai_api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "specifier": {
+          "name": "specifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "collect_data": {
+          "name": "collect_data",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_api_key_organization_id_idx": {
+          "name": "ai_api_key_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_api_key_specifier_idx": {
+          "name": "ai_api_key_specifier_idx",
+          "columns": [
+            {
+              "expression": "specifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_api_key_application_id_idx": {
+          "name": "ai_api_key_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_api_key_deleted_at_idx": {
+          "name": "ai_api_key_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_api_key_organization_id_organization_id_fk": {
+          "name": "ai_api_key_organization_id_organization_id_fk",
+          "tableFrom": "ai_api_key",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_api_key_application_id_ai_application_id_fk": {
+          "name": "ai_api_key_application_id_ai_application_id_fk",
+          "tableFrom": "ai_api_key",
+          "tableTo": "ai_application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "ai_api_key_created_by_user_id_user_id_fk": {
+          "name": "ai_api_key_created_by_user_id_user_id_fk",
+          "tableFrom": "ai_api_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_application": {
+      "name": "ai_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_application_organization_id_idx": {
+          "name": "ai_application_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_application_deleted_at_idx": {
+          "name": "ai_application_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_application_name_organization_id_unique": {
+          "name": "ai_application_name_organization_id_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"ai_application\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_application_organization_id_organization_id_fk": {
+          "name": "ai_application_organization_id_organization_id_fk",
+          "tableFrom": "ai_application",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_account_id_provider_id_idx": {
+          "name": "account_account_id_provider_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard_api_key": {
+      "name": "dashboard_api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "dashboard_api_key_user_id_idx": {
+          "name": "dashboard_api_key_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dashboard_api_key_prefix_idx": {
+          "name": "dashboard_api_key_prefix_idx",
+          "columns": [
+            {
+              "expression": "prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dashboard_api_key_user_id_user_id_fk": {
+          "name": "dashboard_api_key_user_id_user_id_fk",
+          "tableFrom": "dashboard_api_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "passkey_user_id_idx": {
+          "name": "passkey_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_token_idx": {
+          "name": "session_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "session_active_organization_id_organization_id_fk": {
+          "name": "session_active_organization_id_organization_id_fk",
+          "tableFrom": "session",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "active_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sso_provider": {
+      "name": "sso_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_config": {
+          "name": "oidc_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saml_config": {
+          "name": "saml_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain_verified": {
+          "name": "domain_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sso_provider_user_id_user_id_fk": {
+          "name": "sso_provider_user_id_user_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sso_provider_organization_id_organization_id_fk": {
+          "name": "sso_provider_organization_id_organization_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.two_factor": {
+      "name": "two_factor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backup_codes": {
+          "name": "backup_codes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "two_factor_user_id_idx": {
+          "name": "two_factor_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "two_factor_user_id_user_id_fk": {
+          "name": "two_factor_user_id_user_id_fk",
+          "tableFrom": "two_factor",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_settings": {
+          "name": "notification_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_settings": {
+          "name": "display_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires_at": {
+          "name": "ban_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temporary_password": {
+          "name": "temporary_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "call_data.api_call_response": {
+      "name": "api_call_response",
+      "schema": "call_data",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_call_id": {
+          "name": "api_call_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_edit": {
+          "name": "output_edit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highlights": {
+          "name": "highlights",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excluded_messages": {
+          "name": "excluded_messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_exclusions": {
+          "name": "input_exclusions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_call_response_user_id_user_id_fk": {
+          "name": "api_call_response_user_id_user_id_fk",
+          "tableFrom": "api_call_response",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_call_response_api_call_id_api_call_id_fk": {
+          "name": "api_call_response_api_call_id_api_call_id_fk",
+          "tableFrom": "api_call_response",
+          "tableTo": "api_call",
+          "schemaTo": "call_data",
+          "columnsFrom": [
+            "api_call_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "api_call_response_user_id_api_call_id_pk": {
+          "name": "api_call_response_user_id_api_call_id_pk",
+          "columns": [
+            "user_id",
+            "api_call_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "call_data.api_call": {
+      "name": "api_call",
+      "schema": "call_data",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "specified_model": {
+          "name": "specified_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user": {
+          "name": "user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_messages": {
+          "name": "input_messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_message": {
+          "name": "output_message",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_call_api_key_id_idx": {
+          "name": "api_call_api_key_id_idx",
+          "columns": [
+            {
+              "expression": "api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_call_application_id_idx": {
+          "name": "api_call_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_call_organization_id_idx": {
+          "name": "api_call_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_call_organization_id_created_at_idx": {
+          "name": "api_call_organization_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_call_model_idx": {
+          "name": "api_call_model_idx",
+          "columns": [
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_call_api_key_id_ai_api_key_id_fk": {
+          "name": "api_call_api_key_id_ai_api_key_id_fk",
+          "tableFrom": "api_call",
+          "tableTo": "ai_api_key",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "api_call_application_id_ai_application_id_fk": {
+          "name": "api_call_application_id_ai_application_id_fk",
+          "tableFrom": "api_call",
+          "tableTo": "ai_application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "api_call_organization_id_organization_id_fk": {
+          "name": "api_call_organization_id_organization_id_fk",
+          "tableFrom": "api_call",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "call_data.media_object": {
+      "name": "media_object",
+      "schema": "call_data",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_url": {
+          "name": "original_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_bucket": {
+          "name": "s3_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_object_organization_id_sha256_idx": {
+          "name": "media_object_organization_id_sha256_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_object_organization_id_idx": {
+          "name": "media_object_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_object_organization_id_organization_id_fk": {
+          "name": "media_object_organization_id_organization_id_fk",
+          "tableFrom": "media_object",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "call_data.usage_event": {
+      "name": "usage_event",
+      "schema": "call_data",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logged": {
+          "name": "logged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "usage_event_organization_id_created_at_idx": {
+          "name": "usage_event_organization_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_event_created_at_idx": {
+          "name": "usage_event_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_event_api_key_id_idx": {
+          "name": "usage_event_api_key_id_idx",
+          "columns": [
+            {
+              "expression": "api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_event_organization_id_organization_id_fk": {
+          "name": "usage_event_organization_id_organization_id_fk",
+          "tableFrom": "usage_event",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_event_application_id_ai_application_id_fk": {
+          "name": "usage_event_application_id_ai_application_id_fk",
+          "tableFrom": "usage_event",
+          "tableTo": "ai_application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "usage_event_api_key_id_ai_api_key_id_fk": {
+          "name": "usage_event_api_key_id_ai_api_key_id_fk",
+          "tableFrom": "usage_event",
+          "tableTo": "ai_api_key",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "call_data.usage_summary": {
+      "name": "usage_summary",
+      "schema": "call_data",
+      "columns": {
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'00000000-0000-0000-0000-000000000000'"
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_calls": {
+          "name": "total_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "logged_calls": {
+          "name": "logged_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_duration": {
+          "name": "total_duration",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "usage_summary_organization_id_idx": {
+          "name": "usage_summary_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_summary_organization_id_date_idx": {
+          "name": "usage_summary_organization_id_date_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "usage_summary_date_organization_id_application_id_api_key_id_model_pk": {
+          "name": "usage_summary_date_organization_id_application_id_api_key_id_model_pk",
+          "columns": [
+            "date",
+            "organization_id",
+            "application_id",
+            "api_key_id",
+            "model"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_config": {
+      "name": "deployment_config",
+      "schema": "",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "deployment_config_singleton_check": {
+          "name": "deployment_config_singleton_check",
+          "value": "\"deployment_config\".\"singleton\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ai_node": {
+      "name": "ai_node",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "est_capacity": {
+          "name": "est_capacity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "drivers": {
+          "name": "drivers",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"ollama\"}'"
+        },
+        "gpu_count": {
+          "name": "gpu_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "driver_versions": {
+          "name": "driver_versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "gpus": {
+          "name": "gpus",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "auth_token": {
+          "name": "auth_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tls": {
+          "name": "tls",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_node_deleted_at_idx": {
+          "name": "ai_node_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_node_host_port_idx": {
+          "name": "ai_node_host_port_idx",
+          "columns": [
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "port",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"ai_node\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_deployment": {
+      "name": "model_deployment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "public_specifier": {
+          "name": "public_specifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_specifier": {
+          "name": "model_specifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "early_model_specifier": {
+          "name": "early_model_specifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replicas": {
+          "name": "replicas",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "canary_progress_until": {
+          "name": "canary_progress_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canary_progress_from": {
+          "name": "canary_progress_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canary_progress_with_feedback": {
+          "name": "canary_progress_with_feedback",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "progress": {
+          "name": "progress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "kv_cache_size": {
+          "name": "kv_cache_size",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "early_kv_cache_size": {
+          "name": "early_kv_cache_size",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_driver": {
+          "name": "preferred_driver",
+          "type": "inference_driver",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "model_deployment_public_specifier_organization_id_idx": {
+          "name": "model_deployment_public_specifier_organization_id_idx",
+          "columns": [
+            {
+              "expression": "public_specifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"model_deployment\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "model_deployment_deleted_at_idx": {
+          "name": "model_deployment_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_deployment_organization_id_organization_id_fk": {
+          "name": "model_deployment_organization_id_organization_id_fk",
+          "tableFrom": "model_deployment",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_installation_state": {
+      "name": "model_installation_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lifecycle_state": {
+          "name": "lifecycle_state",
+          "type": "lifecycle_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_message": {
+          "name": "status_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_logs": {
+          "name": "failure_logs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_installation_state_id_model_installation_id_fk": {
+          "name": "model_installation_state_id_model_installation_id_fk",
+          "tableFrom": "model_installation_state",
+          "tableTo": "model_installation",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_installation": {
+      "name": "model_installation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "est_capacity": {
+          "name": "est_capacity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kv_cache_capacity": {
+          "name": "kv_cache_capacity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driver": {
+          "name": "driver",
+          "type": "inference_driver",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "model_installation_node_id_idx": {
+          "name": "model_installation_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "model_installation_model_idx": {
+          "name": "model_installation_model_idx",
+          "columns": [
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "model_installation_deleted_at_idx": {
+          "name": "model_installation_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_installation_node_id_ai_node_id_fk": {
+          "name": "model_installation_node_id_ai_node_id_fk",
+          "tableFrom": "model_installation",
+          "tableTo": "ai_node",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification": {
+      "name": "notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'email'"
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_user_id_idx": {
+          "name": "notification_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_organization_id_idx": {
+          "name": "notification_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_type_idx": {
+          "name": "notification_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_deleted_at_idx": {
+          "name": "notification_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_user_id_user_id_fk": {
+          "name": "notification_user_id_user_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_organization_id_organization_id_fk": {
+          "name": "notification_organization_id_organization_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invitation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invitation_organization_id_idx": {
+          "name": "invitation_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "member_user_id_idx": {
+          "name": "member_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_organization_id_idx": {
+          "name": "member_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_user_id_organization_id_idx": {
+          "name": "member_user_id_organization_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sso_self_manage": {
+          "name": "sso_self_manage",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.inference_driver": {
+      "name": "inference_driver",
+      "schema": "public",
+      "values": [
+        "ollama",
+        "vllm"
+      ]
+    },
+    "public.lifecycle_state": {
+      "name": "lifecycle_state",
+      "schema": "public",
+      "values": [
+        "downloading",
+        "installing",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.invitation_status": {
+      "name": "invitation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "rejected",
+        "canceled"
+      ]
+    }
+  },
+  "schemas": {
+    "call_data": "call_data"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/common-db/db-migration/meta/_journal.json
+++ b/packages/common-db/db-migration/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1776685738293,
       "tag": "0005_bumpy_stryfe",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1777108273101,
+      "tag": "0006_absurd_dagger",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/common-db/src/index.ts
+++ b/packages/common-db/src/index.ts
@@ -5,6 +5,7 @@ export * from "./schema/call-data";
 export * from "./schema/models";
 export * from "./schema/orgSchema";
 export * from "./schema/notification";
+export * from "./schema/deployment-config";
 export * from "./model-calc";
 
 export * from "./migrations";

--- a/packages/common-db/src/schema/deployment-config.ts
+++ b/packages/common-db/src/schema/deployment-config.ts
@@ -1,0 +1,16 @@
+import { pgTable, uuid, timestamp, integer, check } from "drizzle-orm/pg-core";
+import { sql, type InferSelectModel } from "drizzle-orm";
+
+const createdAt = timestamp("created_at", { withTimezone: true }).defaultNow().notNull();
+
+// Single-row table holding the dashboard's stable per-install identity.
+// `singleton` is constrained to 1 so the table can hold at most one row.
+export const deploymentConfigT = pgTable("deployment_config", {
+  singleton: integer().primaryKey().default(1),
+  instanceId: uuid("instance_id").notNull().defaultRandom(),
+  createdAt,
+}, table => [
+  check("deployment_config_singleton_check", sql`${table.singleton} = 1`),
+]);
+
+export type DeploymentConfig = InferSelectModel<typeof deploymentConfigT>;

--- a/packages/xinity-ai-dashboard/src/hooks.server.ts
+++ b/packages/xinity-ai-dashboard/src/hooks.server.ts
@@ -10,6 +10,7 @@ import { startDeploymentSyncService } from "$lib/server/lib/orchestration.mod";
 import { startNotificationScheduler } from "$lib/server/notifications/scheduler";
 import { serverEnv } from "$lib/server/serverenv";
 import { checkMigrationState, isMigrationOk } from "$lib/server/migration-check";
+import { loadDeploymentId } from "$lib/server/deployment-id";
 
 const log = rootLogger.child({ name: "hooks" });
 
@@ -17,6 +18,19 @@ const log = rootLogger.child({ name: "hooks" });
  * Verify database migrations are up to date before serving any requests.
  */
 await checkMigrationState();
+
+/**
+ * Warm the deployment instance ID cache so the license module can verify
+ * the optional instanceId claim synchronously. Only when migrations are ok -
+ * the table won't exist otherwise.
+ */
+if (isMigrationOk()) {
+  try {
+    await loadDeploymentId();
+  } catch (err) {
+    log.error({ err }, "Failed to load deployment instance ID; instance binding will be skipped");
+  }
+}
 
 /**
  * Redirects all page requests to /migration-error/ when migrations are outdated.

--- a/packages/xinity-ai-dashboard/src/lib/server/deployment-id.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/deployment-id.ts
@@ -1,0 +1,50 @@
+import { deploymentConfigT } from "common-db";
+import { getDB } from "./db";
+import { rootLogger } from "./logging";
+
+const log = rootLogger.child({ name: "deployment-id" });
+
+let cachedInstanceId: string | null = null;
+let loadPromise: Promise<string> | null = null;
+
+/**
+ * Reads the singleton row from `deployment_config`, inserting one if missing,
+ * and caches the resulting instance ID for the process lifetime.
+ *
+ * Safe to call multiple times - concurrent callers share the same in-flight load.
+ */
+export async function loadDeploymentId(): Promise<string> {
+  if (cachedInstanceId) return cachedInstanceId;
+  if (loadPromise) return loadPromise;
+
+  loadPromise = (async () => {
+    const db = getDB();
+    const existing = await db.select().from(deploymentConfigT).limit(1);
+    if (existing.length > 0) {
+      cachedInstanceId = existing[0].instanceId;
+      log.info({ instanceId: cachedInstanceId }, "Loaded deployment instance ID");
+      return cachedInstanceId;
+    }
+
+    const inserted = await db.insert(deploymentConfigT).values({}).returning();
+    cachedInstanceId = inserted[0].instanceId;
+    log.info({ instanceId: cachedInstanceId }, "Generated deployment instance ID");
+    return cachedInstanceId;
+  })();
+
+  return loadPromise;
+}
+
+/**
+ * Returns the cached deployment instance ID, or null if `loadDeploymentId()`
+ * has not yet completed. License checks treat null as "cannot verify".
+ */
+export function getDeploymentId(): string | null {
+  return cachedInstanceId;
+}
+
+/** Resets the cached deployment ID (test-only). */
+export function resetDeploymentIdCache(): void {
+  cachedInstanceId = null;
+  loadPromise = null;
+}

--- a/packages/xinity-ai-dashboard/src/lib/server/deployment-id.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/deployment-id.ts
@@ -12,24 +12,45 @@ let loadPromise: Promise<string> | null = null;
  * and caches the resulting instance ID for the process lifetime.
  *
  * Safe to call multiple times - concurrent callers share the same in-flight load.
+ * On failure the in-flight promise is cleared so transient DB errors can be retried.
  */
 export async function loadDeploymentId(): Promise<string> {
   if (cachedInstanceId) return cachedInstanceId;
   if (loadPromise) return loadPromise;
 
   loadPromise = (async () => {
-    const db = getDB();
-    const existing = await db.select().from(deploymentConfigT).limit(1);
-    if (existing.length > 0) {
-      cachedInstanceId = existing[0].instanceId;
-      log.info({ instanceId: cachedInstanceId }, "Loaded deployment instance ID");
-      return cachedInstanceId;
-    }
+    try {
+      const db = getDB();
+      const existing = await db.select().from(deploymentConfigT).limit(1);
+      if (existing.length > 0) {
+        cachedInstanceId = existing[0].instanceId;
+        log.info({ instanceId: cachedInstanceId }, "Loaded deployment instance ID");
+        return cachedInstanceId;
+      }
 
-    const inserted = await db.insert(deploymentConfigT).values({}).returning();
-    cachedInstanceId = inserted[0].instanceId;
-    log.info({ instanceId: cachedInstanceId }, "Generated deployment instance ID");
-    return cachedInstanceId;
+      // Atomic upsert + re-select so concurrent multi-process startups converge on
+      // the same row instead of one losing to a primary-key conflict.
+      const inserted = await db
+        .insert(deploymentConfigT)
+        .values({ singleton: 1 })
+        .onConflictDoNothing({ target: deploymentConfigT.singleton })
+        .returning();
+      const rows = inserted.length > 0
+        ? inserted
+        : await db.select().from(deploymentConfigT).limit(1);
+      if (rows.length === 0) {
+        throw new Error("deployment_config row missing after singleton upsert");
+      }
+
+      cachedInstanceId = rows[0].instanceId;
+      log.info(
+        { instanceId: cachedInstanceId },
+        inserted.length > 0 ? "Generated deployment instance ID" : "Loaded deployment instance ID",
+      );
+      return cachedInstanceId;
+    } finally {
+      loadPromise = null;
+    }
   })();
 
   return loadPromise;

--- a/packages/xinity-ai-dashboard/src/lib/server/license/index.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/license/index.ts
@@ -9,6 +9,7 @@ export {
   isExpired,
   isInGracePeriod,
   hasOriginMismatch,
+  hasInstanceMismatch,
   getLicenseSummary,
   type LicenseSummary,
 } from "./license";

--- a/packages/xinity-ai-dashboard/src/lib/server/license/license.test.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/license/license.test.ts
@@ -24,10 +24,8 @@ mock.module("$lib/server/logging", () => ({
 }));
 
 // Mock the deployment-id module so we can control the local instance ID.
-// Mocked under the same relative specifier license.ts uses, so the import binding
-// in license.ts resolves to this fake.
 const deploymentIdMock = { id: null as string | null };
-mock.module("../deployment-id", () => ({
+mock.module("$lib/server/deployment-id", () => ({
   getDeploymentId: () => deploymentIdMock.id,
 }));
 

--- a/packages/xinity-ai-dashboard/src/lib/server/license/license.test.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/license/license.test.ts
@@ -23,8 +23,16 @@ mock.module("$lib/server/logging", () => ({
   rootLogger: { child: () => ({ info: () => {}, warn: () => {}, error: () => {} }) },
 }));
 
+// Mock the deployment-id module so we can control the local instance ID.
+// Mocked under the same relative specifier license.ts uses, so the import binding
+// in license.ts resolves to this fake.
+const deploymentIdMock = { id: null as string | null };
+mock.module("../deployment-id", () => ({
+  getDeploymentId: () => deploymentIdMock.id,
+}));
+
 // Now import the module under test (after mocks are in place).
-const { parseLicense, resetLicenseCache, hasFeature, maxVramGb, tierName, licenseeName, isExpired, isInGracePeriod, hasOriginMismatch, getLicenseSummary } = await import("./license");
+const { parseLicense, resetLicenseCache, hasFeature, maxVramGb, tierName, licenseeName, isExpired, isInGracePeriod, hasOriginMismatch, hasInstanceMismatch, getLicenseSummary } = await import("./license");
 
 const MS_PER_DAY = 1000 * 60 * 60 * 24;
 
@@ -261,6 +269,67 @@ describe("origin mismatch", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Instance mismatch
+// ---------------------------------------------------------------------------
+
+describe("instance mismatch", () => {
+  beforeEach(() => {
+    resetLicenseCache();
+    const { serverEnv } = require("$lib/server/serverenv");
+    serverEnv.LICENSE_KEY = undefined;
+    serverEnv.ORIGIN = "https://dashboard.example.com";
+    deploymentIdMock.id = null;
+  });
+
+  // Valid UUIDs (v4 with proper variant bits) for test fixtures.
+  const ID_A = "11111111-1111-4111-8111-111111111111";
+  const ID_B = "22222222-2222-4222-8222-222222222222";
+
+  test("no mismatch when license has no instanceId claim (backwards compatible)", () => {
+    const { serverEnv } = require("$lib/server/serverenv");
+    serverEnv.LICENSE_KEY = signLicense(validPayload());
+    deploymentIdMock.id = ID_A;
+
+    expect(hasInstanceMismatch()).toBe(false);
+  });
+
+  test("no mismatch when license instanceId equals local deployment ID", () => {
+    const { serverEnv } = require("$lib/server/serverenv");
+    serverEnv.LICENSE_KEY = signLicense(validPayload({ instanceId: ID_A }));
+    deploymentIdMock.id = ID_A;
+
+    expect(hasInstanceMismatch()).toBe(false);
+  });
+
+  test("mismatch when license instanceId differs from local deployment ID", () => {
+    const { serverEnv } = require("$lib/server/serverenv");
+    serverEnv.LICENSE_KEY = signLicense(validPayload({ instanceId: ID_A }));
+    deploymentIdMock.id = ID_B;
+
+    expect(hasInstanceMismatch()).toBe(true);
+  });
+
+  test("no mismatch when local deployment ID has not loaded yet", () => {
+    const { serverEnv } = require("$lib/server/serverenv");
+    serverEnv.LICENSE_KEY = signLicense(validPayload({ instanceId: ID_A }));
+    deploymentIdMock.id = null;
+
+    expect(hasInstanceMismatch()).toBe(false);
+  });
+
+  test("no mismatch on free tier (no key)", () => {
+    deploymentIdMock.id = ID_A;
+    expect(hasInstanceMismatch()).toBe(false);
+  });
+
+  test("rejects a non-UUID instanceId at parse time", () => {
+    const key = signLicense(validPayload({ instanceId: "not-a-uuid" }));
+    const result = parseLicense(key);
+    expect(result.valid).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // getLicenseSummary
 // ---------------------------------------------------------------------------
 
@@ -270,6 +339,7 @@ describe("getLicenseSummary", () => {
     const { serverEnv } = require("$lib/server/serverenv");
     serverEnv.LICENSE_KEY = undefined;
     serverEnv.ORIGIN = "https://dashboard.example.com";
+    deploymentIdMock.id = null;
   });
 
   test("returns complete summary for free tier", () => {
@@ -279,6 +349,7 @@ describe("getLicenseSummary", () => {
     expect(summary.expired).toBe(false);
     expect(summary.inGracePeriod).toBe(false);
     expect(summary.originMismatch).toBe(false);
+    expect(summary.instanceMismatch).toBe(false);
     expect(summary.maxVramGb).toBe(120);
     expect(summary.features.sso).toBe(false);
     expect(summary.features.multiOrg).toBe(false);
@@ -297,5 +368,17 @@ describe("getLicenseSummary", () => {
     expect(summary.features.multiOrg).toBe(true);
     expect(summary.features.allRoles).toBe(true);
     expect(summary.originMismatch).toBe(false);
+    expect(summary.instanceMismatch).toBe(false);
+  });
+
+  test("surfaces instanceMismatch when license instanceId differs from local", () => {
+    const { serverEnv } = require("$lib/server/serverenv");
+    serverEnv.LICENSE_KEY = signLicense(validPayload({
+      instanceId: "33333333-3333-4333-8333-333333333333",
+    }));
+    deploymentIdMock.id = "44444444-4444-4444-8444-444444444444";
+
+    const summary = getLicenseSummary();
+    expect(summary.instanceMismatch).toBe(true);
   });
 });

--- a/packages/xinity-ai-dashboard/src/lib/server/license/license.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/license/license.ts
@@ -3,6 +3,7 @@ import { LicensePayloadSchema, type LicenseInfo, type LicenseFeature } from "./t
 import { PUBLIC_KEY_BASE64 } from "./public-key";
 import { rootLogger } from "$lib/server/logging";
 import { serverEnv } from "../serverenv";
+import { getDeploymentId } from "../deployment-id";
 
 const log = rootLogger.child({ name: "license" });
 
@@ -73,6 +74,25 @@ export function hasOriginMismatch(): boolean {
 }
 
 /**
+ * Returns true if a paid license is active and carries an instanceId claim
+ * that does not match this dashboard's deployment instance ID.
+ *
+ * Licenses without an instanceId claim are unbounded and always pass.
+ * If the deployment ID has not yet loaded (cold start, DB unreachable),
+ * we cannot verify - return false to avoid false positives, the warmup
+ * pass in hooks.server.ts triggers a re-evaluation on the next call.
+ */
+export function hasInstanceMismatch(): boolean {
+  const license = getLicense();
+  if (!license.valid) return false;
+  const claim = license.payload.instanceId;
+  if (!claim) return false;
+  const local = getDeploymentId();
+  if (!local) return false;
+  return claim !== local;
+}
+
+/**
  * Returns the current license info. Reads from LICENSE_KEY env var on first call, then caches.
  * Returns a free-tier fallback if no key is set or if the key is invalid.
  */
@@ -102,6 +122,14 @@ export function getLicense(): LicenseInfo {
       log.error(
         { allowedOrigins: cachedLicense.payload.origins, actual: serverEnv.ORIGIN },
         "LICENSE ORIGIN MISMATCH: The dashboard ORIGIN does not match the licensed origin. The dashboard will idle until this is corrected.",
+      );
+    }
+
+    // Check instance ID mismatch (only when the license carries an instanceId claim)
+    if (hasInstanceMismatch()) {
+      log.error(
+        { licensedInstanceId: cachedLicense.payload.instanceId, actual: getDeploymentId() },
+        "LICENSE INSTANCE MISMATCH: The dashboard instance ID does not match the licensed instance ID. The dashboard will idle until this is corrected.",
       );
     }
   } else {
@@ -174,6 +202,7 @@ export function getLicenseSummary() {
     expired: isExpired(),
     inGracePeriod: isInGracePeriod(),
     originMismatch: hasOriginMismatch(),
+    instanceMismatch: hasInstanceMismatch(),
     maxVramGb: maxVramGb(),
     features: {
       sso: hasFeature("sso"),

--- a/packages/xinity-ai-dashboard/src/lib/server/license/types.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/license/types.ts
@@ -15,6 +15,9 @@ export const LicensePayloadSchema = z.object({
   origins: z.array(z.string().min(1)).min(1),
   issuedAt: z.number().int(),
   expiresAt: z.number().int(),
+  // Optional binding to a specific dashboard install. When set, validation
+  // requires the local deployment_config.instance_id to match.
+  instanceId: z.string().uuid().optional(),
 });
 
 export type LicensePayload = z.infer<typeof LicensePayloadSchema>;

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/instance-settings/+layout.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/instance-settings/+layout.svelte
@@ -3,7 +3,7 @@
   import type { Snippet } from "svelte";
   import * as Card from "$lib/components/ui/card";
   import { Button } from "$lib/components/ui/button";
-  import { Users, Building2, Shield } from "@lucide/svelte";
+  import { Users, Building2, Shield, KeyRound } from "@lucide/svelte";
 
   const { children }: { children: Snippet } = $props();
 
@@ -11,6 +11,7 @@
     { href: "/instance-settings/users", label: "Users", icon: Users },
     { href: "/instance-settings/organizations", label: "Organizations", icon: Building2 },
     { href: "/instance-settings/sso", label: "SSO", icon: Shield },
+    { href: "/instance-settings/license", label: "License", icon: KeyRound },
   ];
 
   const currentPath = $derived($page.url.pathname);

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/instance-settings/license/+page.server.ts
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/instance-settings/license/+page.server.ts
@@ -1,10 +1,25 @@
 import type { PageServerLoad } from "./$types";
 import { getLicenseSummary } from "$lib/server/license";
-import { getDeploymentId } from "$lib/server/deployment-id";
+import { getDeploymentId, loadDeploymentId } from "$lib/server/deployment-id";
+import { rootLogger } from "$lib/server/logging";
+
+const log = rootLogger.child({ name: "instance-settings.license" });
 
 export const load: PageServerLoad = async () => {
+  // If the startup warmup failed (transient DB error), recover on demand so the
+  // page can show the instance ID instead of a permanent "not initialised" state.
+  let instanceId = getDeploymentId();
+  if (!instanceId) {
+    try {
+      instanceId = await loadDeploymentId();
+    } catch (err) {
+      log.error({ err }, "Failed to load deployment instance ID on demand");
+      instanceId = null;
+    }
+  }
+
   return {
     license: getLicenseSummary(),
-    instanceId: getDeploymentId(),
+    instanceId,
   };
 };

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/instance-settings/license/+page.server.ts
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/instance-settings/license/+page.server.ts
@@ -1,0 +1,10 @@
+import type { PageServerLoad } from "./$types";
+import { getLicenseSummary } from "$lib/server/license";
+import { getDeploymentId } from "$lib/server/deployment-id";
+
+export const load: PageServerLoad = async () => {
+  return {
+    license: getLicenseSummary(),
+    instanceId: getDeploymentId(),
+  };
+};

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/instance-settings/license/+page.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/instance-settings/license/+page.svelte
@@ -71,6 +71,7 @@
             variant="outline"
             size="icon"
             title="Copy instance ID"
+            aria-label="Copy instance ID"
             onclick={() => copyToClipboard(data.instanceId!)}
           >
             <Copy class="w-4 h-4" />

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/instance-settings/license/+page.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/instance-settings/license/+page.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+  import * as Card from "$lib/components/ui/card";
+  import { Button } from "$lib/components/ui/button";
+  import { Badge } from "$lib/components/ui/badge";
+  import { Copy } from "@lucide/svelte";
+  import { copyToClipboard } from "$lib/copy";
+  import type { PageData } from "./$types";
+
+  const { data }: { data: PageData } = $props();
+
+  const tierLabel: Record<string, string> = {
+    free: "Free",
+    startup: "Startup",
+    "enterprise-sm": "Enterprise (Small)",
+    "enterprise-lg": "Enterprise (Large)",
+  };
+</script>
+
+<Card.Root>
+  <Card.Header>
+    <Card.Title>License</Card.Title>
+    <Card.Description>Active license details for this dashboard install.</Card.Description>
+  </Card.Header>
+  <Card.Content class="space-y-6">
+    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      <div>
+        <p class="text-sm text-muted-foreground">Tier</p>
+        <p class="font-medium">{tierLabel[data.license.tier] ?? data.license.tier}</p>
+      </div>
+      <div>
+        <p class="text-sm text-muted-foreground">Licensee</p>
+        <p class="font-medium">{data.license.licensee ?? "-"}</p>
+      </div>
+      <div>
+        <p class="text-sm text-muted-foreground">Max VRAM</p>
+        <p class="font-medium">
+          {data.license.maxVramGb === Infinity ? "Unlimited" : `${data.license.maxVramGb} GB`}
+        </p>
+      </div>
+      <div>
+        <p class="text-sm text-muted-foreground">Status</p>
+        <div class="flex flex-wrap gap-2 mt-0.5">
+          {#if data.license.expired && !data.license.inGracePeriod}
+            <Badge variant="destructive">Expired</Badge>
+          {:else if data.license.inGracePeriod}
+            <Badge variant="outline">Grace period</Badge>
+          {:else if data.license.tier !== "free"}
+            <Badge>Active</Badge>
+          {:else}
+            <Badge variant="outline">Free tier</Badge>
+          {/if}
+          {#if data.license.originMismatch}
+            <Badge variant="destructive">Origin mismatch</Badge>
+          {/if}
+          {#if data.license.instanceMismatch}
+            <Badge variant="destructive">Instance mismatch</Badge>
+          {/if}
+        </div>
+      </div>
+    </div>
+
+    <div class="border-t pt-6">
+      <p class="text-sm text-muted-foreground">Deployment instance ID</p>
+      <p class="text-xs text-muted-foreground mt-1 mb-2">
+        Provide this ID when requesting a license to bind it to this specific dashboard install.
+      </p>
+      {#if data.instanceId}
+        <div class="flex items-center gap-2">
+          <code class="flex-1 px-3 py-2 rounded bg-muted text-sm font-mono break-all">{data.instanceId}</code>
+          <Button
+            variant="outline"
+            size="icon"
+            title="Copy instance ID"
+            onclick={() => copyToClipboard(data.instanceId!)}
+          >
+            <Copy class="w-4 h-4" />
+          </Button>
+        </div>
+      {:else}
+        <p class="text-sm text-muted-foreground italic">Not yet initialised. Restart the dashboard to generate one.</p>
+      {/if}
+    </div>
+  </Card.Content>
+</Card.Root>


### PR DESCRIPTION
## Summary
- Adds an optional `instanceId` UUID claim to the license payload, mirroring the existing `origins` binding. When present, the local `deployment_config.instance_id` must match or the dashboard logs a license-mismatch error and surfaces it in the license summary.
- Licenses without the claim continue to validate as before, so existing keys are unaffected.
- Generates and caches a stable per-install instance ID in a new `deployment_config` singleton table, displayed in a new instance-settings License page so operators can copy it into their license-request form.

## Why
The existing `origins` claim binds a license to one dashboard URL but does not protect against a leaked or copied key being moved to a different install at the same URL. An optional instance binding closes that gap without changing the issuance flow for existing customers.

## Out of scope
The external signing service that issues licenses needs to accept the new `instanceId` field and embed it in the payload. That change lives outside this repo.

## Test plan
- [x] `bun test src/` in `packages/xinity-ai-dashboard` - 27/27 license tests pass, including six new cases (matching, mismatched, absent claim, unloaded local id, free tier, non-UUID rejection).
- [x] Apply the new `0006_absurd_dagger.sql` migration on a fresh database and confirm `deployment_config` is created with one row and a stable `instance_id`.
- [x] Restart the dashboard twice and confirm the same `instance_id` is reported on `/instance-settings/license`.
- [x] Sign a test license with `instanceId` matching the local row, confirm the License page shows no mismatch.
- [x] Sign a test license with a different `instanceId`, confirm the dashboard logs `LICENSE INSTANCE MISMATCH` and the summary flag is surfaced on the License page.