### PR TITLE
feat: model deployment testing

### DIFF
--- a/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/model.procedure.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/model.procedure.ts
@@ -3,7 +3,10 @@ import z from "zod";
 import { ModelSchema } from "xinity-infoserver";
 import { infoClient } from "$lib/server/info-client";
 
-const ModelWithSpecifierSchema = ModelSchema.extend({ publicSpecifier: z.string() });
+const ModelWithSpecifierSchema = ModelSchema.extend({
+  publicSpecifier: z.string(),
+  _source: z.string(),
+});
 
 const PaginatedModelsSchema = z.object({
   models: ModelWithSpecifierSchema.array(),

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/docs/access-methods/+page.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/docs/access-methods/+page.svelte
@@ -87,9 +87,10 @@
     <h3 class="mb-1 text-xl font-semibold">Dashboard UI</h3>
     <p class="mb-4 text-gray-600">
       The web interface you are using right now. Covers day-to-day operations: managing deployments, API keys,
-      applications, organizations, and reviewing recorded LLM calls. No credentials or tooling required beyond a browser.
+      applications, organizations, reviewing recorded LLM calls, and testing chat / embedding / rerank deployments
+      directly from the Model Hub without writing any client code. No credentials or tooling required beyond a browser.
     </p>
-    <p class="text-sm text-gray-500">Best for: visual exploration, one-off administrative tasks, reviewing call history.</p>
+    <p class="text-sm text-gray-500">Best for: visual exploration, one-off administrative tasks, reviewing call history, smoke-testing a freshly-deployed model.</p>
   </div>
 
   <!-- Management REST API -->

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/docs/quick-start/+page.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/docs/quick-start/+page.svelte
@@ -165,7 +165,7 @@ const completion = await openai.chat.completions.create({
   <section class="mb-8 p-6 bg-white rounded-lg shadow-md">
     <div class="flex items-start gap-3 mb-4">
       <div
-        class="flex-shrink-0 w-8 h-8 bg-xinity-purple text-white rounded-full flex items-center justify-center font-bold"
+        class="shrink-0 w-8 h-8 bg-xinity-purple text-white rounded-full flex items-center justify-center font-bold"
       >
         1
       </div>
@@ -188,6 +188,16 @@ const completion = await openai.chat.completions.create({
             take a few minutes depending on the model size.
           </li>
         </ol>
+        <div class="mt-4 p-4 bg-xinity-purple/10 border-l-4 border-xinity-purple rounded">
+          <p class="text-sm text-xinity-pink">
+            <strong>Tip:</strong> Once the deployment is in the "Ready" state,
+            click the <strong>Test</strong> button on its card to try it out
+            directly from the Model Hub. Chat, embedding, and rerank models all
+            get a tailored input/output panel. You can paste an existing API
+            key or generate a temporary one that is cleaned up automatically
+            when you close the dialog.
+          </p>
+        </div>
       </div>
     </div>
   </section>
@@ -196,7 +206,7 @@ const completion = await openai.chat.completions.create({
   <section class="mb-8 p-6 bg-white rounded-lg shadow-md">
     <div class="flex items-start gap-3 mb-4">
       <div
-        class="flex-shrink-0 w-8 h-8 bg-xinity-purple text-white rounded-full flex items-center justify-center font-bold"
+        class="shrink-0 w-8 h-8 bg-xinity-purple text-white rounded-full flex items-center justify-center font-bold"
       >
         2
       </div>
@@ -233,7 +243,7 @@ const completion = await openai.chat.completions.create({
   <section class="mb-8 p-6 bg-white rounded-lg shadow-md">
     <div class="flex items-start gap-3 mb-4">
       <div
-        class="flex-shrink-0 w-8 h-8 bg-xinity-purple text-white rounded-full flex items-center justify-center font-bold"
+        class="shrink-0 w-8 h-8 bg-xinity-purple text-white rounded-full flex items-center justify-center font-bold"
       >
         3
       </div>
@@ -267,7 +277,7 @@ const completion = await openai.chat.completions.create({
   <section class="mb-8 p-6 bg-white rounded-lg shadow-md">
     <div class="flex items-start gap-3 mb-4">
       <div
-        class="flex-shrink-0 w-8 h-8 bg-xinity-purple text-white rounded-full flex items-center justify-center font-bold"
+        class="shrink-0 w-8 h-8 bg-xinity-purple text-white rounded-full flex items-center justify-center font-bold"
       >
         4
       </div>
@@ -298,7 +308,7 @@ const completion = await openai.chat.completions.create({
   <section class="mb-8 p-6 bg-white rounded-lg shadow-md">
     <div class="flex items-start gap-3 mb-4">
       <div
-        class="flex-shrink-0 w-8 h-8 bg-xinity-purple text-white rounded-full flex items-center justify-center font-bold"
+        class="shrink-0 w-8 h-8 bg-xinity-purple text-white rounded-full flex items-center justify-center font-bold"
       >
         5
       </div>
@@ -336,7 +346,7 @@ const completion = await openai.chat.completions.create({
   <section class="mb-8 p-6 bg-white rounded-lg shadow-md">
     <div class="flex items-start gap-3 mb-4">
       <div
-        class="flex-shrink-0 w-8 h-8 bg-xinity-purple text-white rounded-full flex items-center justify-center font-bold"
+        class="shrink-0 w-8 h-8 bg-xinity-purple text-white rounded-full flex items-center justify-center font-bold"
       >
         6
       </div>
@@ -369,7 +379,7 @@ const completion = await openai.chat.completions.create({
   <section class="mb-8 p-6 bg-white rounded-lg shadow-md">
     <div class="flex items-start gap-3 mb-4">
       <div
-        class="flex-shrink-0 w-8 h-8 bg-xinity-purple text-white rounded-full flex items-center justify-center font-bold"
+        class="shrink-0 w-8 h-8 bg-xinity-purple text-white rounded-full flex items-center justify-center font-bold"
       >
         7
       </div>
@@ -412,7 +422,7 @@ const completion = await openai.chat.completions.create({
   </section>
 
   <!-- Next Steps -->
-  <section class="p-6 bg-gradient-to-r from-xinity-purple/10 to-xinity-coral/10 rounded-lg">
+  <section class="p-6 bg-linear-to-r from-xinity-purple/10 to-xinity-coral/10 rounded-lg">
     <h2 class="text-2xl font-semibold mb-4">Next Steps</h2>
     <div class="space-y-3">
       <a

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/+page.server.ts
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/+page.server.ts
@@ -3,6 +3,8 @@ import { router } from "$lib/server/orpc/router";
 import { call } from "@orpc/server";
 import { buildClusterCapacity, type ClusterCapacity } from "$lib/server/orpc/procedures/cluster.procedure";
 import type { DeploymentWithStatus } from "$lib/server/orpc/procedures/deployment.procedure";
+import type { ApplicationDto } from "$lib/orpc/dtos/application.dto";
+import { isRedirect, isHttpError } from "@sveltejs/kit";
 
 const emptyCapacity: ClusterCapacity = {
   maxNodeFreeCapacity: 0,
@@ -11,19 +13,29 @@ const emptyCapacity: ClusterCapacity = {
   nodeCapabilities: [],
 };
 
-export const load: PageServerLoad = async ({ parent, request }) => {
+export const load: PageServerLoad = async ({ parent, locals, request }) => {
   const { session } = await parent();
   const activeOrgId = session.activeOrganizationId;
 
   if (!activeOrgId) {
-    return { deployments: Promise.resolve([] as DeploymentWithStatus[]), ...emptyCapacity };
+    return {
+      deployments: Promise.resolve([] as DeploymentWithStatus[]),
+      applications: [] as ApplicationDto[],
+      ...emptyCapacity,
+    };
   }
 
   // Stream deployments - page renders immediately with skeletons while this resolves
   const deployments = call(router.deployment.list, { withStatus: true }, { context: { request } });
   const capacity = await buildClusterCapacity();
+  const applications = await call(router.application.list, {}, { context: locals })
+    .then((r) => r as ApplicationDto[])
+    .catch((err) => {
+      if (isRedirect(err) || isHttpError(err)) throw err;
+      return [] as ApplicationDto[];
+    });
 
-  return { deployments, ...capacity };
+  return { deployments, applications, ...capacity };
 };
 
 export type { DeploymentWithStatus as DeploymentDefinition };

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/+page.server.ts
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/+page.server.ts
@@ -13,7 +13,7 @@ const emptyCapacity: ClusterCapacity = {
   nodeCapabilities: [],
 };
 
-export const load: PageServerLoad = async ({ parent, locals, request }) => {
+export const load: PageServerLoad = async ({ parent, locals }) => {
   const { session } = await parent();
   const activeOrgId = session.activeOrganizationId;
 
@@ -26,7 +26,7 @@ export const load: PageServerLoad = async ({ parent, locals, request }) => {
   }
 
   // Stream deployments - page renders immediately with skeletons while this resolves
-  const deployments = call(router.deployment.list, { withStatus: true }, { context: { request } });
+  const deployments = call(router.deployment.list, { withStatus: true }, { context: locals });
   const capacity = await buildClusterCapacity();
   const applications = await call(router.application.list, {}, { context: locals })
     .then((r) => r as ApplicationDto[])

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/+page.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/+page.svelte
@@ -3,7 +3,8 @@
   import type { DeploymentDefinition } from "./+page.server";
   import type { NodeCapability } from "xinity-infoserver";
   import DeploymentModal from "./DeploymentModal.svelte";
-  import TestModelModal from "./TestModelModal.svelte";
+  import TestChatModal from "./TestChatModal.svelte";
+  import TestEmbeddingModal from "./TestEmbeddingModal.svelte";
   import { orpc } from "$lib/orpc/orpc-client";
   import { humanDate, humanDuration, updateOptimistically } from "$lib/util";
   import { browserLogger } from "$lib/browserLogging";
@@ -105,9 +106,54 @@
   let showCreateDeploymentModal = $state(false);
   let editDeploymentModalId: string | null = $state(null);
   let testDeploymentModalId: string | null = $state(null);
+  let testModelType: "chat" | "embedding" | null = $state(null);
   let deploymentToDelete: DeploymentDefinition | null = $state(null);
   const editDeployment = $derived(deployments.find((d) => d.id === editDeploymentModalId));
   const testDeployment = $derived(deployments.find((d) => d.id === testDeploymentModalId) ?? null);
+
+  // Cached model type per modelSpecifier. Stays "loading" until we know, then
+  // either the resolved type or "unknown" (catalog miss / fetch error). The
+  // Test button only renders for entries we resolved to "chat" or "embedding".
+  type ModelTypeKnowledge =
+    | { status: "loading" }
+    | { status: "known"; type: "chat" | "embedding" | "rerank" }
+    | { status: "unknown" };
+  let modelKnowledge = $state<Record<string, ModelTypeKnowledge>>({});
+
+  $effect(() => {
+    if (!browser || !deploymentsLoaded) return;
+    for (const d of deployments) {
+      if (d.status?.phase !== "ready") continue;
+      if (modelKnowledge[d.modelSpecifier] !== undefined) continue;
+      modelKnowledge[d.modelSpecifier] = { status: "loading" };
+      void fetchModelType(d.modelSpecifier);
+    }
+  });
+
+  async function fetchModelType(specifier: string) {
+    const [err, model] = await orpc.model.get({ specifier });
+    if (err || !model) {
+      modelKnowledge[specifier] = { status: "unknown" };
+      return;
+    }
+    modelKnowledge[specifier] = { status: "known", type: model.type ?? "chat" };
+  }
+
+  function testableType(deployment: DeploymentDefinition): "chat" | "embedding" | null {
+    const k = modelKnowledge[deployment.modelSpecifier];
+    if (k?.status !== "known") return null;
+    return k.type === "chat" || k.type === "embedding" ? k.type : null;
+  }
+
+  function openTest(deployment: DeploymentDefinition, type: "chat" | "embedding") {
+    testModelType = type;
+    testDeploymentModalId = deployment.id;
+  }
+
+  function closeTest() {
+    testDeploymentModalId = null;
+    testModelType = null;
+  }
 
   const visibleDeployments = $derived(
     deployments
@@ -374,10 +420,17 @@
             {#if permissions.canManageDeployments || deployment.status?.phase === "ready"}
               <Card.Footer class="pt-4 border-t flex justify-end gap-2">
                 {#if deployment.status?.phase === "ready"}
-                  <Button variant="outline" size="sm" onclick={() => (testDeploymentModalId = deployment.id)}>
-                    <MessageSquare class="w-4 h-4" />
-                    Test
-                  </Button>
+                  {@const type = testableType(deployment)}
+                  {#if type}
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onclick={() => openTest(deployment, type)}
+                    >
+                      <MessageSquare class="w-4 h-4" />
+                      Test
+                    </Button>
+                  {/if}
                 {/if}
                 {#if permissions.canManageDeployments}
                   <Button variant="outline" size="sm" onclick={() => (editDeploymentModalId = deployment.id)}>
@@ -452,12 +505,20 @@
   />
 {/if}
 
-<TestModelModal
-  open={testDeployment !== null}
-  deployment={testDeployment}
-  applications={data.applications}
-  close={() => (testDeploymentModalId = null)}
-/>
+{#if testModelType === "chat"}
+  <TestChatModal
+    open={testDeployment !== null}
+    deployment={testDeployment}
+    applications={data.applications}
+    close={closeTest}
+  />
+{:else if testModelType === "embedding"}
+  <TestEmbeddingModal
+    open={testDeployment !== null}
+    deployment={testDeployment}
+    close={closeTest}
+  />
+{/if}
 
 <ConfirmDialog
   open={Boolean(deploymentToDelete)}

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/+page.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/+page.svelte
@@ -3,6 +3,7 @@
   import type { DeploymentDefinition } from "./+page.server";
   import type { NodeCapability } from "xinity-infoserver";
   import DeploymentModal from "./DeploymentModal.svelte";
+  import TestModelModal from "./TestModelModal.svelte";
   import { orpc } from "$lib/orpc/orpc-client";
   import { humanDate, humanDuration, updateOptimistically } from "$lib/util";
   import { browserLogger } from "$lib/browserLogging";
@@ -16,7 +17,7 @@
   import { Badge } from "$lib/components/ui/badge";
 
   // Icons
-  import { Plus, Pencil, Trash2, Copy, Rocket, Info } from "@lucide/svelte";
+  import { Plus, Pencil, Trash2, Copy, Rocket, Info, MessageSquare } from "@lucide/svelte";
   import { browser } from "$app/environment";
   import { permissions } from "$lib/state/permissions.svelte";
   import ConfirmDialog from "$lib/components/ConfirmDialog.svelte";
@@ -103,8 +104,10 @@
 
   let showCreateDeploymentModal = $state(false);
   let editDeploymentModalId: string | null = $state(null);
+  let testDeploymentModalId: string | null = $state(null);
   let deploymentToDelete: DeploymentDefinition | null = $state(null);
   const editDeployment = $derived(deployments.find((d) => d.id === editDeploymentModalId));
+  const testDeployment = $derived(deployments.find((d) => d.id === testDeploymentModalId) ?? null);
 
   const visibleDeployments = $derived(
     deployments
@@ -368,16 +371,24 @@
               {/if}
             </Card.Content>
 
-            {#if permissions.canManageDeployments}
+            {#if permissions.canManageDeployments || deployment.status?.phase === "ready"}
               <Card.Footer class="pt-4 border-t flex justify-end gap-2">
-                <Button variant="outline" size="sm" onclick={() => (editDeploymentModalId = deployment.id)}>
-                  <Pencil class="w-4 h-4" />
-                  Edit
-                </Button>
-                <Button variant="destructive" size="sm" onclick={() => requestDelete(deployment)}>
-                  <Trash2 class="w-4 h-4" />
-                  Delete
-                </Button>
+                {#if deployment.status?.phase === "ready"}
+                  <Button variant="outline" size="sm" onclick={() => (testDeploymentModalId = deployment.id)}>
+                    <MessageSquare class="w-4 h-4" />
+                    Test
+                  </Button>
+                {/if}
+                {#if permissions.canManageDeployments}
+                  <Button variant="outline" size="sm" onclick={() => (editDeploymentModalId = deployment.id)}>
+                    <Pencil class="w-4 h-4" />
+                    Edit
+                  </Button>
+                  <Button variant="destructive" size="sm" onclick={() => requestDelete(deployment)}>
+                    <Trash2 class="w-4 h-4" />
+                    Delete
+                  </Button>
+                {/if}
               </Card.Footer>
             {/if}
           </Card.Root>
@@ -440,6 +451,13 @@
     onSaved={refreshDeployments}
   />
 {/if}
+
+<TestModelModal
+  open={testDeployment !== null}
+  deployment={testDeployment}
+  applications={data.applications}
+  close={() => (testDeploymentModalId = null)}
+/>
 
 <ConfirmDialog
   open={Boolean(deploymentToDelete)}

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/+page.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/+page.svelte
@@ -5,6 +5,7 @@
   import DeploymentModal from "./DeploymentModal.svelte";
   import TestChatModal from "./TestChatModal.svelte";
   import TestEmbeddingModal from "./TestEmbeddingModal.svelte";
+  import TestRerankModal from "./TestRerankModal.svelte";
   import { orpc } from "$lib/orpc/orpc-client";
   import { humanDate, humanDuration, updateOptimistically } from "$lib/util";
   import { browserLogger } from "$lib/browserLogging";
@@ -106,14 +107,14 @@
   let showCreateDeploymentModal = $state(false);
   let editDeploymentModalId: string | null = $state(null);
   let testDeploymentModalId: string | null = $state(null);
-  let testModelType: "chat" | "embedding" | null = $state(null);
+  let testModelType: "chat" | "embedding" | "rerank" | null = $state(null);
   let deploymentToDelete: DeploymentDefinition | null = $state(null);
   const editDeployment = $derived(deployments.find((d) => d.id === editDeploymentModalId));
   const testDeployment = $derived(deployments.find((d) => d.id === testDeploymentModalId) ?? null);
 
   // Cached model type per modelSpecifier. Stays "loading" until we know, then
   // either the resolved type or "unknown" (catalog miss / fetch error). The
-  // Test button only renders for entries we resolved to "chat" or "embedding".
+  // Test button only renders for entries we resolved to a supported type.
   type ModelTypeKnowledge =
     | { status: "loading" }
     | { status: "known"; type: "chat" | "embedding" | "rerank" }
@@ -139,13 +140,18 @@
     modelKnowledge[specifier] = { status: "known", type: model.type ?? "chat" };
   }
 
-  function testableType(deployment: DeploymentDefinition): "chat" | "embedding" | null {
+  function testableType(
+    deployment: DeploymentDefinition,
+  ): "chat" | "embedding" | "rerank" | null {
     const k = modelKnowledge[deployment.modelSpecifier];
     if (k?.status !== "known") return null;
-    return k.type === "chat" || k.type === "embedding" ? k.type : null;
+    return k.type === "chat" || k.type === "embedding" || k.type === "rerank" ? k.type : null;
   }
 
-  function openTest(deployment: DeploymentDefinition, type: "chat" | "embedding") {
+  function openTest(
+    deployment: DeploymentDefinition,
+    type: "chat" | "embedding" | "rerank",
+  ) {
     testModelType = type;
     testDeploymentModalId = deployment.id;
   }
@@ -514,6 +520,12 @@
   />
 {:else if testModelType === "embedding"}
   <TestEmbeddingModal
+    open={testDeployment !== null}
+    deployment={testDeployment}
+    close={closeTest}
+  />
+{:else if testModelType === "rerank"}
+  <TestRerankModal
     open={testDeployment !== null}
     deployment={testDeployment}
     close={closeTest}

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/TestApiKeySection.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/TestApiKeySection.svelte
@@ -1,0 +1,130 @@
+<script lang="ts">
+  import { onDestroy } from "svelte";
+  import { Button } from "$lib/components/ui/button";
+  import { Input } from "$lib/components/ui/input";
+  import { Label } from "$lib/components/ui/label";
+  import { Sparkles, Trash2, Eye, EyeOff } from "@lucide/svelte";
+  import { orpc } from "$lib/orpc/orpc-client";
+  import { toastState } from "$lib/state/toast.svelte";
+  import { browserLogger } from "$lib/browserLogging";
+  import { permissions } from "$lib/state/permissions.svelte";
+
+  let {
+    apiKey = $bindable(""),
+    deploymentName,
+  }: {
+    apiKey: string;
+    deploymentName: string;
+  } = $props();
+
+  const canCreateKey = $derived(permissions.can("apiKey", "create"));
+
+  let showKey = $state(false);
+  let temporaryKeyId = $state<string | null>(null);
+  let creatingKey = $state(false);
+
+  async function generate() {
+    if (!canCreateKey || creatingKey) return;
+    creatingKey = true;
+    const stamp = new Date().toISOString().replace(/[-:.TZ]/g, "").slice(0, 12);
+    const [error, result] = await orpc.apiKey.create({
+      name: `Test - ${deploymentName} - ${stamp}`,
+      enabled: true,
+    });
+    creatingKey = false;
+    if (error) {
+      browserLogger.warn({ error }, "Failed to create temporary test key");
+      toastState.add("Failed to create temporary test key", "error");
+      return;
+    }
+    apiKey = result.fullKey;
+    showKey = true;
+    toastState.add("Temporary test key created", "success");
+    // create() returns the specifier but not the id; resolve via list so we
+    // can soft-delete the key later.
+    const [listError, list] = await orpc.apiKey.list({});
+    if (!listError) {
+      const created = list.find((k) => k.specifier === result.specifier);
+      temporaryKeyId = created?.id ?? null;
+    }
+  }
+
+  async function deleteNow() {
+    if (!temporaryKeyId) return;
+    const id = temporaryKeyId;
+    temporaryKeyId = null;
+    apiKey = "";
+    showKey = false;
+    const [error] = await orpc.apiKey.delete({ id });
+    if (error) {
+      browserLogger.warn({ error, id }, "Failed to delete temporary test key");
+      toastState.add("Failed to delete temporary test key", "error");
+    } else {
+      toastState.add("Temporary test key deleted", "success");
+    }
+  }
+
+  // Soft-delete the generated temp key when this section unmounts (modal
+  // close). Fire-and-forget; the user is gone, so failures only get logged.
+  onDestroy(() => {
+    if (!temporaryKeyId) return;
+    const id = temporaryKeyId;
+    void orpc.apiKey.delete({ id }).then(([error]) => {
+      if (error) browserLogger.warn({ error, id }, "Failed to delete temporary test key on close");
+    });
+  });
+</script>
+
+<section class="space-y-2">
+  <div class="flex items-center justify-between">
+    <Label for="testApiKey" class="text-sm font-semibold">API Key</Label>
+    {#if canCreateKey}
+      <Button
+        variant="ghost"
+        size="sm"
+        onclick={generate}
+        disabled={creatingKey}
+      >
+        <Sparkles class="w-4 h-4" />
+        {creatingKey ? "Creating..." : "Generate temporary key"}
+      </Button>
+    {/if}
+  </div>
+  <div class="flex items-center gap-2">
+    <Input
+      id="testApiKey"
+      type={showKey ? "text" : "password"}
+      bind:value={apiKey}
+      placeholder="Paste an API key (sk_...)"
+      class="font-mono text-xs"
+      autocomplete="off"
+    />
+    <Button
+      variant="outline"
+      size="icon"
+      onclick={() => (showKey = !showKey)}
+      title={showKey ? "Hide" : "Show"}
+    >
+      {#if showKey}
+        <EyeOff class="w-4 h-4" />
+      {:else}
+        <Eye class="w-4 h-4" />
+      {/if}
+    </Button>
+    {#if temporaryKeyId}
+      <Button
+        variant="outline"
+        size="icon"
+        onclick={deleteNow}
+        title="Delete generated key now"
+      >
+        <Trash2 class="w-4 h-4" />
+      </Button>
+    {/if}
+  </div>
+  {#if temporaryKeyId}
+    <p class="text-xs text-muted-foreground">
+      Temporary key created. It will be deleted automatically when you close this dialog.
+    </p>
+  {/if}
+</section>

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/TestApiKeySection.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/TestApiKeySection.svelte
@@ -65,12 +65,18 @@
   }
 
   // Soft-delete the generated temp key when this section unmounts (modal
-  // close). Fire-and-forget; the user is gone, so failures only get logged.
+  // close). Fire-and-forget so the modal can close without waiting; toast on
+  // both success and failure so the user sees the cleanup happened.
   onDestroy(() => {
     if (!temporaryKeyId) return;
     const id = temporaryKeyId;
     void orpc.apiKey.delete({ id }).then(([error]) => {
-      if (error) browserLogger.warn({ error, id }, "Failed to delete temporary test key on close");
+      if (error) {
+        browserLogger.warn({ error, id }, "Failed to delete temporary test key on close");
+        toastState.add("Failed to delete temporary test key", "error");
+      } else {
+        toastState.add("Temporary test key deleted", "success");
+      }
     });
   });
 </script>

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/TestChatModal.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/TestChatModal.svelte
@@ -1,20 +1,17 @@
 <script lang="ts">
   import Modal from "$lib/components/Modal.svelte";
   import { Button } from "$lib/components/ui/button";
-  import { Input } from "$lib/components/ui/input";
   import { Label } from "$lib/components/ui/label";
   import { Badge } from "$lib/components/ui/badge";
   import { Checkbox } from "$lib/components/ui/checkbox";
   import * as Select from "$lib/components/ui/select";
   import * as Alert from "$lib/components/ui/alert";
-  import { X, Send, Sparkles, Trash2, Eye, EyeOff, RotateCcw } from "@lucide/svelte";
+  import { X, Send, RotateCcw } from "@lucide/svelte";
 
-  import { orpc } from "$lib/orpc/orpc-client";
   import type { ApplicationDto } from "$lib/orpc/dtos/application.dto";
   import type { DeploymentDefinition } from "./+page.server";
-  import { toastState } from "$lib/state/toast.svelte";
   import { browserLogger } from "$lib/browserLogging";
-  import { permissions } from "$lib/state/permissions.svelte";
+  import TestApiKeySection from "./TestApiKeySection.svelte";
 
   type ChatMessage = { role: "user" | "assistant"; content: string };
 
@@ -33,14 +30,7 @@
     close: () => void;
   } = $props();
 
-  const canCreateKey = $derived(permissions.can("apiKey", "create"));
-
-  // API key. Either pasted by the user or pre-filled by "Generate temporary
-  // key", in which case it is soft-deleted automatically on close.
   let apiKey = $state("");
-  let showKey = $state(false);
-  let temporaryKeyId = $state<string | null>(null);
-  let creatingKey = $state(false);
 
   // Call settings
   let storeCall = $state(false);
@@ -106,48 +96,8 @@
   function resetState() {
     clearTranscript();
     apiKey = "";
-    showKey = false;
-    temporaryKeyId = null;
     storeCall = false;
     selectedApplicationId = NO_APPLICATION;
-  }
-
-  async function generateTemporaryKey() {
-    if (!deployment || creatingKey) return;
-    creatingKey = true;
-    const stamp = new Date().toISOString().replace(/[-:.TZ]/g, "").slice(0, 12);
-    const [error, result] = await orpc.apiKey.create({
-      name: `Test - ${deployment.name} - ${stamp}`,
-      enabled: true,
-    });
-    creatingKey = false;
-    if (error) {
-      browserLogger.warn({ error }, "Failed to create temporary test key");
-      toastState.add("Failed to create temporary test key", "error");
-      return;
-    }
-    apiKey = result.fullKey;
-    showKey = true;
-    // create() returns the specifier but not the id; resolve via list so we
-    // can soft-delete the key on close.
-    const [listError, list] = await orpc.apiKey.list({});
-    if (!listError) {
-      const created = list.find((k) => k.specifier === result.specifier);
-      temporaryKeyId = created?.id ?? null;
-    }
-  }
-
-  async function deleteTemporaryKey(silent = false) {
-    if (!temporaryKeyId) return;
-    const id = temporaryKeyId;
-    temporaryKeyId = null;
-    const [error] = await orpc.apiKey.delete({ id });
-    if (error) {
-      browserLogger.warn({ error, id }, "Failed to delete temporary test key");
-      if (!silent) toastState.add("Failed to clean up temporary test key", "error");
-    } else if (!silent) {
-      toastState.add("Temporary test key deleted", "success");
-    }
   }
 
   async function handleSend() {
@@ -257,11 +207,8 @@
     );
   }
 
-  async function handleClose() {
+  function handleClose() {
     inflight?.abort();
-    if (temporaryKeyId) {
-      await deleteTemporaryKey(true);
-    }
     close();
   }
 </script>
@@ -271,7 +218,7 @@
     <div class="bg-card rounded-xl shadow-2xl w-full max-w-3xl min-w-[min(48rem,90vw)] max-h-[90vh] flex flex-col">
       <header class="p-6 border-b flex justify-between items-center">
         <div>
-          <h2 class="text-2xl font-semibold">Test Model</h2>
+          <h2 class="text-2xl font-semibold">Test Chat Model</h2>
           <p class="text-sm text-muted-foreground mt-1">
             <span class="font-mono">{deployment.publicSpecifier}</span>
           </p>
@@ -282,59 +229,7 @@
       </header>
 
       <main class="p-6 flex-1 overflow-y-auto space-y-5">
-        <section class="space-y-2">
-          <div class="flex items-center justify-between">
-            <Label for="testApiKey" class="text-sm font-semibold">API Key</Label>
-            {#if canCreateKey}
-              <Button
-                variant="ghost"
-                size="sm"
-                onclick={generateTemporaryKey}
-                disabled={creatingKey}
-              >
-                <Sparkles class="w-4 h-4" />
-                {creatingKey ? "Creating..." : "Generate temporary key"}
-              </Button>
-            {/if}
-          </div>
-          <div class="flex items-center gap-2">
-            <Input
-              id="testApiKey"
-              type={showKey ? "text" : "password"}
-              bind:value={apiKey}
-              placeholder="Paste an API key (sk_...)"
-              class="font-mono text-xs"
-              autocomplete="off"
-            />
-            <Button
-              variant="outline"
-              size="icon"
-              onclick={() => (showKey = !showKey)}
-              title={showKey ? "Hide" : "Show"}
-            >
-              {#if showKey}
-                <EyeOff class="w-4 h-4" />
-              {:else}
-                <Eye class="w-4 h-4" />
-              {/if}
-            </Button>
-            {#if temporaryKeyId}
-              <Button
-                variant="outline"
-                size="icon"
-                onclick={() => deleteTemporaryKey(false)}
-                title="Delete generated key now"
-              >
-                <Trash2 class="w-4 h-4" />
-              </Button>
-            {/if}
-          </div>
-          {#if temporaryKeyId}
-            <p class="text-xs text-muted-foreground">
-              Temporary key created. It will be deleted automatically when you close this dialog.
-            </p>
-          {/if}
-        </section>
+        <TestApiKeySection bind:apiKey deploymentName={deployment.name} />
 
         <section class="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <div class="space-y-2">

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/TestEmbeddingModal.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/TestEmbeddingModal.svelte
@@ -1,0 +1,261 @@
+<script lang="ts">
+  import Modal from "$lib/components/Modal.svelte";
+  import { Button } from "$lib/components/ui/button";
+  import { Label } from "$lib/components/ui/label";
+  import * as Alert from "$lib/components/ui/alert";
+  import { X, Send, Copy, RotateCcw } from "@lucide/svelte";
+
+  import type { DeploymentDefinition } from "./+page.server";
+  import { browserLogger } from "$lib/browserLogging";
+  import { copyToClipboard } from "$lib/copy";
+  import TestApiKeySection from "./TestApiKeySection.svelte";
+
+  const DEFAULT_INPUT = "The quick brown fox jumps over the lazy dog.";
+  const PREVIEW_HEAD = 6;
+  const PREVIEW_TAIL = 2;
+
+  type EmbedResult = {
+    embedding: number[];
+    promptTokens: number;
+    totalTokens: number;
+    durationMs: number;
+  };
+
+  let {
+    open = $bindable(false),
+    deployment,
+    close,
+  }: {
+    open: boolean;
+    deployment: DeploymentDefinition | null;
+    close: () => void;
+  } = $props();
+
+  let apiKey = $state("");
+  let inputText = $state(DEFAULT_INPUT);
+  let result = $state<EmbedResult | null>(null);
+  let errorMessage = $state<string | null>(null);
+  let sending = $state(false);
+  let inputEl = $state<HTMLTextAreaElement | null>(null);
+  let inflight: AbortController | null = null;
+
+  const canSend = $derived(
+    !sending && apiKey.trim().length > 0 && inputText.trim().length > 0,
+  );
+  const canReset = $derived(
+    sending || result !== null || errorMessage !== null || inputText !== DEFAULT_INPUT,
+  );
+
+  // Fresh-open reset. Triggers on every false->true transition.
+  let wasOpen = $state(false);
+  $effect(() => {
+    if (open && !wasOpen) {
+      resetState();
+      queueMicrotask(() => inputEl?.focus());
+    }
+    wasOpen = open;
+  });
+
+  function resetState() {
+    inflight?.abort();
+    inflight = null;
+    sending = false;
+    inputText = DEFAULT_INPUT;
+    result = null;
+    errorMessage = null;
+    apiKey = "";
+  }
+
+  function resetInput() {
+    inflight?.abort();
+    inflight = null;
+    sending = false;
+    inputText = DEFAULT_INPUT;
+    result = null;
+    errorMessage = null;
+    queueMicrotask(() => inputEl?.focus());
+  }
+
+  async function handleSend() {
+    if (!canSend || !deployment) return;
+    sending = true;
+    errorMessage = null;
+    result = null;
+
+    inflight?.abort();
+    const ctrl = new AbortController();
+    inflight = ctrl;
+
+    const start = performance.now();
+    try {
+      const res = await fetch("/modelhub/test-embed", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        signal: ctrl.signal,
+        body: JSON.stringify({
+          apiKey: apiKey.trim(),
+          model: deployment.publicSpecifier,
+          input: inputText,
+        }),
+      });
+
+      if (!res.ok) {
+        errorMessage = await formatErrorBody(res);
+        return;
+      }
+
+      const json = await res.json();
+      const embedding = json?.data?.[0]?.embedding;
+      if (!Array.isArray(embedding) || embedding.length === 0) {
+        errorMessage = "Unexpected response shape: missing embedding vector";
+        return;
+      }
+      result = {
+        embedding,
+        promptTokens: json?.usage?.prompt_tokens ?? 0,
+        totalTokens: json?.usage?.total_tokens ?? 0,
+        durationMs: Math.round(performance.now() - start),
+      };
+    } catch (err) {
+      if (ctrl.signal.aborted) return;
+      browserLogger.warn({ err }, "Test embedding request failed");
+      errorMessage = err instanceof Error ? err.message : "Network error";
+    } finally {
+      if (inflight === ctrl) inflight = null;
+      sending = false;
+    }
+  }
+
+  async function formatErrorBody(res: Response): Promise<string> {
+    const text = await res.text().catch(() => "");
+    try {
+      const parsed = JSON.parse(text);
+      if (parsed?.error?.message) return String(parsed.error.message);
+    } catch {
+      /* fall through to raw text */
+    }
+    return text || `Request failed (${res.status})`;
+  }
+
+  function handleClose() {
+    inflight?.abort();
+    close();
+  }
+
+  function copyVector() {
+    if (!result) return;
+    copyToClipboard(JSON.stringify(result.embedding));
+  }
+
+  function previewVector(v: number[]): string {
+    const fmt = (n: number) => n.toFixed(4);
+    if (v.length <= PREVIEW_HEAD + PREVIEW_TAIL + 1) return v.map(fmt).join(", ");
+    const head = v.slice(0, PREVIEW_HEAD).map(fmt).join(", ");
+    const tail = v.slice(-PREVIEW_TAIL).map(fmt).join(", ");
+    return `${head}, ..., ${tail}`;
+  }
+</script>
+
+<Modal {open} onClose={handleClose} class="z-40">
+  {#if open && deployment}
+    <div class="bg-card rounded-xl shadow-2xl w-full max-w-3xl min-w-[min(48rem,90vw)] max-h-[90vh] flex flex-col">
+      <header class="p-6 border-b flex justify-between items-center">
+        <div>
+          <h2 class="text-2xl font-semibold">Test Embedding Model</h2>
+          <p class="text-sm text-muted-foreground mt-1">
+            <span class="font-mono">{deployment.publicSpecifier}</span>
+          </p>
+        </div>
+        <Button variant="ghost" size="icon" onclick={handleClose} aria-label="Close test modal">
+          <X class="w-5 h-5" />
+        </Button>
+      </header>
+
+      <main class="p-6 flex-1 overflow-y-auto space-y-5">
+        <TestApiKeySection bind:apiKey deploymentName={deployment.name} />
+
+        <section class="space-y-2">
+          <div class="flex items-center justify-between">
+            <Label for="testEmbedInput" class="text-sm font-semibold">Input</Label>
+            <Button
+              variant="ghost"
+              size="sm"
+              onclick={resetInput}
+              disabled={!canReset}
+              title="Clear input and result"
+            >
+              <RotateCcw class="w-4 h-4" />
+              Reset
+            </Button>
+          </div>
+          <textarea
+            id="testEmbedInput"
+            bind:value={inputText}
+            bind:this={inputEl}
+            placeholder="Text to embed..."
+            rows="4"
+            disabled={sending}
+            class="w-full min-h-24 rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring resize-y"
+          ></textarea>
+        </section>
+
+        {#if errorMessage}
+          <Alert.Root variant="destructive">
+            <Alert.Description>{errorMessage}</Alert.Description>
+          </Alert.Root>
+        {/if}
+
+        {#if result}
+          <section class="space-y-3">
+            <Label class="text-sm font-semibold">Result</Label>
+            <div class="grid grid-cols-2 sm:grid-cols-4 gap-2">
+              <div class="rounded-md border bg-muted/40 p-3">
+                <div class="text-xs text-muted-foreground">Dimensions</div>
+                <div class="font-mono text-sm">{result.embedding.length}</div>
+              </div>
+              <div class="rounded-md border bg-muted/40 p-3">
+                <div class="text-xs text-muted-foreground">Prompt tokens</div>
+                <div class="font-mono text-sm">{result.promptTokens}</div>
+              </div>
+              <div class="rounded-md border bg-muted/40 p-3">
+                <div class="text-xs text-muted-foreground">Total tokens</div>
+                <div class="font-mono text-sm">{result.totalTokens}</div>
+              </div>
+              <div class="rounded-md border bg-muted/40 p-3">
+                <div class="text-xs text-muted-foreground">Duration</div>
+                <div class="font-mono text-sm">{result.durationMs} ms</div>
+              </div>
+            </div>
+            <div class="space-y-2">
+              <div class="flex items-center justify-between">
+                <Label class="text-sm font-semibold">Vector preview</Label>
+                <Button variant="outline" size="sm" onclick={copyVector}>
+                  <Copy class="w-4 h-4" />
+                  Copy full vector
+                </Button>
+              </div>
+              <div class="rounded-md border bg-background px-3 py-2 font-mono text-xs break-all">
+                [{previewVector(result.embedding)}]
+              </div>
+            </div>
+          </section>
+        {/if}
+
+        {#if !apiKey.trim()}
+          <Alert.Root>
+            <Alert.Description class="text-xs">
+              Paste an API key or click "Generate temporary key" to compute an embedding.
+            </Alert.Description>
+          </Alert.Root>
+        {/if}
+      </main>
+
+      <footer class="p-4 border-t bg-muted/40 rounded-b-xl flex justify-end gap-2">
+        <Button onclick={handleSend} disabled={!canSend}>
+          <Send class="w-4 h-4" />
+          {sending ? "Computing..." : "Compute embedding"}
+        </Button>
+      </footer>
+    </div>
+  {/if}
+</Modal>

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/TestModelModal.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/TestModelModal.svelte
@@ -1,0 +1,447 @@
+<script lang="ts">
+  import Modal from "$lib/components/Modal.svelte";
+  import { Button } from "$lib/components/ui/button";
+  import { Input } from "$lib/components/ui/input";
+  import { Label } from "$lib/components/ui/label";
+  import { Badge } from "$lib/components/ui/badge";
+  import { Checkbox } from "$lib/components/ui/checkbox";
+  import * as Select from "$lib/components/ui/select";
+  import * as Alert from "$lib/components/ui/alert";
+  import { X, Send, Sparkles, Trash2, Eye, EyeOff, RotateCcw } from "@lucide/svelte";
+
+  import { orpc } from "$lib/orpc/orpc-client";
+  import type { ApplicationDto } from "$lib/orpc/dtos/application.dto";
+  import type { DeploymentDefinition } from "./+page.server";
+  import { toastState } from "$lib/state/toast.svelte";
+  import { browserLogger } from "$lib/browserLogging";
+  import { permissions } from "$lib/state/permissions.svelte";
+
+  type ChatMessage = { role: "user" | "assistant"; content: string };
+
+  const DEFAULT_PROMPT = "Hi, introduce yourself";
+  const NO_APPLICATION = "__none__";
+
+  let {
+    open = $bindable(false),
+    deployment,
+    applications = [],
+    close,
+  }: {
+    open: boolean;
+    deployment: DeploymentDefinition | null;
+    applications?: ApplicationDto[];
+    close: () => void;
+  } = $props();
+
+  const canCreateKey = $derived(permissions.can("apiKey", "create"));
+
+  // API key. Either pasted by the user or pre-filled by "Generate temporary
+  // key", in which case it is soft-deleted automatically on close.
+  let apiKey = $state("");
+  let showKey = $state(false);
+  let temporaryKeyId = $state<string | null>(null);
+  let creatingKey = $state(false);
+
+  // Call settings
+  let storeCall = $state(false);
+  let selectedApplicationId = $state<string>(NO_APPLICATION);
+
+  // Chat state
+  let messages = $state<ChatMessage[]>([]);
+  let inputValue = $state(DEFAULT_PROMPT);
+  let sending = $state(false);
+  let chatScroll = $state<HTMLDivElement | null>(null);
+  let inputEl = $state<HTMLTextAreaElement | null>(null);
+  let inflight: AbortController | null = null;
+
+  const selectedApplication = $derived(
+    selectedApplicationId === NO_APPLICATION
+      ? null
+      : applications.find((a) => a.id === selectedApplicationId) ?? null,
+  );
+
+  const canSend = $derived(
+    !sending && apiKey.trim().length > 0 && inputValue.trim().length > 0,
+  );
+
+  // Re-scroll on every streamed chunk; depending on total content length
+  // (rather than messages.length) so chunks that don't change message count
+  // also fire the effect.
+  const totalContentLen = $derived(messages.reduce((n, m) => n + m.content.length, 0));
+  $effect(() => {
+    void totalContentLen;
+    if (chatScroll && messages.length > 0) {
+      chatScroll.scrollTop = chatScroll.scrollHeight;
+    }
+  });
+
+  // Fresh-open reset. Triggers on every false->true transition so reopening
+  // after an error always starts clean.
+  let wasOpen = $state(false);
+  $effect(() => {
+    if (open && !wasOpen) {
+      resetState();
+      focusInput();
+    }
+    wasOpen = open;
+  });
+
+  function focusInput() {
+    queueMicrotask(() => inputEl?.focus());
+  }
+
+  function clearTranscript() {
+    inflight?.abort();
+    inflight = null;
+    sending = false;
+    messages = [];
+    inputValue = DEFAULT_PROMPT;
+  }
+
+  function resetChat() {
+    clearTranscript();
+    focusInput();
+  }
+
+  function resetState() {
+    clearTranscript();
+    apiKey = "";
+    showKey = false;
+    temporaryKeyId = null;
+    storeCall = false;
+    selectedApplicationId = NO_APPLICATION;
+  }
+
+  async function generateTemporaryKey() {
+    if (!deployment || creatingKey) return;
+    creatingKey = true;
+    const stamp = new Date().toISOString().replace(/[-:.TZ]/g, "").slice(0, 12);
+    const [error, result] = await orpc.apiKey.create({
+      name: `Test - ${deployment.name} - ${stamp}`,
+      enabled: true,
+    });
+    creatingKey = false;
+    if (error) {
+      browserLogger.warn({ error }, "Failed to create temporary test key");
+      toastState.add("Failed to create temporary test key", "error");
+      return;
+    }
+    apiKey = result.fullKey;
+    showKey = true;
+    // create() returns the specifier but not the id; resolve via list so we
+    // can soft-delete the key on close.
+    const [listError, list] = await orpc.apiKey.list({});
+    if (!listError) {
+      const created = list.find((k) => k.specifier === result.specifier);
+      temporaryKeyId = created?.id ?? null;
+    }
+  }
+
+  async function deleteTemporaryKey(silent = false) {
+    if (!temporaryKeyId) return;
+    const id = temporaryKeyId;
+    temporaryKeyId = null;
+    const [error] = await orpc.apiKey.delete({ id });
+    if (error) {
+      browserLogger.warn({ error, id }, "Failed to delete temporary test key");
+      if (!silent) toastState.add("Failed to clean up temporary test key", "error");
+    } else if (!silent) {
+      toastState.add("Temporary test key deleted", "success");
+    }
+  }
+
+  async function handleSend() {
+    if (!canSend || !deployment) return;
+    const userText = inputValue.trim();
+    inputValue = "";
+    // Append the user message + an empty assistant placeholder we stream into.
+    messages = [
+      ...messages,
+      { role: "user", content: userText },
+      { role: "assistant", content: "" },
+    ];
+    const assistantIdx = messages.length - 1;
+    sending = true;
+
+    inflight?.abort();
+    const ctrl = new AbortController();
+    inflight = ctrl;
+
+    // X-Application only matters when the call is being stored; skip it
+    // otherwise so behavior matches the disabled selector.
+    const applicationName = storeCall ? selectedApplication?.name ?? null : null;
+
+    try {
+      const res = await fetch("/modelhub/test-chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        signal: ctrl.signal,
+        body: JSON.stringify({
+          apiKey: apiKey.trim(),
+          model: deployment.publicSpecifier,
+          messages: messages
+            .slice(0, assistantIdx)
+            .map((m) => ({ role: m.role, content: m.content })),
+          store: storeCall,
+          applicationName,
+        }),
+      });
+
+      if (!res.ok) {
+        appendToAssistant(assistantIdx, `Error: ${await formatErrorBody(res)}`);
+        return;
+      }
+      if (!res.body) {
+        appendToAssistant(assistantIdx, "Error: empty response body");
+        return;
+      }
+
+      await consumeSseStream(res.body, assistantIdx);
+    } catch (err) {
+      // The abort path (close/reset/new send) is intentional, not a real error.
+      if (ctrl.signal.aborted) return;
+      browserLogger.warn({ err }, "Test chat request failed");
+      const detail = err instanceof Error ? err.message : "Network error";
+      appendToAssistant(assistantIdx, `Error: ${detail}`);
+    } finally {
+      if (inflight === ctrl) inflight = null;
+      sending = false;
+      // Skip refocus on abort: the modal is closing or the chat was reset, and
+      // grabbing focus mid-teardown would steal it from whatever is replacing us.
+      if (!ctrl.signal.aborted) focusInput();
+    }
+  }
+
+  async function consumeSseStream(body: ReadableStream<Uint8Array>, assistantIdx: number) {
+    const reader = body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) return;
+      buffer += decoder.decode(value, { stream: true });
+
+      let nlIdx: number;
+      while ((nlIdx = buffer.indexOf("\n")) >= 0) {
+        const line = buffer.slice(0, nlIdx).replace(/\r$/, "").trim();
+        buffer = buffer.slice(nlIdx + 1);
+        if (!line.startsWith("data:")) continue;
+        const payload = line.slice(5).trim();
+        if (payload === "[DONE]") return;
+        try {
+          const delta = JSON.parse(payload)?.choices?.[0]?.delta?.content;
+          if (typeof delta === "string" && delta.length > 0) {
+            appendToAssistant(assistantIdx, delta);
+          }
+        } catch (err) {
+          browserLogger.warn({ err, payload }, "Failed to parse SSE chunk");
+        }
+      }
+    }
+  }
+
+  async function formatErrorBody(res: Response): Promise<string> {
+    const text = await res.text().catch(() => "");
+    try {
+      const parsed = JSON.parse(text);
+      if (parsed?.error?.message) return String(parsed.error.message);
+    } catch {
+      /* fall through to raw text */
+    }
+    return text || `Request failed (${res.status})`;
+  }
+
+  function appendToAssistant(idx: number, text: string) {
+    messages = messages.map((m, i) =>
+      i === idx ? { ...m, content: m.content + text } : m,
+    );
+  }
+
+  async function handleClose() {
+    inflight?.abort();
+    if (temporaryKeyId) {
+      await deleteTemporaryKey(true);
+    }
+    close();
+  }
+</script>
+
+<Modal {open} onClose={handleClose} class="z-40">
+  {#if open && deployment}
+    <div class="bg-card rounded-xl shadow-2xl w-full max-w-3xl min-w-[min(48rem,90vw)] max-h-[90vh] flex flex-col">
+      <header class="p-6 border-b flex justify-between items-center">
+        <div>
+          <h2 class="text-2xl font-semibold">Test Model</h2>
+          <p class="text-sm text-muted-foreground mt-1">
+            <span class="font-mono">{deployment.publicSpecifier}</span>
+          </p>
+        </div>
+        <Button variant="ghost" size="icon" onclick={handleClose} aria-label="Close test modal">
+          <X class="w-5 h-5" />
+        </Button>
+      </header>
+
+      <main class="p-6 flex-1 overflow-y-auto space-y-5">
+        <section class="space-y-2">
+          <div class="flex items-center justify-between">
+            <Label for="testApiKey" class="text-sm font-semibold">API Key</Label>
+            {#if canCreateKey}
+              <Button
+                variant="ghost"
+                size="sm"
+                onclick={generateTemporaryKey}
+                disabled={creatingKey}
+              >
+                <Sparkles class="w-4 h-4" />
+                {creatingKey ? "Creating..." : "Generate temporary key"}
+              </Button>
+            {/if}
+          </div>
+          <div class="flex items-center gap-2">
+            <Input
+              id="testApiKey"
+              type={showKey ? "text" : "password"}
+              bind:value={apiKey}
+              placeholder="Paste an API key (sk_...)"
+              class="font-mono text-xs"
+              autocomplete="off"
+            />
+            <Button
+              variant="outline"
+              size="icon"
+              onclick={() => (showKey = !showKey)}
+              title={showKey ? "Hide" : "Show"}
+            >
+              {#if showKey}
+                <EyeOff class="w-4 h-4" />
+              {:else}
+                <Eye class="w-4 h-4" />
+              {/if}
+            </Button>
+            {#if temporaryKeyId}
+              <Button
+                variant="outline"
+                size="icon"
+                onclick={() => deleteTemporaryKey(false)}
+                title="Delete generated key now"
+              >
+                <Trash2 class="w-4 h-4" />
+              </Button>
+            {/if}
+          </div>
+          {#if temporaryKeyId}
+            <p class="text-xs text-muted-foreground">
+              Temporary key created. It will be deleted automatically when you close this dialog.
+            </p>
+          {/if}
+        </section>
+
+        <section class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div class="space-y-2">
+            <Label class="text-sm font-semibold">Logging</Label>
+            <label class="flex items-center gap-2 h-9 cursor-pointer select-none">
+              <Checkbox
+                checked={storeCall}
+                onCheckedChange={(checked) => (storeCall = checked === true)}
+              />
+              <span class="text-sm">Store calls</span>
+            </label>
+          </div>
+          <div class="space-y-2">
+            <Label for="testApplication" class="text-sm font-semibold {storeCall ? '' : 'text-muted-foreground'}">
+              Application
+            </Label>
+            <Select.Root type="single" bind:value={selectedApplicationId} disabled={!storeCall}>
+              <Select.Trigger id="testApplication" class="w-full">
+                {selectedApplication?.name ?? "None (default for key)"}
+              </Select.Trigger>
+              <Select.Content portalProps={{ disabled: true }}>
+                <Select.Item value={NO_APPLICATION} label="None (default for key)" />
+                {#each applications as app (app.id)}
+                  <Select.Item value={app.id} label={app.name} />
+                {/each}
+              </Select.Content>
+            </Select.Root>
+          </div>
+        </section>
+
+        <section class="space-y-3">
+          <div class="flex items-center justify-between">
+            <Label class="text-sm font-semibold">Conversation</Label>
+            <Button
+              variant="ghost"
+              size="sm"
+              onclick={resetChat}
+              disabled={messages.length === 0 && !sending}
+              title="Clear conversation and abort any in-flight request"
+            >
+              <RotateCcw class="w-4 h-4" />
+              Reset chat
+            </Button>
+          </div>
+          <div
+            bind:this={chatScroll}
+            class="h-72 overflow-y-auto rounded-md border bg-background p-3 space-y-3"
+          >
+            {#if messages.length === 0}
+              <p class="text-sm text-muted-foreground text-center py-12">
+                Send a message to start chatting with the model.
+              </p>
+            {:else}
+              {#each messages as msg, i (i)}
+                <div class="flex {msg.role === 'user' ? 'justify-end' : 'justify-start'}">
+                  <div
+                    class="max-w-[80%] rounded-lg px-3 py-2 text-sm whitespace-pre-wrap {msg.role === 'user' ? 'bg-primary text-primary-foreground' : 'bg-muted'}"
+                  >
+                    <div class="text-[10px] uppercase tracking-wider opacity-70 mb-1">
+                      {msg.role}
+                    </div>
+                    {#if msg.content}
+                      {msg.content}
+                    {:else if sending && i === messages.length - 1}
+                      <Badge variant="secondary">thinking...</Badge>
+                    {/if}
+                  </div>
+                </div>
+              {/each}
+            {/if}
+          </div>
+        </section>
+
+        {#if !apiKey.trim()}
+          <Alert.Root>
+            <Alert.Description class="text-xs">
+              Paste an API key or click "Generate temporary key" to start chatting.
+            </Alert.Description>
+          </Alert.Root>
+        {/if}
+      </main>
+
+      <footer class="p-4 border-t bg-muted/40 rounded-b-xl">
+        <form
+          onsubmit={(e) => { e.preventDefault(); void handleSend(); }}
+          class="flex items-end gap-2"
+        >
+          <textarea
+            bind:value={inputValue}
+            bind:this={inputEl}
+            placeholder="Type a message..."
+            rows="2"
+            disabled={sending}
+            onkeydown={(e) => {
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault();
+                void handleSend();
+              }
+            }}
+            class="flex-1 min-h-15 max-h-40 rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring resize-y"
+          ></textarea>
+          <Button type="submit" disabled={!canSend}>
+            <Send class="w-4 h-4" />
+            Send
+          </Button>
+        </form>
+      </footer>
+    </div>
+  {/if}
+</Modal>

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/TestRerankModal.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/TestRerankModal.svelte
@@ -1,0 +1,340 @@
+<script lang="ts">
+  import Modal from "$lib/components/Modal.svelte";
+  import { Button } from "$lib/components/ui/button";
+  import { Label } from "$lib/components/ui/label";
+  import * as Alert from "$lib/components/ui/alert";
+  import { X, Send, Plus, Trash2, RotateCcw } from "@lucide/svelte";
+
+  import type { DeploymentDefinition } from "./+page.server";
+  import { browserLogger } from "$lib/browserLogging";
+  import TestApiKeySection from "./TestApiKeySection.svelte";
+
+  const DEFAULT_QUERY = "What is the capital of France?";
+  const DEFAULT_DOCUMENTS = [
+    "Photosynthesis is the process by which green plants convert sunlight into chemical energy stored in glucose molecules. The chloroplasts in plant cells contain chlorophyll, which captures light energy from the sun. This biological mechanism is fundamental to nearly all life on Earth, as it produces the oxygen we breathe and forms the base of most food chains. While reviewing European geography notes last week, I was reminded that Paris is the capital of France, having served as the political and cultural center of the country for over a thousand years. The Calvin cycle and the light-dependent reactions are the two main stages of photosynthesis, each playing a distinct role in turning carbon dioxide and water into sugars.",
+    "Sourdough bread relies on a culture of wild yeast and lactobacilli to leaven and flavor the dough. Bakers maintain a starter by feeding it equal parts flour and water on a regular schedule, allowing the microorganisms to multiply. The fermentation process can take anywhere from twelve to twenty-four hours, depending on the room temperature and the activity of the starter. The resulting loaves develop a tangy flavor, an open crumb structure, and a thick, crackling crust. Many home bakers find that maintaining a healthy starter through changes in temperature and feeding schedule is the most challenging part of getting started.",
+    "Modern competitive chess has been transformed by the widespread availability of powerful engines and online play. Beginners now have access to instructional videos, puzzle databases, and computer analysis that previous generations could only have dreamed of. Tournaments at the highest level have shortened time controls, with rapid and blitz events drawing increasing attention from sponsors and audiences. Despite these changes, the classical format remains the gold standard for determining world champions, with individual games sometimes lasting five or six hours over a single playing session.",
+  ];
+
+  type RankedResult = {
+    rank: number;
+    inputIndex: number;
+    score: number;
+    text: string;
+  };
+
+  type RerankResult = {
+    ranks: RankedResult[];
+    durationMs: number;
+  };
+
+  let {
+    open = $bindable(false),
+    deployment,
+    close,
+  }: {
+    open: boolean;
+    deployment: DeploymentDefinition | null;
+    close: () => void;
+  } = $props();
+
+  let apiKey = $state("");
+  let query = $state(DEFAULT_QUERY);
+  let documents = $state<string[]>([...DEFAULT_DOCUMENTS]);
+  let result = $state<RerankResult | null>(null);
+  let errorMessage = $state<string | null>(null);
+  let sending = $state(false);
+  let queryEl = $state<HTMLTextAreaElement | null>(null);
+  let inflight: AbortController | null = null;
+
+  const trimmedDocuments = $derived(documents.map((d) => d.trim()).filter(Boolean));
+  const canSend = $derived(
+    !sending &&
+      apiKey.trim().length > 0 &&
+      query.trim().length > 0 &&
+      trimmedDocuments.length >= 1,
+  );
+  const canReset = $derived(
+    sending ||
+      result !== null ||
+      errorMessage !== null ||
+      query !== DEFAULT_QUERY ||
+      !arraysEqual(documents, DEFAULT_DOCUMENTS),
+  );
+
+  // Bar width is relative to the largest score in the response so models that
+  // emit small or negative scores still produce a readable chart.
+  const maxAbsScore = $derived(
+    result ? result.ranks.reduce((m, r) => Math.max(m, Math.abs(r.score)), 0) || 1 : 1,
+  );
+
+  // Fresh-open reset. Triggers on every false->true transition.
+  let wasOpen = $state(false);
+  $effect(() => {
+    if (open && !wasOpen) {
+      resetState();
+      queueMicrotask(() => queryEl?.focus());
+    }
+    wasOpen = open;
+  });
+
+  function arraysEqual(a: string[], b: string[]) {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+    return true;
+  }
+
+  function resetState() {
+    inflight?.abort();
+    inflight = null;
+    sending = false;
+    query = DEFAULT_QUERY;
+    documents = [...DEFAULT_DOCUMENTS];
+    result = null;
+    errorMessage = null;
+    apiKey = "";
+  }
+
+  function resetInputs() {
+    inflight?.abort();
+    inflight = null;
+    sending = false;
+    query = DEFAULT_QUERY;
+    documents = [...DEFAULT_DOCUMENTS];
+    result = null;
+    errorMessage = null;
+    queueMicrotask(() => queryEl?.focus());
+  }
+
+  function setDocument(idx: number, value: string) {
+    documents = documents.map((d, i) => (i === idx ? value : d));
+  }
+
+  function addDocument() {
+    documents = [...documents, ""];
+  }
+
+  function removeDocument(idx: number) {
+    if (documents.length <= 1) return;
+    documents = documents.filter((_, i) => i !== idx);
+  }
+
+  async function handleSend() {
+    if (!canSend || !deployment) return;
+    sending = true;
+    errorMessage = null;
+    result = null;
+
+    inflight?.abort();
+    const ctrl = new AbortController();
+    inflight = ctrl;
+
+    const docsForApi = trimmedDocuments;
+    const start = performance.now();
+    try {
+      const res = await fetch("/modelhub/test-rerank", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        signal: ctrl.signal,
+        body: JSON.stringify({
+          apiKey: apiKey.trim(),
+          model: deployment.publicSpecifier,
+          query: query.trim(),
+          documents: docsForApi,
+        }),
+      });
+
+      if (!res.ok) {
+        errorMessage = await formatErrorBody(res);
+        return;
+      }
+
+      const json = await res.json();
+      const results = json?.results;
+      if (!Array.isArray(results)) {
+        errorMessage = "Unexpected response shape: missing results array";
+        return;
+      }
+
+      result = {
+        ranks: results.map((r, rankIdx) => normalizeRankRow(r, rankIdx, docsForApi)),
+        durationMs: Math.round(performance.now() - start),
+      };
+    } catch (err) {
+      if (ctrl.signal.aborted) return;
+      browserLogger.warn({ err }, "Test rerank request failed");
+      errorMessage = err instanceof Error ? err.message : "Network error";
+    } finally {
+      if (inflight === ctrl) inflight = null;
+      sending = false;
+    }
+  }
+
+  // The `document` field can be a raw string, an object with a `text` field, or
+  // omitted entirely; fall back to the input we sent so the user always sees
+  // which document the rank refers to.
+  function normalizeRankRow(
+    row: unknown,
+    rankIdx: number,
+    sentDocs: string[],
+  ): RankedResult {
+    const r = row as { index?: number; relevance_score?: number; document?: unknown } | null;
+    const inputIndex = typeof r?.index === "number" ? r.index : rankIdx;
+    const score = typeof r?.relevance_score === "number" ? r.relevance_score : 0;
+    let text = "";
+    if (typeof r?.document === "string") {
+      text = r.document;
+    } else if (r?.document && typeof r.document === "object" && "text" in r.document) {
+      const t = (r.document as { text?: unknown }).text;
+      if (typeof t === "string") text = t;
+    }
+    if (!text) text = sentDocs[inputIndex] ?? "";
+    return { rank: rankIdx + 1, inputIndex, score, text };
+  }
+
+  async function formatErrorBody(res: Response): Promise<string> {
+    const text = await res.text().catch(() => "");
+    try {
+      const parsed = JSON.parse(text);
+      if (parsed?.error?.message) return String(parsed.error.message);
+    } catch {
+      /* fall through to raw text */
+    }
+    return text || `Request failed (${res.status})`;
+  }
+
+  function handleClose() {
+    inflight?.abort();
+    close();
+  }
+</script>
+
+<Modal {open} onClose={handleClose} class="z-40">
+  {#if open && deployment}
+    <div class="bg-card rounded-xl shadow-2xl w-full max-w-3xl min-w-[min(48rem,90vw)] max-h-[90vh] flex flex-col">
+      <header class="p-6 border-b flex justify-between items-center">
+        <div>
+          <h2 class="text-2xl font-semibold">Test Rerank Model</h2>
+          <p class="text-sm text-muted-foreground mt-1">
+            <span class="font-mono">{deployment.publicSpecifier}</span>
+          </p>
+        </div>
+        <Button variant="ghost" size="icon" onclick={handleClose} aria-label="Close test modal">
+          <X class="w-5 h-5" />
+        </Button>
+      </header>
+
+      <main class="p-6 flex-1 overflow-y-auto space-y-5">
+        <TestApiKeySection bind:apiKey deploymentName={deployment.name} />
+
+        <section class="space-y-2">
+          <div class="flex items-center justify-between">
+            <Label for="testRerankQuery" class="text-sm font-semibold">Query</Label>
+            <Button
+              variant="ghost"
+              size="sm"
+              onclick={resetInputs}
+              disabled={!canReset}
+              title="Restore defaults and clear results"
+            >
+              <RotateCcw class="w-4 h-4" />
+              Reset
+            </Button>
+          </div>
+          <textarea
+            id="testRerankQuery"
+            bind:value={query}
+            bind:this={queryEl}
+            placeholder="The query to rank documents against..."
+            rows="2"
+            disabled={sending}
+            class="w-full min-h-15 rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring resize-y"
+          ></textarea>
+        </section>
+
+        <section class="space-y-2">
+          <div class="flex items-center justify-between">
+            <Label class="text-sm font-semibold">Documents</Label>
+            <Button variant="ghost" size="sm" onclick={addDocument} disabled={sending}>
+              <Plus class="w-4 h-4" />
+              Add document
+            </Button>
+          </div>
+          <div class="space-y-2">
+            {#each documents as doc, i (i)}
+              <div class="flex items-start gap-2">
+                <textarea
+                  value={doc}
+                  oninput={(e) => setDocument(i, e.currentTarget.value)}
+                  placeholder="Document {i + 1}"
+                  rows="5"
+                  disabled={sending}
+                  class="flex-1 min-h-28 rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring resize-y"
+                ></textarea>
+                <Button
+                  variant="outline"
+                  size="icon"
+                  onclick={() => removeDocument(i)}
+                  disabled={sending || documents.length <= 1}
+                  title="Remove document"
+                >
+                  <Trash2 class="w-4 h-4" />
+                </Button>
+              </div>
+            {/each}
+          </div>
+        </section>
+
+        {#if errorMessage}
+          <Alert.Root variant="destructive">
+            <Alert.Description>{errorMessage}</Alert.Description>
+          </Alert.Root>
+        {/if}
+
+        {#if result}
+          <section class="space-y-3">
+            <div class="flex items-center justify-between">
+              <Label class="text-sm font-semibold">Ranked results</Label>
+              <span class="text-xs text-muted-foreground">{result.durationMs} ms</span>
+            </div>
+            <div class="space-y-2">
+              {#each result.ranks as r (r.rank)}
+                <div class="rounded-md border bg-muted/40 p-3">
+                  <div class="flex items-baseline justify-between gap-2 mb-2">
+                    <div class="flex items-baseline gap-2">
+                      <span class="font-mono text-sm font-semibold">#{r.rank}</span>
+                      <span class="text-xs text-muted-foreground">input {r.inputIndex + 1}</span>
+                    </div>
+                    <span class="font-mono text-sm">{r.score.toFixed(4)}</span>
+                  </div>
+                  <div class="w-full bg-muted rounded-full h-1.5 mb-2">
+                    <div
+                      class="bg-primary h-1.5 rounded-full transition-all"
+                      style="width: {Math.max(0, Math.min(100, (Math.abs(r.score) / maxAbsScore) * 100))}%"
+                    ></div>
+                  </div>
+                  <p class="text-sm whitespace-pre-wrap wrap-break-words">{r.text}</p>
+                </div>
+              {/each}
+            </div>
+          </section>
+        {/if}
+
+        {#if !apiKey.trim()}
+          <Alert.Root>
+            <Alert.Description class="text-xs">
+              Paste an API key or click "Generate temporary key" to rank documents.
+            </Alert.Description>
+          </Alert.Root>
+        {/if}
+      </main>
+
+      <footer class="p-4 border-t bg-muted/40 rounded-b-xl flex justify-end gap-2">
+        <Button onclick={handleSend} disabled={!canSend}>
+          <Send class="w-4 h-4" />
+          {sending ? "Ranking..." : "Rank documents"}
+        </Button>
+      </footer>
+    </div>
+  {/if}
+</Modal>

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/test-chat/+server.ts
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/test-chat/+server.ts
@@ -1,0 +1,68 @@
+/**
+ * POST /modelhub/test-chat
+ *
+ * Authenticated server-side proxy for chat-completion requests issued by the
+ * "Test" button on deployment cards. Streams the SSE body from the gateway
+ * straight back to the browser. Lives behind the dashboard session so we
+ * don't need cross-origin support on the gateway.
+ */
+import type { RequestHandler } from "./$types";
+import { auth } from "$lib/server/auth-server";
+import { serverEnv } from "$lib/server/serverenv";
+import { error } from "@sveltejs/kit";
+
+export const POST: RequestHandler = async ({ request, locals }) => {
+  const session = await auth.api.getSession(locals.request);
+  if (!session) error(401, "Unauthorized");
+  if (!session.session.activeOrganizationId) error(403, "No active organization");
+
+  let body: {
+    apiKey?: unknown;
+    model?: unknown;
+    messages?: unknown;
+    store?: unknown;
+    applicationName?: unknown;
+  };
+  try {
+    body = await request.json();
+  } catch {
+    error(400, "Invalid JSON body");
+  }
+
+  const { apiKey, model, messages, store, applicationName } = body;
+  if (typeof apiKey !== "string" || !apiKey) error(400, "Missing apiKey");
+  if (typeof model !== "string" || !model) error(400, "Missing model");
+  if (!Array.isArray(messages) || messages.length === 0) error(400, "Missing messages");
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${apiKey}`,
+    Accept: "text/event-stream",
+  };
+  if (typeof applicationName === "string" && applicationName) {
+    headers["X-Application"] = applicationName;
+  }
+
+  const upstream = await fetch(`${serverEnv.GATEWAY_URL.replace(/\/$/, "")}/v1/chat/completions`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      model,
+      messages,
+      stream: true,
+      store: typeof store === "boolean" ? store : false,
+    }),
+    signal: request.signal,
+  });
+
+  // Pass the upstream response through unchanged (status + body). For SSE
+  // success this streams chunks; for non-2xx the gateway returns a small JSON
+  // error body that the client will handle.
+  return new Response(upstream.body, {
+    status: upstream.status,
+    headers: {
+      "Content-Type": upstream.headers.get("content-type") ?? "text/event-stream",
+      "Cache-Control": "no-cache",
+    },
+  });
+};

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/test-embed/+server.ts
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/test-embed/+server.ts
@@ -1,0 +1,44 @@
+/**
+ * POST /modelhub/test-embed
+ *
+ * Authenticated server-side proxy for embedding requests issued by the "Test"
+ * button on embedding-model deployment cards. Forwards the body to
+ * `${GATEWAY_URL}/v1/embeddings` and returns the JSON response untouched.
+ */
+import type { RequestHandler } from "./$types";
+import { auth } from "$lib/server/auth-server";
+import { serverEnv } from "$lib/server/serverenv";
+import { error } from "@sveltejs/kit";
+
+export const POST: RequestHandler = async ({ request, locals }) => {
+  const session = await auth.api.getSession(locals.request);
+  if (!session) error(401, "Unauthorized");
+  if (!session.session.activeOrganizationId) error(403, "No active organization");
+
+  let body: { apiKey?: unknown; model?: unknown; input?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    error(400, "Invalid JSON body");
+  }
+
+  const { apiKey, model, input } = body;
+  if (typeof apiKey !== "string" || !apiKey) error(400, "Missing apiKey");
+  if (typeof model !== "string" || !model) error(400, "Missing model");
+  if (typeof input !== "string" || !input) error(400, "Missing input");
+
+  const upstream = await fetch(`${serverEnv.GATEWAY_URL.replace(/\/$/, "")}/v1/embeddings`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({ model, input }),
+    signal: request.signal,
+  });
+
+  return new Response(upstream.body, {
+    status: upstream.status,
+    headers: { "Content-Type": upstream.headers.get("content-type") ?? "application/json" },
+  });
+};

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/test-rerank/+server.ts
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/test-rerank/+server.ts
@@ -1,0 +1,50 @@
+/**
+ * POST /modelhub/test-rerank
+ *
+ * Authenticated server-side proxy for rerank requests issued by the "Test"
+ * button on rerank-model deployment cards. Forwards the body to
+ * `${GATEWAY_URL}/v1/rerank` and returns the JSON response untouched.
+ */
+import type { RequestHandler } from "./$types";
+import { auth } from "$lib/server/auth-server";
+import { serverEnv } from "$lib/server/serverenv";
+import { error } from "@sveltejs/kit";
+
+export const POST: RequestHandler = async ({ request, locals }) => {
+  const session = await auth.api.getSession(locals.request);
+  if (!session) error(401, "Unauthorized");
+  if (!session.session.activeOrganizationId) error(403, "No active organization");
+
+  let body: {
+    apiKey?: unknown;
+    model?: unknown;
+    query?: unknown;
+    documents?: unknown;
+  };
+  try {
+    body = await request.json();
+  } catch {
+    error(400, "Invalid JSON body");
+  }
+
+  const { apiKey, model, query, documents } = body;
+  if (typeof apiKey !== "string" || !apiKey) error(400, "Missing apiKey");
+  if (typeof model !== "string" || !model) error(400, "Missing model");
+  if (typeof query !== "string" || !query) error(400, "Missing query");
+  if (!Array.isArray(documents) || documents.length === 0) error(400, "Missing documents");
+
+  const upstream = await fetch(`${serverEnv.GATEWAY_URL.replace(/\/$/, "")}/v1/rerank`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({ model, query, documents }),
+    signal: request.signal,
+  });
+
+  return new Response(upstream.body, {
+    status: upstream.status,
+    headers: { "Content-Type": upstream.headers.get("content-type") ?? "application/json" },
+  });
+};

--- a/packages/xinity-ai-dashboard/src/routes/+layout.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/+layout.svelte
@@ -4,6 +4,9 @@
 	// import favicon from "$lib/assets/favicon.svg";
 
 	let { data, children } = $props();
+	// clientEnv is set once on the server and never changes for a session, so a
+	// non-reactive snapshot at mount time is what we want.
+	// svelte-ignore state_referenced_locally
 	setContext("clientEnv", data.clientEnv);
 </script>
 

--- a/packages/xinity-ai-dashboard/tests/orchestration.test.ts
+++ b/packages/xinity-ai-dashboard/tests/orchestration.test.ts
@@ -13,6 +13,8 @@ function makeNode(overrides: Partial<AiNode> & { id: string }): AiNode {
     driverVersions: {},
     gpus: [],
     gpuCount: 1,
+    authToken: null,
+    tls: false,
     deletedAt: null,
     createdAt: new Date(),
     updatedAt: new Date(),

--- a/tests/system/gateway/gateway.multimodal-s3.test.ts
+++ b/tests/system/gateway/gateway.multimodal-s3.test.ts
@@ -87,8 +87,9 @@ async function objectExists(bucket: string, key: string): Promise<boolean> {
 
 beforeAll(async () => {
   await ensureSystemReady();
+  await ensureInfoServerRunning();
 
-  // Skip entire suite if SeaweedFS is not available
+  // Skip S3-specific setup if SeaweedFS is not available
   if (!(await isSeaweedFSReachable())) {
     console.warn(
       `\nSkipping multimodal S3 system tests, SeaweedFS not reachable at ${S3_ENDPOINT}\n` +
@@ -98,7 +99,6 @@ beforeAll(async () => {
   }
 
   await ensureBucket(S3_BUCKET);
-  await ensureInfoServerRunning();
 
   // Spawn a gateway instance with S3 configured
   gatewayProcess = Bun.spawn(["bun", "run", "src/gatewayServer.ts"], {


### PR DESCRIPTION
## Description

Adds a Test button to ready deployments on the Model Hub for trying models directly from the dashboard. Each click opens a type-specific modal, dispatched from a cached lookup of the deployment's model type. Models whose type can't be confirmed don't get a button.

The three modals share an API-key block (`TestApiKeySection`) that supports paste-your-own or one-click "Generate temporary key" (auto-deleted on close, with a toast confirming each create/delete).

- Chat (`TestChatModal`): streaming SSE chat UI with Store-calls toggle and Application-override select.
- Embedding (`TestEmbeddingModal`): single input, stats card (dimensions / tokens / duration), truncated vector preview, copy-full-vector button.
- Rerank (`TestRerankModal`): query + dynamic document list (add/remove), ranked results with relative score bars.

All three call short authenticated proxies under `/modelhub/test-{chat,embed,rerank}` that forward to `${GATEWAY_URL}/v1/{chat/completions,embeddings,rerank}`. Proxies live behind the dashboard session so the gateway doesn't need CORS support.

Also included: a fix for a flaky CI integration test (`2f230bc`) that ensures the Info Server is up before S3 setup runs.  
Plus a `_source` field added to the orpc model schema and minor cleanups so `svelte-check` runs clean (0 errors, 0 warnings).

## Type of change

New feature

## Testing

Manually exercised the chat, embedding, and rerank flows end-to-end against ready deployments of each type, including: temporary-key generate + auto-cleanup, streaming abort on close/reset, error surfacing for invalid keys, and the no-button case for models missing from the catalog. `bun run check` passes clean. 
No new automated tests added (UI / integration coverage gap acknowledged).

## Checklist

- [x] Tests pass locally (`bun test`), or no testable code was changed
- [x] New or changed behavior is covered by tests, or this change does not require tests
- [x] Documentation is updated, or no user-facing behavior or configuration was changed
- [x] There are no breaking changes, or they are marked with `!` in the commit type and described above
- [x] No security-sensitive changes (authentication, credentials, input handling), or they have been reviewed
- [x] No new dependencies were added, or they have been reviewed for license and maintenance status