### PR TITLE
fix: download+space corrections

### DIFF
--- a/packages/xinity-ai-daemon/src/modules/driver-grouping.test.ts
+++ b/packages/xinity-ai-daemon/src/modules/driver-grouping.test.ts
@@ -1,10 +1,6 @@
 import { describe, test, expect } from "bun:test";
 import { groupInstallationsByDriver } from "./driver-grouping";
 
-// ---------------------------------------------------------------------------
-// groupInstallationsByDriver
-// ---------------------------------------------------------------------------
-
 describe("groupInstallationsByDriver", () => {
   test("groups installations by driver", () => {
     const installations = [
@@ -14,46 +10,12 @@ describe("groupInstallationsByDriver", () => {
     ];
     const groups = groupInstallationsByDriver(installations);
     expect(groups).toHaveLength(2);
-
-    const ollama = groups.find((g) => g.driver === "ollama");
-    const vllm = groups.find((g) => g.driver === "vllm");
-    expect(ollama).toBeDefined();
-    expect(ollama!.installations).toHaveLength(2);
-    expect(vllm).toBeDefined();
-    expect(vllm!.installations).toHaveLength(1);
+    expect(groups.find((g) => g.driver === "ollama")!.installations).toHaveLength(2);
+    expect(groups.find((g) => g.driver === "vllm")!.installations).toHaveLength(1);
   });
 
-  test("returns empty array for empty input", () => {
-    const groups = groupInstallationsByDriver([]);
-    expect(groups).toEqual([]);
-  });
-
-  test("handles single driver", () => {
-    const installations = [
-      { id: "1", model: "a", driver: "ollama" },
-      { id: "2", model: "b", driver: "ollama" },
-    ];
-    const groups = groupInstallationsByDriver(installations);
-    expect(groups).toHaveLength(1);
-    expect(groups[0]!.driver).toBe("ollama");
-    expect(groups[0]!.installations).toHaveLength(2);
-  });
-
-  test("handles many distinct drivers", () => {
-    const installations = [
-      { id: "1", model: "a", driver: "ollama" },
-      { id: "2", model: "b", driver: "vllm" },
-      { id: "3", model: "c", driver: "custom" },
-    ];
-    const groups = groupInstallationsByDriver(installations);
-    expect(groups).toHaveLength(3);
-    expect(groups.map((g) => g.driver).sort()).toEqual(["custom", "ollama", "vllm"]);
-  });
-
-  test("preserves installation objects in groups", () => {
-    const installations = [
-      { id: "x", model: "phi", driver: "ollama", extra: 42 },
-    ];
+  test("preserves installation object identity in groups", () => {
+    const installations = [{ id: "x", model: "phi", driver: "ollama", extra: 42 }];
     const groups = groupInstallationsByDriver(installations);
     expect(groups[0]!.installations[0]).toBe(installations[0]);
   });

--- a/packages/xinity-ai-daemon/src/modules/model-installation/cache-eviction.test.ts
+++ b/packages/xinity-ai-daemon/src/modules/model-installation/cache-eviction.test.ts
@@ -1,0 +1,211 @@
+import { describe, test, expect, mock } from "bun:test";
+import type { ModelInstallation } from "common-db";
+
+mock.module("../../env", () => ({ env: { VLLM_HF_CACHE_DIR: "/tmp/test" } }));
+mock.module("../../logger", () => ({
+  rootLogger: { child: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }) },
+}));
+
+import { planEviction, slugForModel, modelForSlug, type CacheEntry } from "./cache-eviction";
+
+const GB = 1024 ** 3;
+
+function entry(model: string, sizeGb: number, mtime: Date = new Date()): CacheEntry {
+  return {
+    slug: slugForModel(model),
+    model,
+    dir: `/cache/hub/${slugForModel(model)}`,
+    sizeBytes: sizeGb * GB,
+    mtime,
+  };
+}
+
+function inst(model: string, opts: { deletedAt?: Date | null } = {}): ModelInstallation {
+  return {
+    id: crypto.randomUUID(),
+    nodeId: "node-1",
+    model,
+    estCapacity: 16,
+    kvCacheCapacity: 4,
+    port: 8080,
+    driver: "vllm",
+    deletedAt: opts.deletedAt ?? null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+describe("slug round-trip", () => {
+  test("simple org/name", () => {
+    expect(slugForModel("meta-llama/Llama-3.1-8B")).toBe("models--meta-llama--Llama-3.1-8B");
+    expect(modelForSlug("models--meta-llama--Llama-3.1-8B")).toBe("meta-llama/Llama-3.1-8B");
+  });
+
+  test("name with dashes survives round-trip", () => {
+    expect(modelForSlug(slugForModel("mistralai/Mistral-7B-Instruct-v0.3"))).toBe(
+      "mistralai/Mistral-7B-Instruct-v0.3",
+    );
+  });
+});
+
+describe("planEviction - no-op cases", () => {
+  test("does nothing when free space already exceeds required + safety margin", () => {
+    const plan = planEviction({
+      entries: [entry("foo/bar", 50)],
+      installations: [],
+      requiredBytes: 10 * GB,
+      reservedModel: "new/model",
+      freeBytes: 100 * GB,
+      safetyMarginBytes: GB,
+    });
+    expect(plan.evict).toEqual([]);
+    expect(plan.sufficient).toBe(true);
+  });
+});
+
+describe("planEviction - active installations are protected", () => {
+  test("never evicts cache for an active installation", () => {
+    const entries = [entry("active/model", 80), entry("orphan/model", 80)];
+    const installations = [inst("active/model")];
+    const plan = planEviction({
+      entries,
+      installations,
+      requiredBytes: 50 * GB,
+      reservedModel: "new/model",
+      freeBytes: 5 * GB,
+    });
+    expect(plan.evict.map((e) => e.model)).toEqual(["orphan/model"]);
+    expect(plan.sufficient).toBe(true);
+  });
+});
+
+describe("planEviction - reservedModel is skipped", () => {
+  test("never evicts the cache dir of the model we're about to download", () => {
+    const entries = [entry("being/downloaded", 50)];
+    const installations = [inst("being/downloaded", { deletedAt: new Date(2020, 0) })];
+    const plan = planEviction({
+      entries,
+      installations,
+      requiredBytes: 30 * GB,
+      reservedModel: "being/downloaded",
+      freeBytes: 1 * GB,
+    });
+    expect(plan.evict).toEqual([]);
+    expect(plan.sufficient).toBe(false);
+  });
+});
+
+describe("planEviction - ordering", () => {
+  test("oldest deletedAt evicts first", () => {
+    const entries = [
+      entry("recent/del", 20),
+      entry("ancient/del", 20),
+      entry("middle/del", 20),
+    ];
+    const installations = [
+      inst("recent/del", { deletedAt: new Date(2026, 4, 1) }),
+      inst("ancient/del", { deletedAt: new Date(2024, 0, 1) }),
+      inst("middle/del", { deletedAt: new Date(2025, 5, 1) }),
+    ];
+    const plan = planEviction({
+      entries,
+      installations,
+      requiredBytes: 35 * GB,
+      reservedModel: "new/model",
+      freeBytes: 0,
+      safetyMarginBytes: 0,
+    });
+    expect(plan.evict.map((e) => e.model)).toEqual(["ancient/del", "middle/del"]);
+  });
+
+  test("orphaned cache (no DB row) ranks by mtime ascending", () => {
+    const entries = [
+      entry("orphan/young", 20, new Date(2026, 0)),
+      entry("orphan/old", 20, new Date(2024, 0)),
+    ];
+    const plan = planEviction({
+      entries,
+      installations: [],
+      requiredBytes: 15 * GB,
+      reservedModel: "new/model",
+      freeBytes: 0,
+      safetyMarginBytes: 0,
+    });
+    expect(plan.evict.map((e) => e.model)).toEqual(["orphan/old"]);
+  });
+
+  test("uses most recent deletedAt when an installation has multiple deleted rows", () => {
+    const entries = [entry("foo/bar", 20)];
+    const installations = [
+      inst("foo/bar", { deletedAt: new Date(2024, 0) }),
+      inst("foo/bar", { deletedAt: new Date(2026, 0) }),
+    ];
+    const plan = planEviction({
+      entries: [entry("baz/qux", 20, new Date(2025, 0)), ...entries],
+      installations,
+      requiredBytes: 15 * GB,
+      reservedModel: "new/model",
+      freeBytes: 0,
+      safetyMarginBytes: 0,
+    });
+    expect(plan.evict.map((e) => e.model)).toEqual(["baz/qux"]);
+  });
+});
+
+describe("planEviction - stop conditions", () => {
+  test("stops once enough has been freed", () => {
+    const entries = [
+      entry("a/del", 50, new Date(2024, 0)),
+      entry("b/del", 50, new Date(2025, 0)),
+      entry("c/del", 50, new Date(2026, 0)),
+    ];
+    const installations = [
+      inst("a/del", { deletedAt: new Date(2024, 0) }),
+      inst("b/del", { deletedAt: new Date(2025, 0) }),
+      inst("c/del", { deletedAt: new Date(2026, 0) }),
+    ];
+    const plan = planEviction({
+      entries,
+      installations,
+      requiredBytes: 60 * GB,
+      reservedModel: "new/model",
+      freeBytes: 0,
+      safetyMarginBytes: 0,
+    });
+    expect(plan.evict.map((e) => e.model)).toEqual(["a/del", "b/del"]);
+    expect(plan.freedBytes).toBe(100 * GB);
+  });
+
+  test("reports insufficient when no candidates can free enough", () => {
+    const entries = [entry("tiny/del", 1)];
+    const installations = [inst("tiny/del", { deletedAt: new Date(2020, 0) })];
+    const plan = planEviction({
+      entries,
+      installations,
+      requiredBytes: 100 * GB,
+      reservedModel: "new/model",
+      freeBytes: 0,
+      safetyMarginBytes: 0,
+    });
+    expect(plan.sufficient).toBe(false);
+    expect(plan.evict.map((e) => e.model)).toEqual(["tiny/del"]);
+  });
+});
+
+describe("planEviction - safety margin", () => {
+  test("safety margin is respected on top of required", () => {
+    const entries = [entry("a/del", 5, new Date(2024, 0))];
+    const installations = [inst("a/del", { deletedAt: new Date(2024, 0) })];
+    const plan = planEviction({
+      entries,
+      installations,
+      requiredBytes: 10 * GB,
+      reservedModel: "new/model",
+      freeBytes: 11 * GB,
+      safetyMarginBytes: 2 * GB,
+    });
+    // Have 11G free, need 10+2=12G → must evict the 5G entry → 16G free.
+    expect(plan.evict.map((e) => e.model)).toEqual(["a/del"]);
+    expect(plan.sufficient).toBe(true);
+  });
+});

--- a/packages/xinity-ai-daemon/src/modules/model-installation/cache-eviction.ts
+++ b/packages/xinity-ai-daemon/src/modules/model-installation/cache-eviction.ts
@@ -1,0 +1,179 @@
+import { promises as fsp, readdirSync, rmSync, statSync, type Dirent } from "node:fs";
+import * as path from "node:path";
+import { modelInstallationT, sql, type ModelInstallation } from "common-db";
+import { env } from "../../env";
+import { rootLogger } from "../../logger";
+
+const log = rootLogger.child({ name: "cache-eviction" });
+
+const SAFETY_MARGIN_BYTES = 1 * 1024 ** 3;
+
+export interface CacheEntry {
+  slug: string;
+  model: string;
+  dir: string;
+  sizeBytes: number;
+  mtime: Date;
+}
+
+export interface EvictionPlan {
+  evict: CacheEntry[];
+  freedBytes: number;
+  sufficient: boolean;
+}
+
+export function slugForModel(model: string): string {
+  return `models--${model.replace("/", "--")}`;
+}
+
+// A "--" inside the org or repo name itself would mismap here; the rare
+// fallout is that the cache entry doesn't match its DB row and gets treated
+// as orphaned (oldest-first by mtime), which is acceptable.
+export function modelForSlug(slug: string): string {
+  const stripped = slug.startsWith("models--") ? slug.slice("models--".length) : slug;
+  const idx = stripped.indexOf("--");
+  if (idx < 0) return stripped;
+  return `${stripped.slice(0, idx)}/${stripped.slice(idx + 2)}`;
+}
+
+export function getDirSize(dir: string): number {
+  let total = 0;
+  function walk(current: string): void {
+    let entries: Dirent[];
+    try { entries = readdirSync(current, { withFileTypes: true }); }
+    catch { return; }
+    for (const entry of entries) {
+      if (entry.isSymbolicLink()) continue;
+      const p = path.join(current, entry.name);
+      if (entry.isDirectory()) { walk(p); continue; }
+      try { total += statSync(p).size; } catch { /* ignore */ }
+    }
+  }
+  walk(dir);
+  return total;
+}
+
+export async function getDiskFree(targetPath: string): Promise<number> {
+  const stat = await fsp.statfs(targetPath);
+  return Number(stat.bsize) * Number(stat.bavail);
+}
+
+export function listCacheEntries(hubDir: string): CacheEntry[] {
+  let names: string[];
+  try { names = readdirSync(hubDir); } catch { return []; }
+  return names
+    .filter((n) => n.startsWith("models--"))
+    .map((slug): CacheEntry => {
+      const dir = path.join(hubDir, slug);
+      let mtime = new Date(0);
+      try { mtime = statSync(dir).mtime; } catch { /* keep epoch */ }
+      return { slug, model: modelForSlug(slug), dir, sizeBytes: getDirSize(dir), mtime };
+    });
+}
+
+export function planEviction(input: {
+  entries: readonly CacheEntry[];
+  installations: readonly ModelInstallation[];
+  requiredBytes: number;
+  reservedModel: string;
+  freeBytes: number;
+  safetyMarginBytes?: number;
+}): EvictionPlan {
+  const safetyMargin = input.safetyMarginBytes ?? SAFETY_MARGIN_BYTES;
+  const target = input.requiredBytes + safetyMargin;
+
+  if (input.freeBytes >= target) {
+    return { evict: [], freedBytes: 0, sufficient: true };
+  }
+
+  const byModel = new Map<string, ModelInstallation[]>();
+  for (const inst of input.installations) {
+    const arr = byModel.get(inst.model) ?? [];
+    arr.push(inst);
+    byModel.set(inst.model, arr);
+  }
+
+  type Candidate = CacheEntry & { lastNeededAt: Date };
+  const candidates: Candidate[] = [];
+
+  for (const entry of input.entries) {
+    if (entry.model === input.reservedModel) continue;
+
+    const matches = byModel.get(entry.model) ?? [];
+    if (matches.some((m) => m.deletedAt === null)) continue;
+
+    let lastNeededAt = entry.mtime;
+    if (matches.length > 0) {
+      lastNeededAt = matches.reduce<Date>(
+        (latest, m) => (m.deletedAt && m.deletedAt > latest ? m.deletedAt : latest),
+        new Date(0),
+      );
+    }
+    candidates.push({ ...entry, lastNeededAt });
+  }
+
+  candidates.sort((a, b) => a.lastNeededAt.getTime() - b.lastNeededAt.getTime());
+
+  const evict: CacheEntry[] = [];
+  let freed = 0;
+  for (const c of candidates) {
+    if (input.freeBytes + freed >= target) break;
+    evict.push(c);
+    freed += c.sizeBytes;
+  }
+
+  return { evict, freedBytes: freed, sufficient: input.freeBytes + freed >= target };
+}
+
+export async function ensureCacheSpace(input: {
+  requiredBytes: number;
+  reservedModel: string;
+}): Promise<{ evicted: { model: string; sizeBytes: number }[]; freeBefore: number; freeAfter: number }> {
+  const cacheDir = env.VLLM_HF_CACHE_DIR;
+  const hubDir = path.join(cacheDir, "hub");
+
+  const freeBefore = await getDiskFree(cacheDir);
+  if (freeBefore >= input.requiredBytes + SAFETY_MARGIN_BYTES) {
+    return { evicted: [], freeBefore, freeAfter: freeBefore };
+  }
+
+  const entries = listCacheEntries(hubDir);
+  const { getNodeId } = await import("../statekeeper");
+  const { getDB } = await import("../../db/connection");
+  const nodeId = await getNodeId();
+  const installations = await getDB()
+    .select()
+    .from(modelInstallationT)
+    .where(sql`${modelInstallationT.nodeId} = ${nodeId}`);
+
+  const plan = planEviction({
+    entries,
+    installations,
+    requiredBytes: input.requiredBytes,
+    reservedModel: input.reservedModel,
+    freeBytes: freeBefore,
+  });
+
+  if (!plan.sufficient) {
+    throw new Error(
+      `Cannot free enough cache space for ${input.reservedModel}: ` +
+      `need ${input.requiredBytes} bytes, ${freeBefore} free, ` +
+      `only ${plan.freedBytes} additional bytes evictable across ${plan.evict.length} stale model(s)`,
+    );
+  }
+
+  for (const entry of plan.evict) {
+    log.info(
+      { model: entry.model, sizeBytes: entry.sizeBytes, dir: entry.dir },
+      "Evicting stale model cache",
+    );
+    rmSync(entry.dir, { recursive: true, force: true });
+  }
+
+  const freeAfter = await getDiskFree(cacheDir);
+  return {
+    evicted: plan.evict.map((e) => ({ model: e.model, sizeBytes: e.sizeBytes })),
+    freeBefore,
+    freeAfter,
+  };
+}

--- a/packages/xinity-ai-daemon/src/modules/model-installation/file-filter.test.ts
+++ b/packages/xinity-ai-daemon/src/modules/model-installation/file-filter.test.ts
@@ -1,0 +1,184 @@
+import { describe, test, expect } from "bun:test";
+import { selectFiles, buildRules, isMistralRepo } from "./file-filter";
+
+function f(...paths: string[]): { path: string }[] {
+  return paths.map((path) => ({ path }));
+}
+
+function names(files: { path: string }[]): string[] {
+  return files.map((f) => f.path).sort();
+}
+
+describe("isMistralRepo", () => {
+  test("detects consolidated.safetensors", () => {
+    expect(isMistralRepo(["consolidated.safetensors", "params.json"])).toBe(true);
+  });
+
+  test("detects sharded consolidated files", () => {
+    expect(isMistralRepo(["consolidated-00001-of-00002.safetensors"])).toBe(true);
+  });
+
+  test("does not match plain HF sharded layout", () => {
+    expect(isMistralRepo(["model-00001-of-00002.safetensors", "config.json"])).toBe(false);
+  });
+
+  test("does not match consolidated under a subdirectory", () => {
+    expect(isMistralRepo(["original/consolidated.00.pth"])).toBe(false);
+  });
+});
+
+describe("buildRules / selectFiles - HF default mode", () => {
+  test("keeps sharded safetensors and json, drops original/, gguf, pth", () => {
+    const files = f(
+      "model-00001-of-00002.safetensors",
+      "model-00002-of-00002.safetensors",
+      "model.safetensors.index.json",
+      "config.json",
+      "tokenizer.json",
+      "tokenizer.model",
+      "original/consolidated.00.pth",
+      "original/tokenizer.model",
+      "model.gguf",
+      "model.pt",
+      "weights.h5",
+      "README.md",
+      "image.png",
+    );
+
+    const { rules, mode } = buildRules(files, []);
+    expect(mode).toBe("hf");
+
+    expect(names(selectFiles(files, rules))).toEqual([
+      "config.json",
+      "model-00001-of-00002.safetensors",
+      "model-00002-of-00002.safetensors",
+      "model.safetensors.index.json",
+      "tokenizer.json",
+      "tokenizer.model",
+    ]);
+  });
+
+  test("bin fallback kicks in when no safetensors are present", () => {
+    const files = f(
+      "pytorch_model-00001-of-00002.bin",
+      "pytorch_model-00002-of-00002.bin",
+      "config.json",
+      "tokenizer.model",
+      "model.gguf",
+    );
+
+    const { rules } = buildRules(files, []);
+
+    expect(names(selectFiles(files, rules))).toEqual([
+      "config.json",
+      "pytorch_model-00001-of-00002.bin",
+      "pytorch_model-00002-of-00002.bin",
+      "tokenizer.model",
+    ]);
+  });
+
+  test("does not enable bin fallback when safetensors exist", () => {
+    const files = f("model.safetensors", "pytorch_model.bin", "config.json");
+    const { rules } = buildRules(files, []);
+    expect(names(selectFiles(files, rules))).toEqual(["config.json", "model.safetensors"]);
+  });
+});
+
+describe("buildRules / selectFiles - Mistral mode", () => {
+  test("keeps consolidated, drops sharded HF safetensors", () => {
+    const files = f(
+      "consolidated.safetensors",
+      "consolidated.safetensors.index.json",
+      "model-00001-of-00002.safetensors",
+      "model-00002-of-00002.safetensors",
+      "params.json",
+      "tokenizer.model",
+      "tekken.json",
+      "original/consolidated.00.pth",
+    );
+
+    const { rules, mode } = buildRules(files, []);
+    expect(mode).toBe("mistral");
+
+    expect(names(selectFiles(files, rules))).toEqual([
+      "consolidated.safetensors",
+      "consolidated.safetensors.index.json",
+      "params.json",
+      "tekken.json",
+      "tokenizer.model",
+    ]);
+  });
+
+  test("multi-shard consolidated repos keep all consolidated shards", () => {
+    const files = f(
+      "consolidated-00001-of-00003.safetensors",
+      "consolidated-00002-of-00003.safetensors",
+      "consolidated-00003-of-00003.safetensors",
+      "params.json",
+    );
+    const { rules } = buildRules(files, []);
+    expect(names(selectFiles(files, rules))).toEqual([
+      "consolidated-00001-of-00003.safetensors",
+      "consolidated-00002-of-00003.safetensors",
+      "consolidated-00003-of-00003.safetensors",
+      "params.json",
+    ]);
+  });
+});
+
+describe("user override patterns", () => {
+  test("user pattern can drop a file the defaults would keep", () => {
+    const files = f("model.safetensors", "config.json", "tokenizer.json");
+    const { rules } = buildRules(files, ["*.json"]);
+    expect(names(selectFiles(files, rules))).toEqual(["model.safetensors"]);
+  });
+
+  test("user negation re-includes a default-dropped file", () => {
+    const files = f("model.safetensors", "config.json", "model.gguf");
+    const { rules } = buildRules(files, ["!*.gguf"]);
+    expect(names(selectFiles(files, rules))).toEqual([
+      "config.json",
+      "model.gguf",
+      "model.safetensors",
+    ]);
+  });
+
+  test("user can force HF mode by negating consolidated in a Mistral repo", () => {
+    const files = f(
+      "consolidated.safetensors",
+      "model-00001-of-00002.safetensors",
+      "model-00002-of-00002.safetensors",
+      "params.json",
+    );
+    const { rules, mode } = buildRules(files, ["!*.safetensors", "consolidated*.safetensors"]);
+    expect(mode).toBe("mistral");
+
+    expect(names(selectFiles(files, rules))).toEqual([
+      "model-00001-of-00002.safetensors",
+      "model-00002-of-00002.safetensors",
+      "params.json",
+    ]);
+  });
+
+  test("last match wins (user order matters)", () => {
+    const files = f("model.gguf");
+    const reInclude = buildRules(files, ["!*.gguf"]);
+    expect(names(selectFiles(files, reInclude.rules))).toEqual(["model.gguf"]);
+
+    const reExclude = buildRules(files, ["!*.gguf", "*.gguf"]);
+    expect(names(selectFiles(files, reExclude.rules))).toEqual([]);
+  });
+});
+
+describe("nested paths", () => {
+  test("original/** matches subdirectories at any depth", () => {
+    const files = f(
+      "original/consolidated.00.pth",
+      "original/sub/dir/file.bin",
+      "original/tokenizer.model",
+      "model.safetensors",
+    );
+    const { rules } = buildRules(files, []);
+    expect(names(selectFiles(files, rules))).toEqual(["model.safetensors"]);
+  });
+});

--- a/packages/xinity-ai-daemon/src/modules/model-installation/file-filter.ts
+++ b/packages/xinity-ai-daemon/src/modules/model-installation/file-filter.ts
@@ -1,0 +1,89 @@
+/**
+ * Gitignore-style file selection backed by Bun.Glob.
+ *
+ * Rules are processed in order. A leading "!" re-includes; everything else
+ * excludes. The LAST matching rule wins. Files that match no rule at all
+ * are excluded (allow-list semantics, mirroring vLLM's `allow_patterns`).
+ *
+ * Glob syntax follows Bun.Glob: `*` is path-segment, `**` is recursive,
+ * `?` is single char, `[]` is char class, `{}` is brace expansion.
+ */
+
+interface CompiledRule {
+  glob: Bun.Glob;
+  negated: boolean;
+}
+
+function compile(rules: readonly string[]): CompiledRule[] {
+  return rules.map((raw) => {
+    const negated = raw.startsWith("!");
+    return { glob: new Bun.Glob(negated ? raw.slice(1) : raw), negated };
+  });
+}
+
+export function isIncluded(path: string, compiled: readonly CompiledRule[]): boolean {
+  let included = false;
+  for (const rule of compiled) {
+    if (rule.glob.match(path)) included = rule.negated;
+  }
+  return included;
+}
+
+export function selectFiles<T extends { path: string }>(files: readonly T[], rules: readonly string[]): T[] {
+  const compiled = compile(rules);
+  return files.filter((f) => isIncluded(f.path, compiled));
+}
+
+const HF_DEFAULTS: readonly string[] = [
+  "!*.safetensors",
+  "!*.json",
+  "!tokenizer.*",
+  "!merges.txt",
+  "!*.txt",
+  "original/**",
+  "*.gguf",
+  "*.pt",
+  "*.pth",
+  "*.onnx",
+  "*.msgpack",
+  "*.h5",
+];
+
+const MISTRAL_DEFAULTS: readonly string[] = [
+  "!consolidated*.safetensors",
+  "!consolidated.safetensors.index.json",
+  "!*.json",
+  "!tokenizer.*",
+  "!tekken.json",
+  "!merges.txt",
+  "!*.txt",
+  "original/**",
+];
+
+const BIN_FALLBACK = "!*.bin";
+
+export function isMistralRepo(paths: readonly string[]): boolean {
+  return paths.some((p) => /^consolidated.*\.safetensors$/.test(p));
+}
+
+/**
+ * Builds the full ordered rule list for a repo: defaults (Mistral or HF),
+ * optional `*.bin` fallback when no safetensors survive in HF mode, then
+ * user-supplied overrides. User rules come last.
+ */
+export function buildRules<T extends { path: string }>(
+  files: readonly T[],
+  userPatterns: readonly string[],
+): { rules: string[]; mode: "mistral" | "hf" } {
+  const paths = files.map((f) => f.path);
+  if (isMistralRepo(paths)) {
+    return { rules: [...MISTRAL_DEFAULTS, ...userPatterns], mode: "mistral" };
+  }
+
+  const baseRules = [...HF_DEFAULTS];
+  const firstPass = selectFiles(files, [...baseRules, ...userPatterns]);
+  const hasSafetensors = firstPass.some((f) => f.path.endsWith(".safetensors"));
+  if (!hasSafetensors) baseRules.push(BIN_FALLBACK);
+
+  return { rules: [...baseRules, ...userPatterns], mode: "hf" };
+}

--- a/packages/xinity-ai-daemon/src/modules/model-installation/file-filter.ts
+++ b/packages/xinity-ai-daemon/src/modules/model-installation/file-filter.ts
@@ -1,14 +1,5 @@
-/**
- * Gitignore-style file selection backed by Bun.Glob.
- *
- * Rules are processed in order. A leading "!" re-includes; everything else
- * excludes. The LAST matching rule wins. Files that match no rule at all
- * are excluded (allow-list semantics, mirroring vLLM's `allow_patterns`).
- *
- * Glob syntax follows Bun.Glob: `*` is path-segment, `**` is recursive,
- * `?` is single char, `[]` is char class, `{}` is brace expansion.
- */
-
+// Allow-list semantics (default exclude); a leading "!" re-includes; last
+// matching rule wins. Globs are Bun.Glob.
 interface CompiledRule {
   glob: Bun.Glob;
   negated: boolean;
@@ -66,11 +57,6 @@ export function isMistralRepo(paths: readonly string[]): boolean {
   return paths.some((p) => /^consolidated.*\.safetensors$/.test(p));
 }
 
-/**
- * Builds the full ordered rule list for a repo: defaults (Mistral or HF),
- * optional `*.bin` fallback when no safetensors survive in HF mode, then
- * user-supplied overrides. User rules come last.
- */
 export function buildRules<T extends { path: string }>(
   files: readonly T[],
   userPatterns: readonly string[],

--- a/packages/xinity-ai-daemon/src/modules/model-installation/vllm-download.ts
+++ b/packages/xinity-ai-daemon/src/modules/model-installation/vllm-download.ts
@@ -2,6 +2,7 @@ import { env } from "../../env";
 import { rootLogger } from "../../logger";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { buildRules, selectFiles } from "./file-filter";
 
 const log = rootLogger.child({ name: "vllm-download" });
 
@@ -42,6 +43,7 @@ async function hfFetch(url: string, init?: RequestInit): Promise<Response> {
 export async function downloadModel(
   model: string,
   onProgress: (progress: number) => Promise<void>,
+  userPatterns: readonly string[] = [],
 ): Promise<void> {
   const repoDir = path.join(env.VLLM_HF_CACHE_DIR, "hub", `models--${model.replace("/", "--")}`);
   const blobsDir = path.join(repoDir, "blobs");
@@ -50,9 +52,16 @@ export async function downloadModel(
   fs.mkdirSync(blobsDir, { recursive: true });
   fs.mkdirSync(refsDir, { recursive: true });
 
-  const { files, commitHash } = await listRepoFiles(model);
+  const { files: allFiles, commitHash } = await listRepoFiles(model);
+  const { rules, mode } = buildRules(allFiles, userPatterns);
+  const files = selectFiles(allFiles, rules);
   const totalBytes = files.reduce((sum, f) => sum + fileSize(f), 0);
-  log.info({ model, fileCount: files.length, totalBytes, commitHash }, "Starting model download");
+  const droppedFiles = allFiles.length - files.length;
+  const droppedBytes = allFiles.reduce((sum, f) => sum + fileSize(f), 0) - totalBytes;
+  log.info(
+    { model, fileCount: files.length, totalBytes, commitHash, mode, droppedFiles, droppedBytes },
+    "Starting model download",
+  );
 
   if (totalBytes === 0) {
     await onProgress(1);

--- a/packages/xinity-ai-daemon/src/modules/model-installation/vllm-download.ts
+++ b/packages/xinity-ai-daemon/src/modules/model-installation/vllm-download.ts
@@ -3,6 +3,7 @@ import { rootLogger } from "../../logger";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { buildRules, selectFiles } from "./file-filter";
+import { ensureCacheSpace, getDirSize } from "./cache-eviction";
 
 const log = rootLogger.child({ name: "vllm-download" });
 
@@ -66,6 +67,16 @@ export async function downloadModel(
   if (totalBytes === 0) {
     await onProgress(1);
     return;
+  }
+
+  const alreadyCachedBytes = getDirSize(repoDir);
+  const requiredBytes = Math.max(0, totalBytes - alreadyCachedBytes);
+  const eviction = await ensureCacheSpace({ requiredBytes, reservedModel: model });
+  if (eviction.evicted.length > 0) {
+    log.info(
+      { model, evicted: eviction.evicted, freeBefore: eviction.freeBefore, freeAfter: eviction.freeAfter },
+      "Evicted stale cache to make room for download",
+    );
   }
 
   const snapshotDir = path.join(repoDir, "snapshots", commitHash);

--- a/packages/xinity-ai-daemon/src/modules/model-installation/vllm.ts
+++ b/packages/xinity-ai-daemon/src/modules/model-installation/vllm.ts
@@ -145,24 +145,29 @@ function pollUntilHealthy$(
 
 /** Downloads weights, starts the container, and returns the model type for health polling. */
 async function downloadAndStart(installation: ModelInstallation, ops: VllmOps): Promise<string | undefined> {
+  const modelInfo = await infoClient.fetchModel(installation.model);
+
   await updateInstallationState(installation.id, "downloading", { statusMessage: "Downloading model", progress: 0 });
 
   let lastProgressAt = 0;
-  await downloadModel(installation.model, async (progress) => {
-    const now = Date.now();
-    if (now - lastProgressAt >= 5000) {
-      lastProgressAt = now;
-      await updateInstallationState(installation.id, "downloading", { progress });
-    }
-  });
+  await downloadModel(
+    installation.model,
+    async (progress) => {
+      const now = Date.now();
+      if (now - lastProgressAt >= 5000) {
+        lastProgressAt = now;
+        await updateInstallationState(installation.id, "downloading", { progress });
+      }
+    },
+    modelInfo?.downloadFilter ?? [],
+  );
 
   await updateInstallationState(installation.id, "installing", { statusMessage: "Starting vLLM service" });
 
-  const [trustRemoteCode, hasToolsTag, extraArgs, modelInfo, profile] = await Promise.all([
+  const [trustRemoteCode, hasToolsTag, extraArgs, profile] = await Promise.all([
     infoClient.hasTag(installation.model, "custom_code"),
     infoClient.hasTag(installation.model, "tools"),
     infoClient.resolveDriverArgs(installation.model),
-    infoClient.fetchModel(installation.model),
     getHardwareProfile(),
   ]);
 

--- a/packages/xinity-infoserver/definitions/model-definition.ts
+++ b/packages/xinity-infoserver/definitions/model-definition.ts
@@ -120,6 +120,12 @@ export const ModelSchema = z.looseObject({
     ollama: z.array(GpuVendorEnum).optional(),
   }).optional().describe("Per-driver GPU platform requirements. Only nodes with a matching GPU vendor can serve. Absent = any platform"),
   entryVersion: z.string().optional().describe("Version of xinity-ai this model was introduced in"),
+  downloadFilter: flatStringArray.optional().describe(
+    "Gitignore-style glob patterns appended to the daemon's default HuggingFace download filter. " +
+    "Patterns starting with `!` re-include; the last matching rule wins. " +
+    "Arrays are deeply flattened to support YAML anchors. " +
+    "Example: [\"*.gguf\", \"!consolidated.safetensors\"]"
+  ),
   custom: z.looseObject({
     baseModel: z.string(),
     extraFacts: z.record(z.string(), z.any())

--- a/packages/xinity-infoserver/models.schema.json
+++ b/packages/xinity-infoserver/models.schema.json
@@ -210,6 +210,13 @@
             "description": "Version of xinity-ai this model was introduced in",
             "type": "string"
           },
+          "downloadFilter": {
+            "description": "Gitignore-style glob patterns appended to the daemon's default HuggingFace download filter. Patterns starting with `!` re-include; the last matching rule wins. Arrays are deeply flattened to support YAML anchors. Example: [\"*.gguf\", \"!consolidated.safetensors\"]",
+            "type": "array",
+            "items": {
+              "$ref": "#/$defs/__schema0"
+            }
+          },
           "custom": {
             "description": "Info for fine tuned custom models",
             "type": "object",


### PR DESCRIPTION
## Description

Two related daemon improvements to the HuggingFace download path.

Download filter mirrors vLLM `load_format=auto`: The daemon used to pull every file in a repo: both consolidated and sharded safetensors on Mistral (~245 GB extra on Mistral-Large), Llama's `original/*` tree, plus unused GGUF/ONNX siblings. New `file-filter.ts` adds a Bun.Glob-backed gitignore evaluator with allow-list defaults, Mistral detection (`consolidated*.safetensors` → consolidated-only), `*.bin` fallback, and an optional per-model `Model.downloadFilter: string[]` override on the infoserver schema (deeply nested, so YAML anchors compose).

Cache eviction before download: New `ensureCacheSpace` runs after file selection: computes `totalBytes - alreadyCachedBytes`, queries `modelInstallationT` (including soft-deleted), evicts oldest soft-deleted first then orphans by mtime, never touches the reserved model or any dir backing an active installation, 1 GiB safety margin. Throws if it can't free enough so the install fails cleanly instead of crashing mid-download.

## Type of change

Bug Fix

## Testing

- 14 new unit tests in `file-filter.test.ts`, 11 in `cache-eviction.test.ts`.
- Infoserver schema regenerated; change is additive and optional.

## Checklist

- [x] Tests pass locally (`bun test`), or no testable code was changed
- [x] New or changed behavior is covered by tests, or this change does not require tests
- [x] Documentation is updated, or no user-facing behavior or configuration was changed
- [x] There are no breaking changes, or they are marked with `!` in the commit type and described above
- [x] No security-sensitive changes (authentication, credentials, input handling), or they have been reviewed
- [x] No new dependencies were added, or they have been reviewed for license and maintenance status