### PR TITLE
fix: rework deployment+installation specifier and model lookup

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -167,7 +167,6 @@ jobs:
           MAIL_URL: smtp://localhost:1025
           MAIL_FROM: "Auth Service <noreply@example.com>"
           BETTER_AUTH_SECRET: secret_key
-          BETTER_AUTH_URL: http://localhost:5173
           GATEWAY_URL: http://localhost:8080
           APP_NAME: "Xinity Admin"
           SIGNUP_ENABLED: "true"

--- a/deployment/docker/README.md
+++ b/deployment/docker/README.md
@@ -302,7 +302,7 @@ docker compose -f docker-compose.yml -f docker-compose.local.yml up -d
 - Dashboard: `http://localhost:5121`
 - Gateway API: `http://localhost:4121`
 
-The overlay disables Caddy, exposes the gateway and dashboard ports directly, and rewrites `ORIGIN`, `BETTER_AUTH_URL`, and `GATEWAY_URL` for localhost.
+The overlay disables Caddy, exposes the gateway and dashboard ports directly, and rewrites `ORIGIN` and `GATEWAY_URL` for localhost.
 
 ## Advanced Configuration
 
@@ -367,7 +367,7 @@ For development without HTTPS:
 
 1. Comment out Caddy service
 2. Access services directly via ports (see `docker-compose.yml`)
-3. Update `BETTER_AUTH_URL` and `ORIGIN` to use `http://localhost`
+3. Update `ORIGIN` to use `http://localhost`
 
 ## Support
 

--- a/deployment/docker/docker-compose.local.yml
+++ b/deployment/docker/docker-compose.local.yml
@@ -25,7 +25,6 @@ services:
     ports:
       - "${DASHBOARD_PORT:-5121}:${DASHBOARD_PORT:-5121}"
     environment:
-      BETTER_AUTH_URL: http://localhost:${DASHBOARD_PORT:-5121}
       ORIGIN: http://localhost:${DASHBOARD_PORT:-5121}
       HTTP_OVERRIDE_ORIGIN: http://localhost:${DASHBOARD_PORT:-5121}
       GATEWAY_URL: http://localhost:${GATEWAY_PORT:-4121}

--- a/deployment/docker/docker-compose.yml
+++ b/deployment/docker/docker-compose.yml
@@ -89,8 +89,7 @@ services:
       NODE_ENV: production
       DB_CONNECTION_URL: postgresql://${POSTGRES_USER:-xinity}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-xinity}
       BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:?BETTER_AUTH_SECRET is required}
-      BETTER_AUTH_URL: https://${DASHBOARD_SUBDOMAIN:-dashboard}.${DOMAIN:?DOMAIN is required}
-      ORIGIN: https://${DASHBOARD_SUBDOMAIN:-dashboard}.${DOMAIN}
+      ORIGIN: https://${DASHBOARD_SUBDOMAIN:-dashboard}.${DOMAIN:?DOMAIN is required}
       HTTP_OVERRIDE_ORIGIN: https://${DASHBOARD_SUBDOMAIN:-dashboard}.${DOMAIN}
       GATEWAY_URL: https://${GATEWAY_SUBDOMAIN:-api}.${DOMAIN}
       INFOSERVER_URL: ${INFOSERVER_URL:-https://sysinfo.xinity.ai}

--- a/nix/modules/xinity-ai-dashboard.mod.nix
+++ b/nix/modules/xinity-ai-dashboard.mod.nix
@@ -343,9 +343,6 @@ in {
           // lib.optionalAttrs (cfg.betterAuthSecret != null) {
             BETTER_AUTH_SECRET = cfg.betterAuthSecret;
           }
-          // lib.optionalAttrs (cfg.betterAuthUrl != null) {
-            BETTER_AUTH_URL = cfg.betterAuthUrl;
-          }
           // lib.optionalAttrs (cfg.infoserverUrl != null) {
             INFOSERVER_URL = cfg.infoserverUrl;
           }

--- a/packages/common-db/db-migration/0008_outstanding_dazzler.sql
+++ b/packages/common-db/db-migration/0008_outstanding_dazzler.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "model_deployment" ADD COLUMN "specifier" text;--> statement-breakpoint
+ALTER TABLE "model_deployment" ADD COLUMN "early_specifier" text;--> statement-breakpoint
+ALTER TABLE "model_installation" ADD COLUMN "specifier" text;--> statement-breakpoint
+CREATE INDEX "model_installation_specifier_idx" ON "model_installation" USING btree ("specifier");

--- a/packages/common-db/db-migration/meta/0008_snapshot.json
+++ b/packages/common-db/db-migration/meta/0008_snapshot.json
@@ -1,0 +1,3180 @@
+{
+  "id": "dd977b44-fa79-4368-b4ea-ade03632ad2d",
+  "prevId": "8fa047e1-a82e-40a6-8636-9a5f958c521c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ai_api_key": {
+      "name": "ai_api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "specifier": {
+          "name": "specifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "collect_data": {
+          "name": "collect_data",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_api_key_organization_id_idx": {
+          "name": "ai_api_key_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_api_key_specifier_idx": {
+          "name": "ai_api_key_specifier_idx",
+          "columns": [
+            {
+              "expression": "specifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_api_key_application_id_idx": {
+          "name": "ai_api_key_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_api_key_deleted_at_idx": {
+          "name": "ai_api_key_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_api_key_organization_id_organization_id_fk": {
+          "name": "ai_api_key_organization_id_organization_id_fk",
+          "tableFrom": "ai_api_key",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_api_key_application_id_ai_application_id_fk": {
+          "name": "ai_api_key_application_id_ai_application_id_fk",
+          "tableFrom": "ai_api_key",
+          "tableTo": "ai_application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "ai_api_key_created_by_user_id_user_id_fk": {
+          "name": "ai_api_key_created_by_user_id_user_id_fk",
+          "tableFrom": "ai_api_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_application": {
+      "name": "ai_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_application_organization_id_idx": {
+          "name": "ai_application_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_application_deleted_at_idx": {
+          "name": "ai_application_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_application_name_organization_id_unique": {
+          "name": "ai_application_name_organization_id_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"ai_application\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_application_organization_id_organization_id_fk": {
+          "name": "ai_application_organization_id_organization_id_fk",
+          "tableFrom": "ai_application",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_account_id_provider_id_idx": {
+          "name": "account_account_id_provider_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard_api_key": {
+      "name": "dashboard_api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "dashboard_api_key_user_id_idx": {
+          "name": "dashboard_api_key_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dashboard_api_key_prefix_idx": {
+          "name": "dashboard_api_key_prefix_idx",
+          "columns": [
+            {
+              "expression": "prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dashboard_api_key_config_id_idx": {
+          "name": "dashboard_api_key_config_id_idx",
+          "columns": [
+            {
+              "expression": "config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dashboard_api_key_user_id_user_id_fk": {
+          "name": "dashboard_api_key_user_id_user_id_fk",
+          "tableFrom": "dashboard_api_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "passkey_user_id_idx": {
+          "name": "passkey_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_token_idx": {
+          "name": "session_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "session_active_organization_id_organization_id_fk": {
+          "name": "session_active_organization_id_organization_id_fk",
+          "tableFrom": "session",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "active_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sso_provider": {
+      "name": "sso_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_config": {
+          "name": "oidc_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saml_config": {
+          "name": "saml_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain_verified": {
+          "name": "domain_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sso_provider_user_id_user_id_fk": {
+          "name": "sso_provider_user_id_user_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sso_provider_organization_id_organization_id_fk": {
+          "name": "sso_provider_organization_id_organization_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.two_factor": {
+      "name": "two_factor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backup_codes": {
+          "name": "backup_codes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "two_factor_user_id_idx": {
+          "name": "two_factor_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "two_factor_user_id_user_id_fk": {
+          "name": "two_factor_user_id_user_id_fk",
+          "tableFrom": "two_factor",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_settings": {
+          "name": "notification_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_settings": {
+          "name": "display_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires_at": {
+          "name": "ban_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temporary_password": {
+          "name": "temporary_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "call_data.api_call_response": {
+      "name": "api_call_response",
+      "schema": "call_data",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_call_id": {
+          "name": "api_call_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_edit": {
+          "name": "output_edit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highlights": {
+          "name": "highlights",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excluded_messages": {
+          "name": "excluded_messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_exclusions": {
+          "name": "input_exclusions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_call_response_user_id_user_id_fk": {
+          "name": "api_call_response_user_id_user_id_fk",
+          "tableFrom": "api_call_response",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_call_response_api_call_id_api_call_id_fk": {
+          "name": "api_call_response_api_call_id_api_call_id_fk",
+          "tableFrom": "api_call_response",
+          "tableTo": "api_call",
+          "schemaTo": "call_data",
+          "columnsFrom": [
+            "api_call_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "api_call_response_user_id_api_call_id_pk": {
+          "name": "api_call_response_user_id_api_call_id_pk",
+          "columns": [
+            "user_id",
+            "api_call_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "call_data.api_call": {
+      "name": "api_call",
+      "schema": "call_data",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "specified_model": {
+          "name": "specified_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user": {
+          "name": "user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_messages": {
+          "name": "input_messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_message": {
+          "name": "output_message",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_call_api_key_id_idx": {
+          "name": "api_call_api_key_id_idx",
+          "columns": [
+            {
+              "expression": "api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_call_application_id_idx": {
+          "name": "api_call_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_call_organization_id_idx": {
+          "name": "api_call_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_call_organization_id_created_at_idx": {
+          "name": "api_call_organization_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_call_model_idx": {
+          "name": "api_call_model_idx",
+          "columns": [
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_call_api_key_id_ai_api_key_id_fk": {
+          "name": "api_call_api_key_id_ai_api_key_id_fk",
+          "tableFrom": "api_call",
+          "tableTo": "ai_api_key",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "api_call_application_id_ai_application_id_fk": {
+          "name": "api_call_application_id_ai_application_id_fk",
+          "tableFrom": "api_call",
+          "tableTo": "ai_application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "api_call_organization_id_organization_id_fk": {
+          "name": "api_call_organization_id_organization_id_fk",
+          "tableFrom": "api_call",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "call_data.media_object": {
+      "name": "media_object",
+      "schema": "call_data",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_url": {
+          "name": "original_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_bucket": {
+          "name": "s3_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "media_object_organization_id_sha256_idx": {
+          "name": "media_object_organization_id_sha256_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_object_organization_id_idx": {
+          "name": "media_object_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_object_organization_id_organization_id_fk": {
+          "name": "media_object_organization_id_organization_id_fk",
+          "tableFrom": "media_object",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "call_data.usage_event": {
+      "name": "usage_event",
+      "schema": "call_data",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logged": {
+          "name": "logged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "usage_event_organization_id_created_at_idx": {
+          "name": "usage_event_organization_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_event_created_at_idx": {
+          "name": "usage_event_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_event_api_key_id_idx": {
+          "name": "usage_event_api_key_id_idx",
+          "columns": [
+            {
+              "expression": "api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_event_organization_id_organization_id_fk": {
+          "name": "usage_event_organization_id_organization_id_fk",
+          "tableFrom": "usage_event",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_event_application_id_ai_application_id_fk": {
+          "name": "usage_event_application_id_ai_application_id_fk",
+          "tableFrom": "usage_event",
+          "tableTo": "ai_application",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "usage_event_api_key_id_ai_api_key_id_fk": {
+          "name": "usage_event_api_key_id_ai_api_key_id_fk",
+          "tableFrom": "usage_event",
+          "tableTo": "ai_api_key",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "call_data.usage_summary": {
+      "name": "usage_summary",
+      "schema": "call_data",
+      "columns": {
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'00000000-0000-0000-0000-000000000000'"
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_calls": {
+          "name": "total_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "logged_calls": {
+          "name": "logged_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_duration": {
+          "name": "total_duration",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "usage_summary_organization_id_idx": {
+          "name": "usage_summary_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_summary_organization_id_date_idx": {
+          "name": "usage_summary_organization_id_date_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "usage_summary_date_organization_id_application_id_api_key_id_model_pk": {
+          "name": "usage_summary_date_organization_id_application_id_api_key_id_model_pk",
+          "columns": [
+            "date",
+            "organization_id",
+            "application_id",
+            "api_key_id",
+            "model"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_config": {
+      "name": "deployment_config",
+      "schema": "",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "deployment_config_singleton_check": {
+          "name": "deployment_config_singleton_check",
+          "value": "\"deployment_config\".\"singleton\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ai_node": {
+      "name": "ai_node",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "est_capacity": {
+          "name": "est_capacity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "drivers": {
+          "name": "drivers",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"ollama\"}'"
+        },
+        "gpu_count": {
+          "name": "gpu_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "driver_versions": {
+          "name": "driver_versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "gpus": {
+          "name": "gpus",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "auth_token": {
+          "name": "auth_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tls": {
+          "name": "tls",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_node_deleted_at_idx": {
+          "name": "ai_node_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_node_host_port_idx": {
+          "name": "ai_node_host_port_idx",
+          "columns": [
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "port",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"ai_node\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_deployment": {
+      "name": "model_deployment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "public_specifier": {
+          "name": "public_specifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "specifier": {
+          "name": "specifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "early_specifier": {
+          "name": "early_specifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_specifier": {
+          "name": "model_specifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "early_model_specifier": {
+          "name": "early_model_specifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replicas": {
+          "name": "replicas",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "canary_progress_until": {
+          "name": "canary_progress_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canary_progress_from": {
+          "name": "canary_progress_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canary_progress_with_feedback": {
+          "name": "canary_progress_with_feedback",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "progress": {
+          "name": "progress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "kv_cache_size": {
+          "name": "kv_cache_size",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "early_kv_cache_size": {
+          "name": "early_kv_cache_size",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_driver": {
+          "name": "preferred_driver",
+          "type": "inference_driver",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "model_deployment_public_specifier_organization_id_idx": {
+          "name": "model_deployment_public_specifier_organization_id_idx",
+          "columns": [
+            {
+              "expression": "public_specifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"model_deployment\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "model_deployment_deleted_at_idx": {
+          "name": "model_deployment_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_deployment_organization_id_organization_id_fk": {
+          "name": "model_deployment_organization_id_organization_id_fk",
+          "tableFrom": "model_deployment",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_installation_state": {
+      "name": "model_installation_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lifecycle_state": {
+          "name": "lifecycle_state",
+          "type": "lifecycle_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_message": {
+          "name": "status_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_logs": {
+          "name": "failure_logs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_installation_state_id_model_installation_id_fk": {
+          "name": "model_installation_state_id_model_installation_id_fk",
+          "tableFrom": "model_installation_state",
+          "tableTo": "model_installation",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_installation": {
+      "name": "model_installation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "specifier": {
+          "name": "specifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "est_capacity": {
+          "name": "est_capacity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kv_cache_capacity": {
+          "name": "kv_cache_capacity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driver": {
+          "name": "driver",
+          "type": "inference_driver",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "model_installation_node_id_idx": {
+          "name": "model_installation_node_id_idx",
+          "columns": [
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "model_installation_specifier_idx": {
+          "name": "model_installation_specifier_idx",
+          "columns": [
+            {
+              "expression": "specifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "model_installation_model_idx": {
+          "name": "model_installation_model_idx",
+          "columns": [
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "model_installation_deleted_at_idx": {
+          "name": "model_installation_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_installation_node_id_ai_node_id_fk": {
+          "name": "model_installation_node_id_ai_node_id_fk",
+          "tableFrom": "model_installation",
+          "tableTo": "ai_node",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification": {
+      "name": "notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'email'"
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_user_id_idx": {
+          "name": "notification_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_organization_id_idx": {
+          "name": "notification_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_type_idx": {
+          "name": "notification_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_deleted_at_idx": {
+          "name": "notification_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_user_id_user_id_fk": {
+          "name": "notification_user_id_user_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_organization_id_organization_id_fk": {
+          "name": "notification_organization_id_organization_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invitation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invitation_organization_id_idx": {
+          "name": "invitation_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "member_user_id_idx": {
+          "name": "member_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_organization_id_idx": {
+          "name": "member_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_user_id_organization_id_idx": {
+          "name": "member_user_id_organization_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sso_self_manage": {
+          "name": "sso_self_manage",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.inference_driver": {
+      "name": "inference_driver",
+      "schema": "public",
+      "values": [
+        "ollama",
+        "vllm"
+      ]
+    },
+    "public.lifecycle_state": {
+      "name": "lifecycle_state",
+      "schema": "public",
+      "values": [
+        "downloading",
+        "installing",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.invitation_status": {
+      "name": "invitation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "rejected",
+        "canceled"
+      ]
+    }
+  },
+  "schemas": {
+    "call_data": "call_data"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/common-db/db-migration/meta/_journal.json
+++ b/packages/common-db/db-migration/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1777457650674,
       "tag": "0007_cute_starhawk",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1777972698032,
+      "tag": "0008_outstanding_dazzler",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/common-db/src/schema/models.ts
+++ b/packages/common-db/src/schema/models.ts
@@ -32,17 +32,13 @@ export const modelDeploymentT = pgTable("model_deployment", {
    * This indirection enables project scoping, and canary deployments.
    * Tbs, by default it will simply reflect the specifier of the deployed model */
   publicSpecifier: text("public_specifier").notNull(),
-  /** Canonical model identifier (infoserver publicSpecifier today; per-org custom model id in the future).
-   * Used for all infoserver lookups and deployment ↔ installation joins. Nullable for legacy rows
-   * created before this column existed; new rows always populate it. */
+  /** Canonical model identifier. Nullable for legacy rows. */
   specifier: text(),
-  /** Canary counterpart of {@link specifier}. */
   earlySpecifier: text("early_specifier"),
-  /** @deprecated Use {@link specifier}. This is the driver-specific provider string and is preserved
-   * only for back-compat with rows that pre-date the specifier migration, and as the model name actually
-   * passed to vLLM/Ollama at launch time. */
+  /** @deprecated Will be removed in the next major version. The value is not trusted; the
+   * canonical {@link specifier} is the only source of identity. */
   modelSpecifier: text("model_specifier").notNull(),
-  /** @deprecated Use {@link earlySpecifier}. See {@link modelSpecifier}. */
+  /** @deprecated Will be removed in the next major version. */
   earlyModelSpecifier: text("early_model_specifier"),
   replicas: integer().notNull().default(1),
   /** When present, marks the point at which progress should reach 100 */
@@ -106,12 +102,10 @@ export type AiNode = InferSelectModel<typeof aiNodeT>;
 export const modelInstallationT = pgTable("model_installation", {
   id: uuid().primaryKey().defaultRandom(),
   nodeId: uuid("node_id").notNull().references(() => aiNodeT.id, { onDelete: "cascade" }),
-  /** Canonical model identifier (see {@link modelDeploymentT.specifier}). Nullable for legacy
-   * installations; new installations always populate it. */
+  /** Canonical model identifier. Nullable for legacy rows. */
   specifier: text(),
-  /** @deprecated Use {@link specifier} for catalog identity. This is the driver-specific provider
-   * string actually passed to vLLM/Ollama at launch and is preserved both for back-compat and as
-   * the value the daemon needs to invoke the underlying server. */
+  /** @deprecated Will be removed in the next major version. The value is not trusted; the
+   * provider-model name is derived from the catalog via {@link specifier}. */
   model: text().notNull(),
   /** estimated total GPU capacity required (model weights + KV cache), taken up on the selected node */
   estCapacity: real("est_capacity").notNull(),
@@ -131,6 +125,20 @@ export const modelInstallationT = pgTable("model_installation", {
   index("model_installation_deleted_at_idx").on(table.deletedAt),
 ]);
 export type ModelInstallation = InferSelectModel<typeof modelInstallationT>;
+
+/** SQL: deployment matches an installation by canonical specifier with legacy-string fallback.
+ * Use as the JOIN ON condition between modelDeploymentT and modelInstallationT. */
+export const deploymentMatchesInstallation = sql`
+  (COALESCE(${modelDeploymentT.specifier}, ${modelDeploymentT.modelSpecifier})
+    = COALESCE(${modelInstallationT.specifier}, ${modelInstallationT.model})
+  OR COALESCE(${modelDeploymentT.earlySpecifier}, ${modelDeploymentT.earlyModelSpecifier})
+    = COALESCE(${modelInstallationT.specifier}, ${modelInstallationT.model}))
+`;
+
+/** SQL: installation matches the given lookup value (specifier or providerModel). */
+export function installationMatchesLookup(value: string) {
+  return sql`COALESCE(${modelInstallationT.specifier}, ${modelInstallationT.model}) = ${value}`;
+}
 
 /**
  * Represents known additional info about any particular model installation. This is a 1-on-1 mapping, but kept

--- a/packages/common-db/src/schema/models.ts
+++ b/packages/common-db/src/schema/models.ts
@@ -32,9 +32,17 @@ export const modelDeploymentT = pgTable("model_deployment", {
    * This indirection enables project scoping, and canary deployments.
    * Tbs, by default it will simply reflect the specifier of the deployed model */
   publicSpecifier: text("public_specifier").notNull(),
-  /** The model to actually deploy. In case of canary deployments, this represents the end-state */
+  /** Canonical model identifier (infoserver publicSpecifier today; per-org custom model id in the future).
+   * Used for all infoserver lookups and deployment ↔ installation joins. Nullable for legacy rows
+   * created before this column existed; new rows always populate it. */
+  specifier: text(),
+  /** Canary counterpart of {@link specifier}. */
+  earlySpecifier: text("early_specifier"),
+  /** @deprecated Use {@link specifier}. This is the driver-specific provider string and is preserved
+   * only for back-compat with rows that pre-date the specifier migration, and as the model name actually
+   * passed to vLLM/Ollama at launch time. */
   modelSpecifier: text("model_specifier").notNull(),
-  /** The model to start with in terms of canary deployment. Once progress has reached 100, this falls away */
+  /** @deprecated Use {@link earlySpecifier}. See {@link modelSpecifier}. */
   earlyModelSpecifier: text("early_model_specifier"),
   replicas: integer().notNull().default(1),
   /** When present, marks the point at which progress should reach 100 */
@@ -98,6 +106,12 @@ export type AiNode = InferSelectModel<typeof aiNodeT>;
 export const modelInstallationT = pgTable("model_installation", {
   id: uuid().primaryKey().defaultRandom(),
   nodeId: uuid("node_id").notNull().references(() => aiNodeT.id, { onDelete: "cascade" }),
+  /** Canonical model identifier (see {@link modelDeploymentT.specifier}). Nullable for legacy
+   * installations; new installations always populate it. */
+  specifier: text(),
+  /** @deprecated Use {@link specifier} for catalog identity. This is the driver-specific provider
+   * string actually passed to vLLM/Ollama at launch and is preserved both for back-compat and as
+   * the value the daemon needs to invoke the underlying server. */
   model: text().notNull(),
   /** estimated total GPU capacity required (model weights + KV cache), taken up on the selected node */
   estCapacity: real("est_capacity").notNull(),
@@ -112,6 +126,7 @@ export const modelInstallationT = pgTable("model_installation", {
   updatedAt,
 }, table => [
   index("model_installation_node_id_idx").on(table.nodeId),
+  index("model_installation_specifier_idx").on(table.specifier),
   index("model_installation_model_idx").on(table.model),
   index("model_installation_deleted_at_idx").on(table.deletedAt),
 ]);

--- a/packages/xinity-ai-daemon/src/modules/model-installation/cache-eviction.test.ts
+++ b/packages/xinity-ai-daemon/src/modules/model-installation/cache-eviction.test.ts
@@ -24,6 +24,7 @@ function inst(model: string, opts: { deletedAt?: Date | null } = {}): ModelInsta
   return {
     id: crypto.randomUUID(),
     nodeId: "node-1",
+    specifier: null,
     model,
     estCapacity: 16,
     kvCacheCapacity: 4,

--- a/packages/xinity-ai-daemon/src/modules/model-installation/ollama.test.ts
+++ b/packages/xinity-ai-daemon/src/modules/model-installation/ollama.test.ts
@@ -64,6 +64,7 @@ function makeInstallation(model: string, id = crypto.randomUUID()) {
   return {
     id,
     nodeId: "node-1",
+    specifier: null,
     model,
     estCapacity: 8,
     kvCacheCapacity: 0,

--- a/packages/xinity-ai-daemon/src/modules/model-installation/vllm.test.ts
+++ b/packages/xinity-ai-daemon/src/modules/model-installation/vllm.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, mock, beforeEach } from "bun:test";
 import { firstValueFrom } from "rxjs";
 import type { VllmOps } from "./vllm-ops";
+import { installationLookup } from "xinity-infoserver";
 
 // ---------------------------------------------------------------------------
 // Mocks: must be set up before importing the module under test
@@ -65,8 +66,10 @@ const mockHasTag = mock<(specifier: string, tag: string) => Promise<boolean>>(
 const mockResolveDriverArgs = mock<(specifier: string) => Promise<string[]>>(
   () => Promise.resolve([]),
 );
-const mockFetchModel = mock<(specifier: string) => Promise<{ type?: string } | undefined>>(
-  () => Promise.resolve({ type: "chat" }),
+type Lookup = { kind: "canonical"; specifier: string } | { kind: "legacy"; providerModel: string };
+const lookupValue = (l: Lookup) => l.kind === "canonical" ? l.specifier : l.providerModel;
+const mockFetchModel = mock<(lookup: Lookup) => Promise<{ type?: string; providers: { vllm?: string; ollama?: string } } | undefined>>(
+  (lookup) => Promise.resolve({ type: "chat", providers: { vllm: lookupValue(lookup) } }),
 );
 
 mock.module("xinity-infoserver", () => ({
@@ -75,6 +78,7 @@ mock.module("xinity-infoserver", () => ({
     resolveDriverArgs: mockResolveDriverArgs,
     fetchModel: mockFetchModel,
   }),
+  installationLookup,
 }));
 
 // Mock the statekeeper hardware profile
@@ -109,6 +113,7 @@ function makeInstallation(model: string, id: string = crypto.randomUUID(), port 
   return {
     id,
     nodeId: "node-1",
+    specifier: null,
     model,
     estCapacity: 16,
     kvCacheCapacity: 4,
@@ -148,7 +153,7 @@ describe("syncVllmInstallations$", () => {
     mockSelectWhere.mockImplementation(() => Promise.resolve([]));
     mockHasTag.mockImplementation(() => Promise.resolve(false));
     mockResolveDriverArgs.mockImplementation(() => Promise.resolve([]));
-    mockFetchModel.mockImplementation(() => Promise.resolve({ type: "chat" }));
+    mockFetchModel.mockImplementation((lookup) => Promise.resolve({ type: "chat", providers: { vllm: lookupValue(lookup) } }));
     mockGetFreeMemoryMb.mockImplementation(() => Promise.resolve(20480));
   });
 
@@ -438,7 +443,7 @@ describe("syncVllmInstallations$", () => {
   test("adds --runner pooling for embedding models", async () => {
     const id = crypto.randomUUID();
     const inst = makeInstallation("embed-model", id, 9102);
-    mockFetchModel.mockImplementation(() => Promise.resolve({ type: "embedding" }));
+    mockFetchModel.mockImplementation((lookup) => Promise.resolve({ type: "embedding", providers: { vllm: lookupValue(lookup) } }));
     const ops = createMockOps({
       listRunning: mock(() => Promise.resolve([])),
       checkHealth: mock(() => Promise.resolve(true)),
@@ -455,7 +460,7 @@ describe("syncVllmInstallations$", () => {
   test("adds --runner pooling for rerank models", async () => {
     const id = crypto.randomUUID();
     const inst = makeInstallation("rerank-model", id, 9103);
-    mockFetchModel.mockImplementation(() => Promise.resolve({ type: "rerank" }));
+    mockFetchModel.mockImplementation((lookup) => Promise.resolve({ type: "rerank", providers: { vllm: lookupValue(lookup) } }));
     const ops = createMockOps({
       listRunning: mock(() => Promise.resolve([])),
       checkHealth: mock(() => Promise.resolve(true)),
@@ -472,7 +477,7 @@ describe("syncVllmInstallations$", () => {
   test("does not add --runner pooling for chat models", async () => {
     const id = crypto.randomUUID();
     const inst = makeInstallation("chat-model", id, 9104);
-    mockFetchModel.mockImplementation(() => Promise.resolve({ type: "chat" }));
+    mockFetchModel.mockImplementation((lookup) => Promise.resolve({ type: "chat", providers: { vllm: lookupValue(lookup) } }));
     const ops = createMockOps({
       listRunning: mock(() => Promise.resolve([])),
       checkHealth: mock(() => Promise.resolve(true)),
@@ -483,6 +488,37 @@ describe("syncVllmInstallations$", () => {
 
     const startCall = (ops.start as ReturnType<typeof mock>).mock.calls[0]!;
     expect(startCall[1].extraArgs).not.toContain("--runner");
+  });
+
+  test("uses providers.vllm from the catalog rather than the installation row's model column", async () => {
+    const id = crypto.randomUUID();
+    const inst = { ...makeInstallation("legacy-stale-name", id, 9105), specifier: "canonical-x" };
+    mockFetchModel.mockImplementation(() => Promise.resolve({ type: "chat", providers: { vllm: "real-vllm-name" } }));
+    const ops = createMockOps({
+      listRunning: mock(() => Promise.resolve([])),
+      checkHealth: mock(() => Promise.resolve(true)),
+      isAlive: mock(() => Promise.resolve(true)),
+    });
+
+    await firstValueFrom(syncVllmInstallations$([inst], ops));
+
+    const startCall = (ops.start as ReturnType<typeof mock>).mock.calls[0]!;
+    expect(startCall[1].model).toBe("real-vllm-name");
+  });
+
+  test("aborts the installation when the catalog has no vllm provider for the chosen driver", async () => {
+    const id = crypto.randomUUID();
+    const inst = makeInstallation("ollama-only-model", id, 9106);
+    mockFetchModel.mockImplementation(() => Promise.resolve({ type: "chat", providers: { ollama: "ollama-only-model" } }));
+    const ops = createMockOps({
+      listRunning: mock(() => Promise.resolve([])),
+      checkHealth: mock(() => Promise.resolve(true)),
+      isAlive: mock(() => Promise.resolve(true)),
+    });
+
+    await firstValueFrom(syncVllmInstallations$([inst], ops));
+
+    expect(ops.start).not.toHaveBeenCalled();
   });
 
   test("reconciles crash-looping container to failed and stops it", async () => {

--- a/packages/xinity-ai-daemon/src/modules/model-installation/vllm.ts
+++ b/packages/xinity-ai-daemon/src/modules/model-installation/vllm.ts
@@ -22,7 +22,7 @@ import {
   createSystemdVllmOps,
   type VllmOps,
 } from "./vllm-ops";
-import { createInfoserverClient } from "xinity-infoserver";
+import { createInfoserverClient, installationLookup } from "xinity-infoserver";
 import { rootLogger } from "../../logger";
 import { getHardwareProfile } from "../statekeeper";
 import { getFreeMemoryMb } from "../hardware-detect";
@@ -90,6 +90,7 @@ async function warmupChatModel(port: number, model: string): Promise<void> {
 function pollUntilHealthy$(
   installation: ModelInstallation,
   ops: VllmOps,
+  providerModel: string,
   modelType?: string,
 ): Observable<void> {
   const deadline = Date.now() + env.VLLM_HEALTH_TIMEOUT_MS;
@@ -133,7 +134,7 @@ function pollUntilHealthy$(
     switchMap(() =>
       from((async () => {
         if (modelType !== "embedding" && modelType !== "rerank") {
-          await warmupChatModel(installation.port, installation.model);
+          await warmupChatModel(installation.port, providerModel);
         }
         await updateInstallationState(installation.id, "ready", { statusMessage: "vLLM server healthy" });
       })()),
@@ -143,15 +144,20 @@ function pollUntilHealthy$(
   );
 }
 
-/** Downloads weights, starts the container, and returns the model type for health polling. */
-async function downloadAndStart(installation: ModelInstallation, ops: VllmOps): Promise<string | undefined> {
-  const modelInfo = await infoClient.fetchModel(installation.model);
+/** Downloads weights, starts the container, and returns metadata used for health polling and warmup. */
+async function downloadAndStart(installation: ModelInstallation, ops: VllmOps): Promise<{ modelType: string | undefined; providerModel: string }> {
+  const lookup = installationLookup(installation);
+  const modelInfo = await infoClient.fetchModel(lookup);
+  const providerModel = modelInfo?.providers.vllm;
+  if (!providerModel) {
+    throw new Error(`Catalog entry has no vllm provider for installation ${installation.id}`);
+  }
 
   await updateInstallationState(installation.id, "downloading", { statusMessage: "Downloading model", progress: 0 });
 
   let lastProgressAt = 0;
   await downloadModel(
-    installation.model,
+    providerModel,
     async (progress) => {
       const now = Date.now();
       if (now - lastProgressAt >= 5000) {
@@ -165,9 +171,9 @@ async function downloadAndStart(installation: ModelInstallation, ops: VllmOps): 
   await updateInstallationState(installation.id, "installing", { statusMessage: "Starting vLLM service" });
 
   const [trustRemoteCode, hasToolsTag, extraArgs, profile] = await Promise.all([
-    infoClient.hasTag(installation.model, "custom_code"),
-    infoClient.hasTag(installation.model, "tools"),
-    infoClient.resolveDriverArgs(installation.model),
+    infoClient.hasTag(lookup, "custom_code", "vllm"),
+    infoClient.hasTag(lookup, "tools", "vllm"),
+    infoClient.resolveDriverArgs(lookup, "vllm"),
     getHardwareProfile(),
   ]);
 
@@ -175,7 +181,7 @@ async function downloadAndStart(installation: ModelInstallation, ops: VllmOps): 
   const modelType = modelInfo?.type;
 
   await ops.start(installation.id, {
-    model: installation.model,
+    model: providerModel,
     port: installation.port,
     kvCacheBytes: `${installation.kvCacheCapacity}g`,
     trustRemoteCode,
@@ -187,7 +193,7 @@ async function downloadAndStart(installation: ModelInstallation, ops: VllmOps): 
     ],
   });
 
-  return modelType;
+  return { modelType, providerModel };
 }
 
 export function computeGpuUtilization(
@@ -372,12 +378,12 @@ function startNewInstallations$(candidates: ModelInstallation[], ops: VllmOps): 
         mergeMap((installation) => {
           let containerStarted = false;
           return defer(() =>
-            from(downloadAndStart(installation, ops).then((modelType) => {
+            from(downloadAndStart(installation, ops).then((res) => {
               containerStarted = true;
-              return modelType;
+              return res;
             })),
           ).pipe(
-            switchMap((modelType) => pollUntilHealthy$(installation, ops, modelType)),
+            switchMap(({ modelType, providerModel }) => pollUntilHealthy$(installation, ops, providerModel, modelType)),
             catchError((err) => handleInstallationError(err, installation, ops, containerStarted)),
           );
         }),

--- a/packages/xinity-ai-dashboard/.env.test
+++ b/packages/xinity-ai-dashboard/.env.test
@@ -1,7 +1,6 @@
 MAIL_URL=smtp://localhost:1025
 MAIL_FROM=Auth Service <noreply@example.com>
 BETTER_AUTH_SECRET=secret_key
-BETTER_AUTH_URL=http://localhost:5173
 GATEWAY_URL=http://localhost:4010
 APP_NAME=Xinity Admin
 SIGNUP_ENABLED=true

--- a/packages/xinity-ai-dashboard/example.env
+++ b/packages/xinity-ai-dashboard/example.env
@@ -3,7 +3,6 @@ MAIL_URL=smtp://localhost:1025
 MAIL_FROM="Auth Service <noreply@example.com>"
 # Generate with: openssl rand -base64 33
 BETTER_AUTH_SECRET="replace-me"
-BETTER_AUTH_URL=http://localhost:5173
 GATEWAY_URL=http://localhost:4010
 APP_NAME="Xinity Admin"
 SIGNUP_ENABLED=true

--- a/packages/xinity-ai-dashboard/src/lib/orpc/dtos/model.dto.ts
+++ b/packages/xinity-ai-dashboard/src/lib/orpc/dtos/model.dto.ts
@@ -10,7 +10,12 @@ export const DeploymentDto = CommonDto.extend({
 
   enabled: z.boolean(),
   publicSpecifier: z.string().trim(),
+  /** Canonical model identifier. Required server-side at create time. */
+  specifier: z.string().trim().nullish(),
+  earlySpecifier: z.string().trim().nullish(),
+  /** @deprecated Driver-specific provider string; derived server-side from {@link specifier}. */
   modelSpecifier: z.string().trim(),
+  /** @deprecated */
   earlyModelSpecifier: z.string().trim().nullish(),
   replicas: z.number().default(1),
   canaryProgressUntil: z.date().nullish(),

--- a/packages/xinity-ai-dashboard/src/lib/remoteFNS/model.remote.ts
+++ b/packages/xinity-ai-dashboard/src/lib/remoteFNS/model.remote.ts
@@ -19,7 +19,7 @@ async function getRemoteSession() {
 }
 
 /** Resolves a single model's full metadata by public specifier. */
-export const getModelInfoR = query(z.string(), async (publicSpecifier) => {
+export const getModelInfoR = query(z.string(), async (specifier) => {
   await getRemoteSession();
-  return await infoClient?.fetchModel(publicSpecifier) ?? null;
+  return await infoClient?.fetchModel({ kind: "canonical", specifier }) ?? null;
 });

--- a/packages/xinity-ai-dashboard/src/lib/server/env-schema.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/env-schema.ts
@@ -7,7 +7,8 @@ export const dashboardEnvSchema = z.object({
   ORIGIN: z.url().default("http://localhost:5173").describe("Public origin URL, no trailing slash (e.g. https://xinity.mydomain.com)"),
   HTTP_PORT: z.coerce.number().int().default(5173).describe("TCP port the server listens on (use a reverse proxy if deploying behind HTTPS)").meta(expert()),
   BETTER_AUTH_SECRET: z.string().describe("Better Auth secret key, generate with: openssl rand -base64 33").meta(secret()),
-  BETTER_AUTH_URL: z.string().describe("Better Auth URL, usually the same as ORIGIN (e.g. https://xinity.mydomain.com)"),
+  /** @deprecated */
+  BETTER_AUTH_URL: z.string().optional().describe("DEPRECATED: no longer used. ORIGIN is used as the Better Auth base URL.").meta(expert()),
   INFOSERVER_URL: z.url().describe("Infoserver URL (default hosted: https://sysinfo.xinity.ai, or your self-hosted instance)"),
   SIGNUP_ENABLED: z.stringbool().default(true).describe("Enable user signup"),
   COMPUTE_MANAGEMENT_ENABLED: z.stringbool().default(true).describe("Enable compute management").meta(expert()),

--- a/packages/xinity-ai-dashboard/src/lib/server/lib/orchestration.mod.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/lib/orchestration.mod.ts
@@ -1,7 +1,7 @@
 import { inArray, isNull, modelDeploymentT, sql, calcCanaryProgress, modelInstallationT, aiNodeT, type ModelInstallation, type AiNode, type InferInsertModel } from "common-db";
 import { getDB } from "../db";
 import { infoClient } from "../info-client";
-import { resolveDriverForProviderModel, resolveMinVersionForDriver, resolveRequiredPlatformsForDriver, checkNodeCompatibility, type ModelNodeRequirements, type NodeCapability } from "xinity-infoserver";
+import { resolveDefaultProvider, resolveMinVersionForDriver, resolveRequiredPlatformsForDriver, checkNodeCompatibility, deploymentLookup, deploymentEarlyLookup, installationKey, lookupKey, type ModelNodeRequirements, type NodeCapability, type Provider, type ModelLookup } from "xinity-infoserver";
 import { rootLogger } from "../logging";
 import { building } from "$app/environment";
 import { maxVramGb } from "$lib/server/license";
@@ -21,55 +21,59 @@ interface ClusterState {
   availableServers: AiNode[];
 }
 
-/** Represents required replicas and optional kvCacheSize per model specifier. */
-export type ModelRequirement = { replicas: number; kvCacheSize: number | null };
+export type ModelRequirement = { lookup: ModelLookup; replicas: number; kvCacheSize: number | null; preferredDriver: Provider | null };
 export type ModelRequirementTable = Record<string, ModelRequirement>;
 
 /** Builds the replica requirement table based on enabled deployments. */
 export async function assembleModelRequirementTable(): Promise<ModelRequirementTable> {
   const enabledDeployments = await getDB().select().from(modelDeploymentT).where(sql`
-    ${modelDeploymentT.enabled} 
-  AND 
+    ${modelDeploymentT.enabled}
+  AND
     ${modelDeploymentT.deletedAt} IS NULL
   `);
   const models = enabledDeployments.flatMap((deployment) => {
     const progress = calcCanaryProgress(deployment);
-    const isNotCanary = progress === 100 || !deployment.earlyModelSpecifier;
+    const earlyLookup = deploymentEarlyLookup(deployment);
+    const isNotCanary = progress === 100 || !earlyLookup;
     if (isNotCanary) {
       return [{
-        spec: deployment.modelSpecifier,
+        lookup: deploymentLookup(deployment),
         replicas: deployment.replicas,
         kvCacheSize: deployment.kvCacheSize,
+        preferredDriver: deployment.preferredDriver,
       }]
     }
     const replicas = deployment.replicas;
     return [{
-      spec: deployment.modelSpecifier,
+      lookup: deploymentLookup(deployment),
       replicas: Math.ceil(replicas * (progress / 100)),
       kvCacheSize: deployment.kvCacheSize,
+      preferredDriver: deployment.preferredDriver,
     }, {
-      spec: deployment.earlyModelSpecifier!,
+      lookup: earlyLookup!,
       replicas: Math.ceil(replicas * ((100 - progress) / 100)),
       kvCacheSize: deployment.earlyKvCacheSize,
+      preferredDriver: deployment.preferredDriver,
     }]
   });
-  // Take the maximum replica count and kvCacheSize when the same specifier appears in multiple deployments
-  const modelRequirements = models.reduce((agg, { spec, replicas, kvCacheSize }) => {
-    const existing = agg[spec];
+  // Take the maximum replica count and kvCacheSize when the same lookup key appears in multiple deployments
+  const modelRequirements = models.reduce((agg, entry) => {
+    const key = lookupKey(entry.lookup);
+    const existing = agg[key];
     if (existing) {
-      if (replicas > existing.replicas) existing.replicas = replicas;
-      if (kvCacheSize != null && (existing.kvCacheSize == null || kvCacheSize > existing.kvCacheSize)) {
-        existing.kvCacheSize = kvCacheSize;
+      if (entry.replicas > existing.replicas) existing.replicas = entry.replicas;
+      if (entry.kvCacheSize != null && (existing.kvCacheSize == null || entry.kvCacheSize > existing.kvCacheSize)) {
+        existing.kvCacheSize = entry.kvCacheSize;
       }
     } else {
-      agg[spec] = { replicas, kvCacheSize };
+      agg[key] = entry;
     }
     return agg;
   }, {} as ModelRequirementTable);
   return modelRequirements;
 }
 
-/** Indexes existing installations by model and by server, and initialises capacity tracking. */
+/** Indexes existing installations by lookup key and by server, and initialises capacity tracking. */
 export function buildClusterState(existing: ModelInstallation[], availableServers: AiNode[]): ClusterState {
   const installationsByModel = new Map<string, ModelInstallation[]>();
   const installationsByServer = new Map<string, ModelInstallation[]>();
@@ -81,9 +85,10 @@ export function buildClusterState(existing: ModelInstallation[], availableServer
   }
 
   for (const install of existing) {
-    const modelInstalls = installationsByModel.get(install.model) || [];
+    const key = installationKey(install);
+    const modelInstalls = installationsByModel.get(key) || [];
     modelInstalls.push(install);
-    installationsByModel.set(install.model, modelInstalls);
+    installationsByModel.set(key, modelInstalls);
 
     const serverInstalls = installationsByServer.get(install.nodeId);
     if (serverInstalls) {
@@ -129,7 +134,7 @@ export function collectExcessInstallations(requiredModels: ModelRequirementTable
  * Also skips nodes that already host the model.
  */
 export function findServerForModel(
-  model: string,
+  specifier: string,
   driver: string,
   weight: number,
   state: ClusterState,
@@ -147,8 +152,8 @@ export function findServerForModel(
     if (!cap) continue;
 
     const serverInstalls = state.installationsByServer.get(server.id) || [];
-    const alreadyHasModel = serverInstalls.some(inst => inst.model === model)
-      || pending.some(p => p.nodeId === server.id && p.model === model);
+    const alreadyHasModel = serverInstalls.some(inst => installationKey(inst) === specifier)
+      || pending.some(p => p.nodeId === server.id && installationKey({ specifier: p.specifier ?? null, model: p.model }) === specifier);
     if (alreadyHasModel) continue;
 
     const nodeCap: NodeCapability = {
@@ -186,25 +191,33 @@ function allocatePort(driver: string, nodeId: string, state: ClusterState, pendi
 async function planNewInstallations(requiredModels: ModelRequirementTable, state: ClusterState): Promise<NewInstallation[]> {
   const toInstall: NewInstallation[] = [];
 
-  for (const [model, requirement] of Object.entries(requiredModels)) {
-    const current = (state.installationsByModel.get(model) || []).length;
+  for (const [key, requirement] of Object.entries(requiredModels)) {
+    const current = (state.installationsByModel.get(key) || []).length;
     if (current >= requirement.replicas) continue;
 
-    const modelStatus = await infoClient?.fetchModelStatus(model);
+    const modelStatus = await infoClient?.fetchModelStatus(requirement.lookup);
     if (!modelStatus || modelStatus.status === "unavailable") {
-      log.warn({ model, error: modelStatus?.status === "unavailable" ? modelStatus.error : undefined },
+      log.warn({ lookup: requirement.lookup, error: modelStatus?.status === "unavailable" ? modelStatus.error : undefined },
         "Info server unreachable; skipping installation planning for this sync cycle");
       continue;
     }
     if (modelStatus.status === "not_found") {
-      log.warn({ model },
+      log.warn({ lookup: requirement.lookup },
         "Model not found in catalog; installations cannot be scheduled. " +
         "If this model has been intentionally removed, disable or delete the deployment.");
       continue;
     }
     const modelInfo = modelStatus.model;
 
-    const driver = resolveDriverForProviderModel(modelInfo, model) ?? "ollama";
+    const fallback = resolveDefaultProvider(modelInfo);
+    const driver: Provider = (requirement.preferredDriver && modelInfo.providers[requirement.preferredDriver])
+      ? requirement.preferredDriver
+      : (fallback?.driver ?? "ollama");
+    const providerModel = modelInfo.providers[driver];
+    if (!providerModel) {
+      log.warn({ lookup: requirement.lookup, driver }, "Catalog entry has no provider string for the chosen driver; skipping");
+      continue;
+    }
     const minVersion = resolveMinVersionForDriver(modelInfo, driver);
     const requiredPlatforms = resolveRequiredPlatformsForDriver(modelInfo, driver);
     const needed = requirement.replicas - current;
@@ -212,15 +225,25 @@ async function planNewInstallations(requiredModels: ModelRequirementTable, state
     const effectiveKvCache = Math.max(requirement.kvCacheSize ?? 0, modelInfo.minKvCache);
     const totalCapacity = modelInfo.weight + effectiveKvCache;
 
+    const installSpecifier = requirement.lookup.kind === "canonical" ? requirement.lookup.specifier : null;
+
     for (let i = 0; i < needed; i++) {
-      const nodeId = findServerForModel(model, driver, totalCapacity, state, toInstall, minVersion, requiredPlatforms);
+      const nodeId = findServerForModel(key, driver, totalCapacity, state, toInstall, minVersion, requiredPlatforms);
       if (!nodeId) {
-        log.warn({ model }, "No server with enough capacity for additional replica");
+        log.warn({ lookup: requirement.lookup }, "No server with enough capacity for additional replica");
         break;
       }
 
       const port = allocatePort(driver, nodeId, state, toInstall);
-      toInstall.push({ nodeId, model, estCapacity: totalCapacity, kvCacheCapacity: effectiveKvCache, driver, port });
+      toInstall.push({
+        nodeId,
+        specifier: installSpecifier,
+        model: providerModel,
+        estCapacity: totalCapacity,
+        kvCacheCapacity: effectiveKvCache,
+        driver,
+        port,
+      });
 
       const cap = state.serverCapacity.get(nodeId)!;
       cap.used += totalCapacity;

--- a/packages/xinity-ai-dashboard/src/lib/server/notifications/scheduler.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/notifications/scheduler.ts
@@ -9,6 +9,7 @@ import {
   organizationT,
   userT,
   count,
+  deploymentMatchesInstallation,
 } from "common-db";
 import { serverEnv } from "$lib/server/serverenv";
 import { getDB } from "$lib/server/db";
@@ -55,10 +56,7 @@ async function getDeploymentPhases(): Promise<Map<string, { phase: DeploymentPha
     .from(modelDeploymentT)
     .where(sql`${modelDeploymentT.enabled} = true AND ${modelDeploymentT.deletedAt} IS NULL`)
     .leftJoin(organizationT, sql`${organizationT.id} = ${modelDeploymentT.organizationId}`)
-    .leftJoin(modelInstallationT, sql`
-      (${modelDeploymentT.modelSpecifier} = ${modelInstallationT.model}
-      OR ${modelDeploymentT.earlyModelSpecifier} = ${modelInstallationT.model})
-      AND ${modelInstallationT.deletedAt} IS NULL`)
+    .leftJoin(modelInstallationT, sql`${deploymentMatchesInstallation} AND ${modelInstallationT.deletedAt} IS NULL`)
     .leftJoin(modelInstallationStateT, sql`${modelInstallationStateT.id} = ${modelInstallationT.id}`);
 
   type DeploymentInfo = { phase: DeploymentPhase; orgId: string; orgName: string; name: string; model: string; error: string | null };

--- a/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/deployment.procedure.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/deployment.procedure.ts
@@ -1,13 +1,13 @@
 import { rootOs, withOrganization, requirePermission } from "../root";
 import { commonInputFilter } from "$lib/orpc/dtos/common.dto";
-import { sql, modelDeploymentT, modelInstallationT, modelInstallationStateT, organizationT, type ModelDeployment } from "common-db";
+import { sql, modelDeploymentT, modelInstallationT, modelInstallationStateT, organizationT, deploymentMatchesInstallation, type ModelDeployment } from "common-db";
 import z from "zod";
 import { DeploymentDto } from "$lib/orpc/dtos/model.dto";
 import { getDB } from "$lib/server/db";
 import { syncDeployedModels } from "$lib/server/lib/orchestration.mod";
 import { infoClient } from "$lib/server/info-client";
 import { buildClusterCapacity } from "./cluster.procedure";
-import { resolveDriverForProviderModel, resolveMinVersionForDriver, resolveRequiredPlatformsForDriver, checkNodeCompatibility, type ModelNodeRequirements } from "xinity-infoserver";
+import { resolveDefaultProvider, resolveMinVersionForDriver, resolveRequiredPlatformsForDriver, checkNodeCompatibility, deploymentLookup, deploymentEarlyLookup, lookupKey, type ModelNodeRequirements, type Provider, type ModelLookup } from "xinity-infoserver";
 import { rootLogger } from "$lib/server/logging";
 import { aggregatePhase, type PhaseInfo } from "$lib/server/lib/deployment-phase";
 import { notifyOrgMembers } from "$lib/server/notifications/notification.service";
@@ -19,25 +19,38 @@ const tags = ["Deployment"];
 const SuccessDto = z.object({ success: z.literal(true) });
 const successObject = { success: true } as const;
 
+async function deriveProviderModel(lookup: ModelLookup, preferredDriver: Provider | null): Promise<string | undefined> {
+  if (!infoClient) return undefined;
+  const status = await infoClient.fetchModelStatus(lookup);
+  if (status.status !== "found") return undefined;
+  const model = status.model;
+  if (preferredDriver && model.providers[preferredDriver]) return model.providers[preferredDriver];
+  return resolveDefaultProvider(model)?.providerModel;
+}
+
 /** Validates that primary and canary models share the same type. */
-async function validateCanaryModelTypes(modelSpecifier: string, earlyModelSpecifier: string | null | undefined) {
-  if (!earlyModelSpecifier) return;
-  const primary = await infoClient?.fetchModel(modelSpecifier);
-  const canary = await infoClient?.fetchModel(earlyModelSpecifier);
-  if (primary?.type && canary?.type && primary.type !== canary.type) {
-    throw new Error(`Cannot mix model types in a canary deployment: primary is "${primary.type}" but canary is "${canary.type}"`);
+async function validateCanaryModelTypes(primary: ModelLookup, early: ModelLookup | null) {
+  if (!early) return;
+  const primaryModel = await infoClient?.fetchModel(primary);
+  const earlyModel = await infoClient?.fetchModel(early);
+  if (primaryModel?.type && earlyModel?.type && primaryModel.type !== earlyModel.type) {
+    throw new Error(`Cannot mix model types in a canary deployment: primary is "${primaryModel.type}" but canary is "${earlyModel.type}"`);
   }
 }
 
-/** Input shape for capacity checking, matches the deployment fields that affect capacity. */
 const CapacityCheckInput = z.object({
-  modelSpecifier: z.string().trim(),
+  specifier: z.string().trim().nullish(),
+  earlySpecifier: z.string().trim().nullish(),
+  /** @deprecated Pass the canonical {@link specifier} instead. */
+  modelSpecifier: z.string().trim().optional(),
+  /** @deprecated Pass {@link earlySpecifier} instead. */
   earlyModelSpecifier: z.string().trim().nullish(),
   replicas: z.number().default(1),
   progress: z.number().default(100),
   kvCacheSize: z.number().nullish(),
   earlyKvCacheSize: z.number().nullish(),
-});
+  preferredDriver: z.enum(["ollama", "vllm"]).nullish(),
+}).refine(d => d.specifier || d.modelSpecifier, { message: "Either `specifier` or `modelSpecifier` must be provided", path: ["specifier"] });
 
 const CapacityCheckOutput = z.object({
   deployable: z.boolean(),
@@ -52,36 +65,41 @@ type CapacityCheckResult = z.infer<typeof CapacityCheckOutput>;
  * accounting for the fact that they share the same pool of node capacity.
  */
 async function checkDeploymentCapacity(input: z.infer<typeof CapacityCheckInput>): Promise<CapacityCheckResult> {
-  const isCanary = input.progress < 100 && !!input.earlyModelSpecifier;
+  const primaryLookup = deploymentLookup(input);
+  if (!primaryLookup) {
+    return { deployable: false, reason: "Capacity check requires a model identifier" };
+  }
+  const earlyLookup = deploymentEarlyLookup(input);
+  const isCanary = input.progress < 100 && !!earlyLookup;
 
   // Build the list of models that need capacity
-  const modelsToCheck: { specifier: string; replicas: number; kvCacheSize: number | null | undefined }[] = [];
+  const modelsToCheck: { lookup: ModelLookup; label: string; replicas: number; kvCacheSize: number | null | undefined }[] = [];
   if (isCanary) {
     modelsToCheck.push(
-      { specifier: input.modelSpecifier, replicas: Math.ceil(input.replicas * (input.progress / 100)), kvCacheSize: input.kvCacheSize },
-      { specifier: input.earlyModelSpecifier!, replicas: Math.ceil(input.replicas * ((100 - input.progress) / 100)), kvCacheSize: input.earlyKvCacheSize ?? input.kvCacheSize },
+      { lookup: primaryLookup, label: lookupKey(primaryLookup), replicas: Math.ceil(input.replicas * (input.progress / 100)), kvCacheSize: input.kvCacheSize },
+      { lookup: earlyLookup!, label: lookupKey(earlyLookup!), replicas: Math.ceil(input.replicas * ((100 - input.progress) / 100)), kvCacheSize: input.earlyKvCacheSize ?? input.kvCacheSize },
     );
   } else {
-    modelsToCheck.push({ specifier: input.modelSpecifier, replicas: input.replicas, kvCacheSize: input.kvCacheSize });
+    modelsToCheck.push({ lookup: primaryLookup, label: lookupKey(primaryLookup), replicas: input.replicas, kvCacheSize: input.kvCacheSize });
   }
 
   // Fetch model info for all models, distinguishing not_found from unavailable
   const modelInfos = await Promise.all(
     modelsToCheck.map(async (m) => {
-      const status = await infoClient?.fetchModelStatus(m.specifier);
-      if (!status || status.status === "unavailable") return { kind: "unavailable" as const, specifier: m.specifier };
-      if (status.status === "not_found") return { kind: "not_found" as const, specifier: m.specifier };
+      const status = await infoClient?.fetchModelStatus(m.lookup);
+      if (!status || status.status === "unavailable") return { kind: "unavailable" as const, label: m.label };
+      if (status.status === "not_found") return { kind: "not_found" as const, label: m.label };
       const info = status.model;
       const effectiveKvCache = Math.max(m.kvCacheSize ?? 0, info.minKvCache);
-      const driver = resolveDriverForProviderModel(info, m.specifier);
+      const driver: Provider | undefined = input.preferredDriver ?? resolveDefaultProvider(info)?.driver;
       const minVersion = driver ? resolveMinVersionForDriver(info, driver) : undefined;
       const requiredPlatforms = driver ? resolveRequiredPlatformsForDriver(info, driver) : [];
-      return { kind: "found" as const, specifier: m.specifier, replicas: m.replicas, perReplica: info.weight + effectiveKvCache, driver, minVersion, requiredPlatforms };
+      return { kind: "found" as const, label: m.label, replicas: m.replicas, perReplica: info.weight + effectiveKvCache, driver, minVersion, requiredPlatforms };
     }),
   );
 
   const notFound = modelInfos.find(m => m.kind === "not_found");
-  if (notFound) return { deployable: false, reason: `Model "${notFound.specifier}" was not found in the model catalog` };
+  if (notFound) return { deployable: false, reason: `Model "${notFound.label}" was not found in the model catalog` };
 
   const resolved = modelInfos.filter((m): m is Extract<typeof modelInfos[number], { kind: "found" }> => m.kind === "found");
   if (resolved.length === 0) return { deployable: true, reason: "Capacity could not be verified: model catalog is unavailable" };
@@ -114,8 +132,8 @@ async function checkDeploymentCapacity(input: z.infer<typeof CapacityCheckInput>
     }
     if (placed < model.replicas) {
       const reason = compatible.length === 0 && model.driver
-        ? `No compatible node for "${model.specifier}" (requires ${model.driver}${model.minVersion ? ` >= ${model.minVersion}` : ""}${model.requiredPlatforms.length ? `, platform: ${model.requiredPlatforms.join("/")}` : ""})`
-        : `Insufficient cluster capacity: cannot place ${model.replicas} ${model.replicas === 1 ? "replica" : "replicas"} of "${model.specifier}" (${model.perReplica.toFixed(1)} GB each). Only ${placed} compatible ${placed === 1 ? "node has" : "nodes have"} enough free capacity`;
+        ? `No compatible node for "${model.label}" (requires ${model.driver}${model.minVersion ? ` >= ${model.minVersion}` : ""}${model.requiredPlatforms.length ? `, platform: ${model.requiredPlatforms.join("/")}` : ""})`
+        : `Insufficient cluster capacity: cannot place ${model.replicas} ${model.replicas === 1 ? "replica" : "replicas"} of "${model.label}" (${model.perReplica.toFixed(1)} GB each). Only ${placed} compatible ${placed === 1 ? "node has" : "nodes have"} enough free capacity`;
       return { deployable: false, reason };
     }
   }
@@ -158,11 +176,7 @@ async function queryDeploymentsWithStatus(where: ReturnType<typeof sql>): Promis
   const rows = await getDB()
     .select()
     .from(modelDeploymentT)
-    .leftJoin(modelInstallationT, sql`
-      (${modelDeploymentT.modelSpecifier} = ${modelInstallationT.model}
-      OR
-      ${modelDeploymentT.earlyModelSpecifier} = ${modelInstallationT.model})
-      AND ${modelInstallationT.deletedAt} IS NULL`)
+    .leftJoin(modelInstallationT, sql`${deploymentMatchesInstallation} AND ${modelInstallationT.deletedAt} IS NULL`)
     .leftJoin(modelInstallationStateT, sql`${modelInstallationStateT.id} = ${modelInstallationT.id}`)
     .where(where);
 
@@ -213,27 +227,25 @@ const listDeployments = rootOs.use(withOrganization)
       // as a distinct "not_in_catalog" phase so the UI can warn the operator.
       const noStatusEnabled = results.filter(r => !r.status && r.enabled);
       if (noStatusEnabled.length > 0 && infoClient) {
-        const specifiers = [...new Set(
-          noStatusEnabled.flatMap(e => [
-            e.modelSpecifier,
-            ...(e.earlyModelSpecifier ? [e.earlyModelSpecifier] : []),
-          ]),
-        )];
-        try {
-          const batchResult = await infoClient.fetchModelsBatch(specifiers);
-          for (const entry of noStatusEnabled) {
-            const primaryMissing = batchResult[entry.modelSpecifier] === null;
-            const earlyMissing = entry.earlyModelSpecifier
-              ? batchResult[entry.earlyModelSpecifier] === null
-              : false;
-            if (primaryMissing || earlyMissing) {
-              (entry as any).status = { phase: "not_in_catalog" as const, progress: null, error: null };
-            }
+        const client = infoClient;
+        const isMissing = async (lookup: ModelLookup | null): Promise<boolean> => {
+          if (!lookup) return false;
+          try {
+            const status = await client.fetchModelStatus(lookup);
+            return status.status === "not_found";
+          } catch {
+            return false;
           }
-        } catch {
-          // Info server unreachable: leave status as undefined rather than
-          // falsely marking deployments as not_in_catalog.
-        }
+        };
+        await Promise.all(noStatusEnabled.map(async (entry) => {
+          const [primaryMissing, earlyMissing] = await Promise.all([
+            isMissing(deploymentLookup(entry)),
+            isMissing(deploymentEarlyLookup(entry)),
+          ]);
+          if (primaryMissing || earlyMissing) {
+            entry.status = { phase: "not_in_catalog", progress: null, error: null };
+          }
+        }));
       }
 
       return results;
@@ -252,9 +264,9 @@ const updateDeployment = rootOs
   .errors({ NOT_FOUND: {}, BAD_REQUEST: {}, INSUFFICIENT_CAPACITY: {}, CONFLICT: {} })
   .handler(async ({ context, input, errors }) => {
     const rlog = log.child({ traceId: context.traceId });
-    if (input.modelSpecifier && input.earlyModelSpecifier) {
+    if (input.modelSpecifier) {
       try {
-        await validateCanaryModelTypes(input.modelSpecifier, input.earlyModelSpecifier);
+        await validateCanaryModelTypes(deploymentLookup(input), deploymentEarlyLookup(input));
       } catch (err: unknown) {
         throw errors.BAD_REQUEST({ message: err instanceof Error ? err.message : String(err) });
       }
@@ -278,6 +290,8 @@ const updateDeployment = rootOs
         { field: "kvCacheSize", changed: input.kvCacheSize !== undefined && input.kvCacheSize !== current.kvCacheSize },
         { field: "earlyKvCacheSize", changed: input.earlyKvCacheSize !== undefined && input.earlyKvCacheSize !== current.earlyKvCacheSize },
         { field: "preferredDriver", changed: input.preferredDriver !== undefined && input.preferredDriver !== current.preferredDriver },
+        { field: "specifier", changed: input.specifier !== undefined && input.specifier !== current.specifier },
+        { field: "earlySpecifier", changed: input.earlySpecifier !== undefined && input.earlySpecifier !== current.earlySpecifier },
         { field: "modelSpecifier", changed: input.modelSpecifier !== undefined && input.modelSpecifier !== current.modelSpecifier },
         { field: "earlyModelSpecifier", changed: input.earlyModelSpecifier !== undefined && input.earlyModelSpecifier !== current.earlyModelSpecifier },
       ];
@@ -439,34 +453,48 @@ export const createDeployment = rootOs
   .output(DeploymentDto)
   .errors({ CONFLICT: {}, BAD_REQUEST: {} })
   .handler(async ({ context, input, errors }) => {
-    // Validate that the requested model specifiers exist in the catalog.
-    // If the info server is unreachable we let the request through. An outage
-    // should not prevent operators from managing deployments.
+    if (!input.specifier) {
+      throw errors.BAD_REQUEST({ message: "specifier is required when creating a deployment" });
+    }
+    const primaryLookup: ModelLookup = { kind: "canonical", specifier: input.specifier };
+    const earlyLookup: ModelLookup | null = input.earlySpecifier
+      ? { kind: "canonical", specifier: input.earlySpecifier }
+      : null;
+
     if (infoClient) {
       const client = infoClient;
-      const specsToCheck = [
-        { field: "modelSpecifier", specifier: input.modelSpecifier },
-        ...(input.earlyModelSpecifier ? [{ field: "earlyModelSpecifier", specifier: input.earlyModelSpecifier }] : []),
+      const checks: { label: string; lookup: ModelLookup }[] = [
+        { label: input.specifier, lookup: primaryLookup },
+        ...(earlyLookup ? [{ label: input.earlySpecifier!, lookup: earlyLookup }] : []),
       ];
-      const statuses = await Promise.all(specsToCheck.map(async s => ({ ...s, status: await client.fetchModelStatus(s.specifier) })));
+      const statuses = await Promise.all(checks.map(async c => ({ ...c, status: await client.fetchModelStatus(c.lookup) })));
       const missing = statuses.find(s => s.status.status === "not_found");
       if (missing) {
-        throw errors.BAD_REQUEST({ message: `Model "${missing.specifier}" was not found in the model catalog` });
+        throw errors.BAD_REQUEST({ message: `Model "${missing.label}" was not found in the model catalog` });
       }
     }
 
     const rlog = log.child({ traceId: context.traceId });
     try {
-      await validateCanaryModelTypes(input.modelSpecifier, input.earlyModelSpecifier);
+      await validateCanaryModelTypes(primaryLookup, earlyLookup);
     } catch (err: any) {
       throw errors.BAD_REQUEST({ message: err.message });
     }
+
+    const derivedModelSpecifier = await deriveProviderModel(primaryLookup, input.preferredDriver ?? null) ?? input.modelSpecifier;
+    const derivedEarlyModelSpecifier = earlyLookup
+      ? (await deriveProviderModel(earlyLookup, input.preferredDriver ?? null) ?? input.earlyModelSpecifier ?? null)
+      : null;
 
     try {
       const [deployment] = await getDB()
         .insert(modelDeploymentT)
         .values({
           ...input,
+          specifier: input.specifier,
+          earlySpecifier: input.earlySpecifier ?? null,
+          modelSpecifier: derivedModelSpecifier,
+          earlyModelSpecifier: derivedEarlyModelSpecifier,
           organizationId: context.activeOrganizationId,
         })
         .returning();

--- a/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/instance-admin.procedure.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/instance-admin.procedure.ts
@@ -357,7 +357,9 @@ const listOrganizations = rootOs
           totalCapacity: sql<number>`(
             SELECT coalesce(sum("model_installation"."est_capacity"), 0)
             FROM "model_deployment" md
-            INNER JOIN "model_installation" ON "model_installation"."model" = md."model_specifier"
+            INNER JOIN "model_installation"
+              ON COALESCE("model_installation"."specifier", "model_installation"."model")
+               = COALESCE(md."specifier", md."model_specifier")
             WHERE md."organization_id" = "organization"."id"
               AND md."deleted_at" IS NULL
           )`.as("total_capacity"),

--- a/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/model.procedure.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/model.procedure.ts
@@ -36,7 +36,7 @@ const getModel = rootOs
   .input(z.object({ specifier: z.string() }))
   .output(ModelWithSpecifierSchema.nullable())
   .handler(async ({ input }) => {
-    return await infoClient?.fetchModel(input.specifier) ?? null;
+    return await infoClient?.fetchModel({ kind: "canonical", specifier: input.specifier }) ?? null;
   });
 
 export const modelRouter = rootOs.prefix("/model").router({ 

--- a/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/onboarding.procedure.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/onboarding.procedure.ts
@@ -32,7 +32,8 @@ const setupOnboarding = rootOs
   .route({ path: "/onboarding/setup", method: "POST", tags: ["Onboarding"], summary: "Complete onboarding setup" })
   .input(z.object({
     orgName: z.string().min(1).describe("Name of the organization to create"),
-    modelSpecifier: z.string().describe("The model specifier to deploy"),
+    specifier: z.string().describe("The canonical model identifier"),
+    modelSpecifier: z.string().describe("The driver-specific provider model string"),
     publicSpecifier: z.string().describe("The public-facing model name"),
   }))
   .output(z.object({
@@ -70,6 +71,7 @@ const setupOnboarding = rootOs
     // 3. Deploy the selected model
     await call(createDeployment, {
       name: input.publicSpecifier,
+      specifier: input.specifier,
       modelSpecifier: input.modelSpecifier,
       publicSpecifier: input.publicSpecifier,
       enabled: true,

--- a/packages/xinity-ai-dashboard/src/lib/util.ts
+++ b/packages/xinity-ai-dashboard/src/lib/util.ts
@@ -120,6 +120,12 @@ export function humanDate(d: Date | undefined) {
   });
 }
 
+/** Formats a date (no time) using the "de" locale for consistent UI display. */
+export function humanDateShort(d: Date | undefined) {
+  if (!d || !d.toLocaleDateString) return "Unknown date";
+  return d.toLocaleDateString("de", { dateStyle: "medium" });
+}
+
 /** Formats a duration expressed in hours into a human-readable label. */
 export function humanDuration(hours: number) {
   if (hours < 1) {

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/OnboardingFlow.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/OnboardingFlow.svelte
@@ -66,6 +66,7 @@
 
     const { error: setupError, data } = await orpc.onboarding.setup({
       orgName,
+      specifier: selectedModel.publicSpecifier,
       modelSpecifier: Object.values(selectedModel.providers)[0] ?? selectedModel.publicSpecifier,
       publicSpecifier: selectedModel.publicSpecifier,
     });

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/instance-settings/organizations/+page.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/instance-settings/organizations/+page.svelte
@@ -11,11 +11,17 @@
   import { Search, ChevronDown, ChevronRight, ChevronLeft, X, Users, Shield, HardDrive } from "@lucide/svelte";
   import { toastState } from "$lib/state/toast.svelte";
   import { createUrlSearchParamsStore } from "$lib/urlSearchParamsStore";
+  import { humanDateShort } from "$lib/util";
+
+  type ListOrgsData = NonNullable<Awaited<ReturnType<typeof orpc.instanceAdmin.listOrganizations>>["data"]>;
+  type AdminOrganization = ListOrgsData["organizations"][number];
+  type GetOrgMembersData = NonNullable<Awaited<ReturnType<typeof orpc.instanceAdmin.getOrganizationMembers>>["data"]>;
+  type OrgMember = GetOrgMembersData["members"][number];
 
   const searchParams = createUrlSearchParamsStore();
   const LIMIT = 25;
 
-  let orgs = $state<any[]>([]);
+  let orgs = $state<AdminOrganization[]>([]);
   let total = $state(0);
 
   const currentPage = $derived(Number($searchParams.page) || 1);
@@ -24,7 +30,7 @@
   let searchInputValue = $state($searchParams.search ?? "");
   let searchTimeout: ReturnType<typeof setTimeout> | undefined;
   let expandedOrg = $state<string | null>(null);
-  let orgMembers = $state<Record<string, any[]>>({});
+  let orgMembers = $state<Record<string, OrgMember[]>>({});
   let loadingMembers = $state<Set<string>>(new Set());
 
   async function fetchOrgs() {
@@ -181,7 +187,7 @@
                   <span class="text-sm text-muted-foreground">{org.deploymentCount} deployments &middot; {org.totalCapacity.toFixed(1)} GB</span>
                 </div>
                 <span class="text-xs text-muted-foreground">
-                  {new Date(org.createdAt).toLocaleDateString()}
+                  {humanDateShort(org.createdAt)}
                 </span>
               </div>
             </Collapsible.Trigger>

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/instance-settings/users/+page.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/instance-settings/users/+page.svelte
@@ -14,13 +14,19 @@
   import { toastState } from "$lib/state/toast.svelte";
   import { copyToClipboard } from "$lib/copy";
   import { createUrlSearchParamsStore } from "$lib/urlSearchParamsStore";
+  import { humanDateShort } from "$lib/util";
+
+  type ListUsersData = NonNullable<Awaited<ReturnType<typeof orpc.instanceAdmin.listUsers>>["data"]>;
+  type AdminUser = ListUsersData["users"][number];
+  type ListOrgsData = NonNullable<Awaited<ReturnType<typeof orpc.instanceAdmin.listOrganizations>>["data"]>;
+  type AdminOrganization = ListOrgsData["organizations"][number];
 
   const searchParams = createUrlSearchParamsStore();
   const LIMIT = 25;
 
-  let users = $state<any[]>([]);
+  let users = $state<AdminUser[]>([]);
   let total = $state(0);
-  let organizations = $state<any[]>([]);
+  let organizations = $state<AdminOrganization[]>([]);
 
   const currentPage = $derived(Number($searchParams.page) || 1);
   const searchValue = $derived($searchParams.search ?? "");
@@ -94,7 +100,7 @@
   const addOrgOrgLabel = $derived(
     addOrgSelectedOrg === ""
       ? "Select organization..."
-      : organizations.find((o: any) => o.id === addOrgSelectedOrg)?.name ?? "Select organization...",
+      : organizations.find((o) => o.id === addOrgSelectedOrg)?.name ?? "Select organization...",
   );
   const addOrgRoleLabel = $derived(roleLabels[addOrgSelectedRole] ?? "Select role...");
 
@@ -292,7 +298,7 @@
                   </div>
                 </td>
                 <td class="py-3 pr-4 text-muted-foreground text-xs whitespace-nowrap">
-                  {new Date(user.createdAt).toLocaleDateString()}
+                  {humanDateShort(user.createdAt)}
                 </td>
                 <td class="py-3">
                   <DropdownMenu.Root>

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/DeploymentFormBody.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/DeploymentFormBody.svelte
@@ -118,6 +118,11 @@
     preferredDriverStr === "" ? "Auto" : driverLabel(preferredDriverStr),
   );
 
+  const effectiveDriver = $derived(
+    preferredDriver ?? (selectedPrimaryModel?.providers.vllm ? "vllm" : "ollama"),
+  );
+  const showKvCacheSliders = $derived(effectiveDriver !== "ollama");
+
   function openSelector(mode: "primary" | "canary") {
     selectorMode = mode;
     showModelSelector = true;
@@ -286,7 +291,7 @@
             {/if}
           </div>
 
-          {#if selectedCanaryModel}
+          {#if selectedCanaryModel && showKvCacheSliders}
             <div class="space-y-2">
               <Label for="canary-kv-cache-size{idSuffix}">
                 Canary KV Cache Size: <span class="font-bold text-primary">{earlyKvCacheSize ?? minCanaryKvCache} GB</span>
@@ -385,34 +390,36 @@
           {/if}
         </div>
 
-        <div class="space-y-2">
-          <Label for="kv-cache-size{idSuffix}">
-            {isCanaryEnabled ? "Primary " : ""}KV Cache Size: <span class="font-bold text-primary">{kvCacheSize ?? minKvCache} GB</span>
-          </Label>
-          {#if requiresDisabled}
-            <input
-              id="kv-cache-size{idSuffix}"
-              type="range" min={minKvCache} max={maxKvCache || minKvCache + 1} step="0.1"
-              value={kvCacheSize ?? minKvCache}
-              disabled
-              class="w-full h-2 bg-muted rounded-lg appearance-none cursor-not-allowed opacity-50"
-            />
-            <p class="text-sm text-muted-foreground">Disable the deployment to change the KV cache size.</p>
-          {:else}
-            <input
-              id="kv-cache-size{idSuffix}"
-              type="range" min={minKvCache} max={maxKvCache || minKvCache + 1} step="0.1"
-              bind:value={kvCacheSize}
-              class="w-full h-2 bg-muted rounded-lg appearance-none cursor-pointer"
-            />
-            <p class="text-sm text-muted-foreground">
-              Min: {minKvCache} GB · Max: {maxKvCache} GB. Larger values improve throughput for concurrent requests.
-            </p>
-          {/if}
-          {#if kvCacheSize !== null && kvCacheSize < minKvCache}
-            <p class="text-sm text-destructive">Value must be at least {minKvCache} GB for this model.</p>
-          {/if}
-        </div>
+        {#if showKvCacheSliders}
+          <div class="space-y-2">
+            <Label for="kv-cache-size{idSuffix}">
+              {isCanaryEnabled ? "Primary " : ""}KV Cache Size: <span class="font-bold text-primary">{kvCacheSize ?? minKvCache} GB</span>
+            </Label>
+            {#if requiresDisabled}
+              <input
+                id="kv-cache-size{idSuffix}"
+                type="range" min={minKvCache} max={maxKvCache || minKvCache + 1} step="0.1"
+                value={kvCacheSize ?? minKvCache}
+                disabled
+                class="w-full h-2 bg-muted rounded-lg appearance-none cursor-not-allowed opacity-50"
+              />
+              <p class="text-sm text-muted-foreground">Disable the deployment to change the KV cache size.</p>
+            {:else}
+              <input
+                id="kv-cache-size{idSuffix}"
+                type="range" min={minKvCache} max={maxKvCache || minKvCache + 1} step="0.1"
+                bind:value={kvCacheSize}
+                class="w-full h-2 bg-muted rounded-lg appearance-none cursor-pointer"
+              />
+              <p class="text-sm text-muted-foreground">
+                Min: {minKvCache} GB · Max: {maxKvCache} GB. Larger values improve throughput for concurrent requests.
+              </p>
+            {/if}
+            {#if kvCacheSize !== null && kvCacheSize < minKvCache}
+              <p class="text-sm text-destructive">Value must be at least {minKvCache} GB for this model.</p>
+            {/if}
+          </div>
+        {/if}
 
         {#if modelDriverOptions.length > 0}
           <div class="space-y-2">

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/DeploymentModal.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/DeploymentModal.svelte
@@ -112,8 +112,8 @@
     deploymentName = d.name;
     deploymentNameEdited = true;
     enabled = d.enabled;
-    selectedPrimarySpecifier = d.modelSpecifier;
-    selectedCanarySpecifier = d.earlyModelSpecifier ?? null;
+    selectedPrimarySpecifier = d.specifier ?? d.modelSpecifier;
+    selectedCanarySpecifier = d.earlySpecifier ?? d.earlyModelSpecifier ?? null;
     isCanaryEnabled = Boolean(d.earlyModelSpecifier);
     canaryTraffic = d.progress ?? 100;
     kvCacheSize = d.kvCacheSize ?? null;
@@ -286,12 +286,21 @@
   async function handleSubmit() {
     if (!isFormValid || !selectedPrimaryModel) return;
 
+    const primarySpecifier = selectedPrimaryModel.publicSpecifier;
+    const earlySpecifier = isCanaryEnabled && selectedCanaryModel ? selectedCanaryModel.publicSpecifier : null;
+    // Ollama has no KV-cache knob; clear any value carried over from a different driver
+    const effectiveDriver = preferredDriver ?? (selectedPrimaryModel.providers.vllm ? "vllm" : "ollama");
+    const submittedKvCacheSize = effectiveDriver === "ollama" ? null : kvCacheSize;
+    const submittedEarlyKvCacheSize = effectiveDriver === "ollama" ? null : earlyKvCacheSize;
+
     const [error] = isEditMode
       ? await orpc.deployment.update({
           ...deployment!,
           name: deploymentName.trim(),
           publicSpecifier: publicSpecifier.trim(),
           enabled,
+          specifier: primarySpecifier,
+          earlySpecifier,
           earlyModelSpecifier: isCanaryEnabled ? (selectedCanarySpecifier ?? null) : null,
           progress: isCanaryEnabled ? canaryTraffic : 100,
           canaryProgressWithFeedback: isCanaryEnabled && advancementStrategy === "smart-auto",
@@ -299,16 +308,18 @@
             ? (deployment!.canaryProgressFrom ?? new Date()) : null,
           canaryProgressUntil: isCanaryEnabled && advancementStrategy === "time-based"
             ? new Date(Date.now() + timeBasedDurationHours * 3_600_000) : null,
-          kvCacheSize,
-          earlyKvCacheSize: isCanaryEnabled ? earlyKvCacheSize : null,
+          kvCacheSize: submittedKvCacheSize,
+          earlyKvCacheSize: isCanaryEnabled ? submittedEarlyKvCacheSize : null,
           preferredDriver: preferredDriver || null, replicas,
         })
       : await orpc.deployment.create({
           enabled, name: deploymentName.trim(), publicSpecifier: publicSpecifier.trim(),
+          specifier: primarySpecifier,
+          earlySpecifier: earlySpecifier ?? undefined,
           modelSpecifier: resolveProviderModel(selectedPrimaryModel, preferredDriver),
           replicas, canaryProgressWithFeedback: advancementStrategy === "smart-auto",
-          kvCacheSize: kvCacheSize && kvCacheSize > minKvCache ? kvCacheSize : undefined,
-          earlyKvCacheSize: isCanaryEnabled && selectedCanaryModel && earlyKvCacheSize && earlyKvCacheSize > minCanaryKvCache ? earlyKvCacheSize : undefined,
+          kvCacheSize: submittedKvCacheSize && submittedKvCacheSize > minKvCache ? submittedKvCacheSize : undefined,
+          earlyKvCacheSize: isCanaryEnabled && selectedCanaryModel && submittedEarlyKvCacheSize && submittedEarlyKvCacheSize > minCanaryKvCache ? submittedEarlyKvCacheSize : undefined,
           preferredDriver: preferredDriver || null,
           earlyModelSpecifier: isCanaryEnabled && selectedCanaryModel
             ? resolveProviderModel(selectedCanaryModel, preferredDriver) : undefined,

--- a/packages/xinity-ai-dashboard/src/routes/login/+page.server.ts
+++ b/packages/xinity-ai-dashboard/src/routes/login/+page.server.ts
@@ -12,6 +12,10 @@ export const load: PageServerLoad = async ({ request, url }) => {
     redirect(303, "/");
   }
 
+  const configuredOrigin = new URL(serverEnv.ORIGIN);
+  const hostMismatch =
+    serverEnv.NODE_ENV !== "development" && url.host !== configuredOrigin.host;
+
   let ssoProviders: { providerId: string; domain: string }[] = [];
   if (!serverEnv.MULTI_TENANT_MODE) {
     ssoProviders = await getDB().select({
@@ -26,5 +30,7 @@ export const load: PageServerLoad = async ({ request, url }) => {
     ssoProviders,
     signupEnabled: serverEnv.SIGNUP_ENABLED,
     emailVerificationRequired: Boolean(serverEnv.MAIL_URL),
+    hostMismatch,
+    configuredOrigin: configuredOrigin.origin,
   };
 };

--- a/packages/xinity-ai-dashboard/src/routes/login/+page.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/login/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
+  import { page } from "$app/stores";
   import { signIn, signUp } from "$lib/auth";
   import { Button } from "$lib/components/ui/button";
   import { Input } from "$lib/components/ui/input";
@@ -32,7 +33,11 @@
 
   /** Turn raw Better Auth / Zod validation errors into user-friendly text. */
   function friendlyError(raw: string | undefined): string {
-    if (!raw) return "An unknown error occurred.";
+    const originMisconfigured = `This dashboard is configured for a different URL than the one you used to reach it, so authentication cannot complete. Contact your administrator for the correct URL and how to access it.`;
+    if (!raw) return originMisconfigured;
+    if (/invalid origin|missing or null origin|cross-site navigation login blocked/i.test(raw)) {
+      return originMisconfigured;
+    }
     const match = raw.match(/^\[body\.(\w+)\]\s*(.+)/);
     if (!match) return raw;
     const [, field, detail] = match;
@@ -57,6 +62,7 @@
 
       if (res?.error) {
         errorSignIn = friendlyError(res.error.message);
+        console.log(res.error)
       }
     } catch (e) {
       errorSignIn = (e as Error).message ?? "Unexpected error";
@@ -102,7 +108,21 @@
       <img src="/xinity-logo.png" alt="Xinity" class="h-10 w-auto" />
     </Card.Header>
     <Card.Content class="space-y-6">
-      {#if signUpSuccess}
+      {#if data.hostMismatch}
+        <div role="alert" class="space-y-2 p-4 text-sm text-destructive bg-destructive/10 border border-destructive/30 rounded-lg">
+          <p class="font-semibold">Wrong dashboard URL</p>
+          <p>
+            This dashboard is configured for
+            <span class="font-mono break-all">{data.configuredOrigin}</span>,
+            but you reached it via
+            <span class="font-mono break-all">{$page.url.origin}</span>.
+            Authentication will not work here.
+          </p>
+          <p>
+            Contact your administrator for the correct URL and how to access it.
+          </p>
+        </div>
+      {:else if signUpSuccess}
         <div class="space-y-4 text-center">
           <h2 class="text-xl font-bold">Check your email</h2>
           <p class="text-muted-foreground">

--- a/packages/xinity-ai-dashboard/tests/orchestration.test.ts
+++ b/packages/xinity-ai-dashboard/tests/orchestration.test.ts
@@ -24,6 +24,7 @@ function makeNode(overrides: Partial<AiNode> & { id: string }): AiNode {
 
 function makeInstallation(overrides: Partial<ModelInstallation> & { id: string; nodeId: string; model: string }): ModelInstallation {
   return {
+    specifier: null,
     estCapacity: 8,
     kvCacheCapacity: 2,
     port: 11434,
@@ -60,7 +61,9 @@ describe("orchestration: node goes unavailable", () => {
     expect(state.installationsByModel.has("llama2:7b")).toBe(false);
 
     // No excess to trim (nothing active)
-    const requiredModels: ModelRequirementTable = { "llama2:7b": { replicas: 1, kvCacheSize: 2 } };
+    const requiredModels: ModelRequirementTable = {
+      "llama2:7b": { lookup: { kind: "legacy", providerModel: "llama2:7b" }, replicas: 1, kvCacheSize: 2, preferredDriver: null },
+    };
     const excess = collectExcessInstallations(requiredModels, state);
     expect(excess).toHaveLength(0);
 
@@ -123,5 +126,30 @@ describe("orchestration: node goes unavailable", () => {
     const state = buildClusterState([], [cpuNode]);
 
     expect(findServerForModel("mxfp4-model", "vllm", 8, state, [], undefined, ["nvidia"])).toBeNull();
+  });
+});
+
+describe("orchestration: lookup-key correlation", () => {
+  const node = makeNode({ id: "node-1" });
+
+  test("canonical installation indexes under its specifier, not the legacy provider model", () => {
+    const inst = makeInstallation({ id: "i1", nodeId: "node-1", specifier: "llama-3.3-70b", model: "legacy-name" });
+    const state = buildClusterState([inst], [node]);
+    expect(state.installationsByModel.has("llama-3.3-70b")).toBe(true);
+    expect(state.installationsByModel.has("legacy-name")).toBe(false);
+  });
+
+  test("canonical and legacy installations of the same provider model do not correlate", () => {
+    const canonical = makeInstallation({ id: "c", nodeId: "node-1", specifier: "llama-3.3-70b", model: "llama" });
+    const legacy = makeInstallation({ id: "l", nodeId: "node-1", specifier: null, model: "llama" });
+    const state = buildClusterState([canonical, legacy], [node]);
+    expect(state.installationsByModel.get("llama-3.3-70b")).toHaveLength(1);
+    expect(state.installationsByModel.get("llama")).toHaveLength(1);
+  });
+
+  test("findServerForModel skips a node that already hosts the canonical specifier", () => {
+    const inst = makeInstallation({ id: "i1", nodeId: "node-1", specifier: "llama-3.3-70b", model: "llama" });
+    const state = buildClusterState([inst], [node]);
+    expect(findServerForModel("llama-3.3-70b", "ollama", 8, state, [])).toBeNull();
   });
 });

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-models.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-models.ts
@@ -1,4 +1,4 @@
-import { modelDeploymentT, modelInstallationT, organizationT, sql, type ModelDeployment, type ModelInstallation } from "common-db";
+import { modelDeploymentT, modelInstallationT, organizationT, sql, deploymentMatchesInstallation, type ModelDeployment, type ModelInstallation } from "common-db";
 import { getDB } from "../../db";
 import { checkAuth } from "../auth";
 
@@ -14,10 +14,7 @@ export async function handleModelsRequest(req: Request): Promise<Response> {
   const models = await getDB()
     .select()
     .from(modelDeploymentT)
-    .leftJoin(modelInstallationT, sql`
-      (${modelDeploymentT.modelSpecifier} = ${modelInstallationT.model}
-      OR ${modelDeploymentT.earlyModelSpecifier} = ${modelInstallationT.model})
-      AND ${modelInstallationT.deletedAt} IS NULL`)
+    .leftJoin(modelInstallationT, sql`${deploymentMatchesInstallation} AND ${modelInstallationT.deletedAt} IS NULL`)
     .where(sql`${modelDeploymentT.organizationId} = ${orgId} AND ${modelDeploymentT.deletedAt} IS NULL`);
 
   const modelMap = new Map<string, { modelDeployment: ModelDeployment, modelInstallations: ModelInstallation[] }>();

--- a/packages/xinity-ai-gateway/src/llm-forward/model-data.test.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/model-data.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, mock, jest, beforeEach } from "bun:test";
 import { drizzle, modelDeploymentT } from "common-db";
+import { deploymentLookup, deploymentEarlyLookup, lookupKey } from "xinity-infoserver";
 
 mock.module("../env", () => ({
   env: {
@@ -30,13 +31,21 @@ mock.module("../db", () => ({
 
 const mockResolveModelMeta = jest.fn(async () => ({ type: "chat" as string | undefined, tags: ["tools"] as string[] }));
 const mockResolveRequestParams = jest.fn(async () => ({} as Record<string, string>));
+const mockFetchModel = jest.fn(async (lookup: { kind: "canonical"; specifier: string } | { kind: "legacy"; providerModel: string }) => {
+  const value = lookup.kind === "canonical" ? lookup.specifier : lookup.providerModel;
+  return { providers: { ollama: value, vllm: value } as { ollama?: string; vllm?: string } };
+});
 
 mock.module("xinity-infoserver", () => ({
   createInfoserverClient: () => ({
     resolveModelMeta: mockResolveModelMeta,
     resolveRequestParams: mockResolveRequestParams,
+    fetchModel: mockFetchModel,
   }),
   BLOCKED_REQUEST_PARAM_PREFIXES: ["chat_template", "tokenize", "prompt", "api_key"],
+  deploymentLookup,
+  deploymentEarlyLookup,
+  lookupKey,
 }));
 
 const { getModelInfo, _deps } = await import("./model-data");
@@ -84,6 +93,11 @@ beforeEach(() => {
   mockResolveModelMeta.mockResolvedValue({ type: "chat", tags: ["tools"] });
   mockResolveRequestParams.mockReset();
   mockResolveRequestParams.mockResolvedValue({});
+  mockFetchModel.mockReset();
+  mockFetchModel.mockImplementation(async (lookup) => {
+    const value = lookup.kind === "canonical" ? lookup.specifier : lookup.providerModel;
+    return { providers: { ollama: value, vllm: value } };
+  });
 });
 
 describe("getModelInfo", () => {
@@ -197,8 +211,8 @@ describe("getModelInfo", () => {
     expect(result!.type).toBe("embedding");
     expect(result!.tags).toEqual(["multilingual"]);
     expect(result!.requestParams).toEqual({ "top_k": "number" });
-    expect(mockResolveModelMeta).toHaveBeenCalledWith("llama3:latest");
-    expect(mockResolveRequestParams).toHaveBeenCalledWith("llama3:latest");
+    expect(mockResolveModelMeta).toHaveBeenCalledWith({ kind: "legacy", providerModel: "llama3:latest" }, "ollama");
+    expect(mockResolveRequestParams).toHaveBeenCalledWith({ kind: "legacy", providerModel: "llama3:latest" }, "ollama");
   });
 
   test("skips early model lookup when earlyModelSpecifier is null", async () => {

--- a/packages/xinity-ai-gateway/src/llm-forward/model-data.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/model-data.ts
@@ -1,7 +1,7 @@
-import { calcCanaryProgress, sql, modelDeploymentT, modelInstallationT, aiNodeT } from "common-db";
+import { calcCanaryProgress, sql, modelDeploymentT, aiNodeT, modelInstallationT, installationMatchesLookup } from "common-db";
 import { getDB } from "../db";
 import { env } from "../env";
-import { createInfoserverClient } from "xinity-infoserver";
+import { createInfoserverClient, deploymentLookup, deploymentEarlyLookup, lookupKey, type ModelLookup } from "xinity-infoserver";
 import { selectHost as _selectHost, type LoadBalanceStrategy } from "./load-balancer";
 
 /** Indirection for testability. tests can swap this without mock.module. */
@@ -26,19 +26,14 @@ async function publicModelSpecifierToModelSource(orgId: string, specifier: strin
   }
 
   return {
-    /**
-     * Proportion of traffic that should be sent to the target model, as specified via modelSpecifier.
-     * The rest goes to the early model as specified via earlyModelSpecifier
-     */
     progress: calcCanaryProgress(deployment),
-    earlyModelSpecifier: deployment.earlyModelSpecifier,
-    modelSpecifier: deployment.modelSpecifier,
+    primary: deploymentLookup(deployment),
+    early: deploymentEarlyLookup(deployment),
   }
 }
 
-/** Retrieves the servers under which the model going by the given specifier is available */
-async function getModelSources(modelSpecifier: string) {
-
+/** Retrieves the servers under which the model identified by the given lookup is available. */
+async function getModelSources(lookup: ModelLookup) {
   const modelLocations = await getDB().select({
     host: aiNodeT.host,
     nodePort: aiNodeT.port,
@@ -47,7 +42,7 @@ async function getModelSources(modelSpecifier: string) {
     tls: aiNodeT.tls,
   }).from(modelInstallationT)
     .innerJoin(aiNodeT, sql`${modelInstallationT.nodeId} = ${aiNodeT.id} AND ${aiNodeT.deletedAt} IS NULL`)
-    .where(sql`${modelInstallationT.model} = ${modelSpecifier} AND ${modelInstallationT.deletedAt} IS NULL`);
+    .where(sql`${installationMatchesLookup(lookupKey(lookup))} AND ${modelInstallationT.deletedAt} IS NULL`);
 
   const driverMap = new Map<string, string>();
   const authTokenMap = new Map<string, string | null>();
@@ -85,37 +80,43 @@ type ModelInfo = {
   release: () => void;
 }
 
-/** Retrieves the up to date model data for the specified api user id, and model specifier.
- * If no model can be found, returns undefined
+/** Retrieves the up to date model data for the specified api user id, and public deployment specifier.
+ * If no deployment can be found, returns undefined.
  */
-export async function getModelInfo(orgId: string, modelSpecifier: string, keyId: string): Promise<ModelInfo | undefined> {
-  const accessInfo = await publicModelSpecifierToModelSource(orgId, modelSpecifier);
+export async function getModelInfo(orgId: string, publicSpecifier: string, keyId: string): Promise<ModelInfo | undefined> {
+  const accessInfo = await publicModelSpecifierToModelSource(orgId, publicSpecifier);
   if (!accessInfo) {
     return;
   }
+  const emptySources = {
+    hosts: [] as string[],
+    driverMap: new Map<string, string>(),
+    authTokenMap: new Map<string, string | null>(),
+    tlsMap: new Map<string, boolean>(),
+  };
   const [finalSources, earlySources] = await Promise.all([
-    getModelSources(accessInfo.modelSpecifier),
-    accessInfo.earlyModelSpecifier
-      ? getModelSources(accessInfo.earlyModelSpecifier)
-      : Promise.resolve({ hosts: [], driverMap: new Map<string, string>(), authTokenMap: new Map<string, string | null>(), tlsMap: new Map<string, boolean>() }),
+    getModelSources(accessInfo.primary),
+    accessInfo.early
+      ? getModelSources(accessInfo.early)
+      : Promise.resolve(emptySources),
   ]);
 
   const result = await _deps.selectHost(env.LOAD_BALANCE_STRATEGY as LoadBalanceStrategy, {
     hosts: finalSources.hosts,
     earlyHosts: earlySources.hosts,
     canaryProgress: accessInfo.progress,
-    hasEarlyModel: !!accessInfo.earlyModelSpecifier,
+    hasEarlyModel: !!accessInfo.early,
     keyId,
-    publicModel: modelSpecifier,
+    publicModel: publicSpecifier,
   });
 
   if (!result) {
     return;
   }
 
-  const resolvedModel = result.useFinalModel
-    ? accessInfo.modelSpecifier
-    : (accessInfo.earlyModelSpecifier ?? accessInfo.modelSpecifier);
+  const resolvedLookup = result.useFinalModel
+    ? accessInfo.primary
+    : (accessInfo.early ?? accessInfo.primary);
 
   // Look up driver and auth token from whichever source set the host came from
   const driver = finalSources.driverMap.get(result.host)
@@ -128,14 +129,21 @@ export async function getModelInfo(orgId: string, modelSpecifier: string, keyId:
     ?? earlySources.tlsMap.get(result.host)
     ?? false;
 
+  const model = await infoClient.fetchModel(resolvedLookup);
+  const providerModel = model?.providers[driver as "vllm" | "ollama"];
+  if (!providerModel) {
+    result.release();
+    return;
+  }
+
   const [{ type, tags }, requestParams] = await Promise.all([
-    infoClient.resolveModelMeta(resolvedModel),
-    infoClient.resolveRequestParams(resolvedModel),
+    infoClient.resolveModelMeta(resolvedLookup, driver as "vllm" | "ollama"),
+    infoClient.resolveRequestParams(resolvedLookup, driver as "vllm" | "ollama"),
   ]);
 
   return {
     host: result.host,
-    model: resolvedModel,
+    model: providerModel,
     driver,
     authToken,
     tls,

--- a/packages/xinity-ai-gateway/src/llm-forward/model-data.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/model-data.ts
@@ -130,7 +130,8 @@ export async function getModelInfo(orgId: string, publicSpecifier: string, keyId
     ?? false;
 
   const model = await infoClient.fetchModel(resolvedLookup);
-  const providerModel = model?.providers[driver as "vllm" | "ollama"];
+  const providerModel = model?.providers[driver as "vllm" | "ollama"]
+    ?? (resolvedLookup.kind === "legacy" ? resolvedLookup.providerModel : undefined);
   if (!providerModel) {
     result.release();
     return;

--- a/packages/xinity-infoserver/api-handlers.ts
+++ b/packages/xinity-infoserver/api-handlers.ts
@@ -51,14 +51,21 @@ export function handleModelsByFamily(req: Request): Response {
 }
 
 /**
- * GET /api/v1/models/:specifier: single model lookup.
+ * GET /api/v1/models/:specifier
+ * `?lookup=canonical` forces primary-key resolution; `?lookup=provider` forces
+ * provider-string reverse lookup. Omitting falls back to `resolve()` (back-compat).
  */
 export function handleModelBySpecifier(req: Request): Response {
   const specifier = (req as any).params?.specifier as string | undefined;
   if (!specifier) {
     return Response.json({ error: "Missing specifier parameter" }, { status: 400 });
   }
-  const model = catalog.resolve(specifier);
+  const lookup = new URL(req.url).searchParams.get("lookup");
+  const model = lookup === "canonical"
+    ? catalog.get(specifier)
+    : lookup === "provider"
+      ? catalog.getByProviderModel(specifier)
+      : catalog.resolve(specifier);
   if (!model) {
     return Response.json({ error: "Model not found" }, { status: 404 });
   }

--- a/packages/xinity-infoserver/client.test.ts
+++ b/packages/xinity-infoserver/client.test.ts
@@ -112,7 +112,7 @@ describe("createInfoserverClient", () => {
   describe("fetchModel", () => {
     it("fetches a model from the server on cache miss", async () => {
       const client = makeClient();
-      const model = await client.fetchModel("llama-3.3-70b");
+      const model = await client.fetchModel({ kind: "canonical", specifier: "llama-3.3-70b" });
       expect(model).toBeDefined();
       expect(model!.publicSpecifier).toBe("llama-3.3-70b");
       expect(requestLog).toHaveLength(1);
@@ -120,9 +120,9 @@ describe("createInfoserverClient", () => {
 
     it("returns cached data on subsequent calls within TTL", async () => {
       const client = makeClient();
-      await client.fetchModel("llama-3.3-70b");
-      await client.fetchModel("llama-3.3-70b");
-      await client.fetchModel("llama-3.3-70b");
+      await client.fetchModel({ kind: "canonical", specifier: "llama-3.3-70b" });
+      await client.fetchModel({ kind: "canonical", specifier: "llama-3.3-70b" });
+      await client.fetchModel({ kind: "canonical", specifier: "llama-3.3-70b" });
       // Only one server request
       expect(requestLog).toHaveLength(1);
     });
@@ -133,12 +133,12 @@ describe("createInfoserverClient", () => {
       nowSpy.mockReturnValue(start);
 
       const client = makeClient(1000); // 1 second TTL
-      await client.fetchModel("llama-3.3-70b");
+      await client.fetchModel({ kind: "canonical", specifier: "llama-3.3-70b" });
       expect(requestLog).toHaveLength(1);
 
       // Advance past TTL
       nowSpy.mockReturnValue(start + 1500);
-      await client.fetchModel("llama-3.3-70b");
+      await client.fetchModel({ kind: "canonical", specifier: "llama-3.3-70b" });
       expect(requestLog).toHaveLength(2);
 
       nowSpy.mockRestore();
@@ -146,13 +146,32 @@ describe("createInfoserverClient", () => {
 
     it("returns undefined for 404", async () => {
       const client = makeClient();
-      const model = await client.fetchModel("not-found");
+      const model = await client.fetchModel({ kind: "canonical", specifier: "not-found" });
       expect(model).toBeUndefined();
     });
 
     it("throws on server error", async () => {
       const client = makeClient();
-      await expect(client.fetchModel("server-error")).rejects.toThrow('Infoserver unavailable for "server-error": HTTP 500');
+      await expect(client.fetchModel({ kind: "canonical", specifier: "server-error" })).rejects.toThrow('Infoserver unavailable for canonical "server-error": HTTP 500');
+    });
+
+    it("sends `lookup=canonical` for canonical lookups", async () => {
+      const client = makeClient();
+      await client.fetchModel({ kind: "canonical", specifier: "llama-3.3-70b" });
+      expect(requestLog[0]!.url).toContain("lookup=canonical");
+    });
+
+    it("sends `lookup=provider` for legacy lookups", async () => {
+      const client = makeClient();
+      await client.fetchModel({ kind: "legacy", providerModel: "llama-3.3-70b" });
+      expect(requestLog[0]!.url).toContain("lookup=provider");
+    });
+
+    it("caches canonical and legacy lookups under separate keys", async () => {
+      const client = makeClient();
+      await client.fetchModel({ kind: "canonical", specifier: "llama-3.3-70b" });
+      await client.fetchModel({ kind: "legacy", providerModel: "llama-3.3-70b" });
+      expect(requestLog).toHaveLength(2);
     });
   });
 
@@ -194,19 +213,19 @@ describe("createInfoserverClient", () => {
   describe("hasTag", () => {
     it("returns true when model has the tag", async () => {
       const client = makeClient();
-      expect(await client.hasTag("llama-3.3-70b", "tools")).toBe(true);
+      expect(await client.hasTag({ kind: "canonical", specifier: "llama-3.3-70b" }, "tools")).toBe(true);
     });
 
     it("returns false when model does not have the tag", async () => {
       const client = makeClient();
-      expect(await client.hasTag("llama-3.3-70b", "custom_code")).toBe(false);
+      expect(await client.hasTag({ kind: "canonical", specifier: "llama-3.3-70b" }, "custom_code")).toBe(false);
     });
   });
 
   describe("resolveDriverArgs", () => {
     it("returns empty array when model has no providerArgs", async () => {
       const client = makeClient();
-      const args = await client.resolveDriverArgs("llama-3.3-70b");
+      const args = await client.resolveDriverArgs({ kind: "canonical", specifier: "llama-3.3-70b" });
       expect(args).toEqual([]);
     });
   });

--- a/packages/xinity-infoserver/client.ts
+++ b/packages/xinity-infoserver/client.ts
@@ -4,12 +4,17 @@
  */
 import type { ModelWithSpecifier } from "./definitions/model-definition";
 import { resolveDriverForProviderModel, resolveTagsForDriver, resolveArgsForDriver, resolveRequestParamsForDriver, type RequestParamMap } from "./model-tags";
+import { lookupKey, type ModelLookup } from "./lookup-helpers";
 
 export interface InfoserverClientConfig {
   /** Base URL of the infoserver (e.g. "http://localhost:8090"). */
   baseUrl: string;
   /** How long cached responses remain valid before re-fetching (ms). */
   cacheTtlMs: number;
+}
+
+function lookupCacheKey(lookup: ModelLookup): string {
+  return `${lookup.kind}:${lookupKey(lookup)}`;
 }
 
 /**
@@ -62,19 +67,22 @@ export function createInfoserverClient(config: InfoserverClientConfig) {
   }
 
   /**
-   * Fetches a model and returns a typed status result.
+   * Fetches a model via the requested resolution path and returns a typed status result.
    * - `found`: model exists; result is cached for `cacheTtlMs`
    * - `not_found`: server returned 404; result is NOT cached so a re-added model
    *   is visible on the next request without waiting for TTL expiry
    * - `unavailable`: network error or non-404 HTTP error; result is NOT cached
+   *
+   * Canonical and legacy lookups are cached under separate keys; results never cross over.
    */
-  async function fetchModelStatus(specifier: string): Promise<FetchModelStatus> {
-    const key = `model:${specifier}`;
+  async function fetchModelStatus(lookup: ModelLookup): Promise<FetchModelStatus> {
+    const key = `model:${lookupCacheKey(lookup)}`;
     const existing = cache.get(key);
     if (isFresh(existing)) return { status: "found", model: existing.data };
 
+    const url = `${baseUrl}/api/v1/models/${encodeURIComponent(lookupKey(lookup))}?lookup=${lookup.kind === "canonical" ? "canonical" : "provider"}`;
     try {
-      const res = await fetch(`${baseUrl}/api/v1/models/${encodeURIComponent(specifier)}`);
+      const res = await fetch(url);
       if (res.status === 404) return { status: "not_found" };
       if (!res.ok) return { status: "unavailable", error: `HTTP ${res.status}` };
       const model = await res.json() as ModelWithSpecifier;
@@ -85,10 +93,10 @@ export function createInfoserverClient(config: InfoserverClientConfig) {
     }
   }
 
-  async function fetchModel(specifier: string): Promise<ModelWithSpecifier | undefined> {
-    const result = await fetchModelStatus(specifier);
+  async function fetchModel(lookup: ModelLookup): Promise<ModelWithSpecifier | undefined> {
+    const result = await fetchModelStatus(lookup);
     if (result.status === "found") return result.model;
-    if (result.status === "unavailable") throw new Error(`Infoserver unavailable for "${specifier}": ${result.error}`);
+    if (result.status === "unavailable") throw new Error(`Infoserver unavailable for ${lookup.kind} "${lookupKey(lookup)}": ${result.error}`);
     return undefined;
   }
 
@@ -132,35 +140,43 @@ export function createInfoserverClient(config: InfoserverClientConfig) {
     });
   }
 
-  // Convenience methods that combine a fetch with pure tag helpers
+  // Convenience methods that combine a fetch with pure tag helpers.
+  // The driver-tag/args/params helpers need a Provider; for canonical lookups the caller passes
+  // the chosen driver, for legacy lookups it's reverse-derived from the provider string.
 
-  async function resolveModelMeta(specifier: string): Promise<{ type: string | undefined; tags: string[] }> {
-    const model = await fetchModel(specifier);
+  function driverFor(model: ModelWithSpecifier, lookup: ModelLookup, override?: "vllm" | "ollama") {
+    if (override) return override;
+    if (lookup.kind === "legacy") return resolveDriverForProviderModel(model, lookup.providerModel);
+    return undefined;
+  }
+
+  async function resolveModelMeta(lookup: ModelLookup, driver?: "vllm" | "ollama"): Promise<{ type: string | undefined; tags: string[] }> {
+    const model = await fetchModel(lookup);
     if (!model) return { type: undefined, tags: [] };
-    const driver = resolveDriverForProviderModel(model, specifier);
-    const tags = driver ? resolveTagsForDriver(model, driver) : (model.tags ?? []);
+    const d = driverFor(model, lookup, driver);
+    const tags = d ? resolveTagsForDriver(model, d) : (model.tags ?? []);
     return { type: model.type, tags };
   }
 
-  async function hasTag(specifier: string, tag: string): Promise<boolean> {
-    const { tags } = await resolveModelMeta(specifier);
+  async function hasTag(lookup: ModelLookup, tag: string, driver?: "vllm" | "ollama"): Promise<boolean> {
+    const { tags } = await resolveModelMeta(lookup, driver);
     return tags.includes(tag);
   }
 
-  async function resolveDriverArgs(specifier: string): Promise<string[]> {
-    const model = await fetchModel(specifier);
+  async function resolveDriverArgs(lookup: ModelLookup, driver?: "vllm" | "ollama"): Promise<string[]> {
+    const model = await fetchModel(lookup);
     if (!model) return [];
-    const driver = resolveDriverForProviderModel(model, specifier);
-    if (!driver) return [];
-    return resolveArgsForDriver(model, driver);
+    const d = driverFor(model, lookup, driver);
+    if (!d) return [];
+    return resolveArgsForDriver(model, d);
   }
 
-  async function resolveRequestParams(specifier: string): Promise<RequestParamMap> {
-    const model = await fetchModel(specifier);
+  async function resolveRequestParams(lookup: ModelLookup, driver?: "vllm" | "ollama"): Promise<RequestParamMap> {
+    const model = await fetchModel(lookup);
     if (!model) return {};
-    const driver = resolveDriverForProviderModel(model, specifier);
-    if (!driver) return {};
-    return resolveRequestParamsForDriver(model, driver);
+    const d = driverFor(model, lookup, driver);
+    if (!d) return {};
+    return resolveRequestParamsForDriver(model, d);
   }
 
   return {

--- a/packages/xinity-infoserver/index.ts
+++ b/packages/xinity-infoserver/index.ts
@@ -3,4 +3,5 @@ export * from "./model-tags";
 export { satisfiesMinVersion, normalizePep440 } from "./semver";
 export { checkNodeCompatibility, isDeployableOnCluster, type GpuInfo, type NodeCapability, type ModelNodeRequirements, type IncompatibilityReason } from "./node-compat";
 export { createInfoserverClient, type InfoserverClientConfig, type InfoserverClient, type PaginatedModels, type FetchModelsParams, type FetchModelStatus } from "./client";
+export { type ModelLookup, lookupKey, deploymentLookup, deploymentEarlyLookup, installationLookup, installationKey } from "./lookup-helpers";
 export { PaginationSchema, ModelListQuerySchema } from "./api-schemas";

--- a/packages/xinity-infoserver/lookup-helpers.test.ts
+++ b/packages/xinity-infoserver/lookup-helpers.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "bun:test";
+import { deploymentLookup, deploymentEarlyLookup, installationLookup, installationKey, lookupKey } from "./lookup-helpers";
+
+describe("deploymentLookup", () => {
+  it("prefers canonical specifier when set", () => {
+    expect(deploymentLookup({ specifier: "x", modelSpecifier: "y" })).toEqual({ kind: "canonical", specifier: "x" });
+  });
+  it("falls back to modelSpecifier when canonical specifier is null", () => {
+    expect(deploymentLookup({ specifier: null, modelSpecifier: "y" })).toEqual({ kind: "legacy", providerModel: "y" });
+  });
+  it("returns null when neither identifier is provided", () => {
+    expect(deploymentLookup({})).toBeNull();
+  });
+});
+
+describe("deploymentEarlyLookup", () => {
+  it("returns null when no canary model is configured", () => {
+    expect(deploymentEarlyLookup({})).toBeNull();
+  });
+  it("prefers canonical earlySpecifier over legacy earlyModelSpecifier", () => {
+    expect(deploymentEarlyLookup({ earlySpecifier: "a", earlyModelSpecifier: "b" })).toEqual({ kind: "canonical", specifier: "a" });
+  });
+});
+
+describe("installationLookup / installationKey", () => {
+  it("uses canonical key when specifier is set", () => {
+    expect(installationKey({ specifier: "x", model: "legacy-y" })).toBe("x");
+  });
+  it("falls back to provider model for legacy installations", () => {
+    expect(installationKey({ specifier: null, model: "legacy-y" })).toBe("legacy-y");
+  });
+});
+
+describe("lookupKey", () => {
+  it("returns the canonical specifier for canonical lookups", () => {
+    expect(lookupKey({ kind: "canonical", specifier: "x" })).toBe("x");
+  });
+  it("returns the provider model for legacy lookups", () => {
+    expect(lookupKey({ kind: "legacy", providerModel: "y" })).toBe("y");
+  });
+});

--- a/packages/xinity-infoserver/lookup-helpers.ts
+++ b/packages/xinity-infoserver/lookup-helpers.ts
@@ -1,0 +1,34 @@
+/**
+ * Catalog-resolution descriptor and the row-shape helpers that build it. Two paths exist:
+ * canonical (catalog primary key) and legacy (provider-string reverse lookup, ambiguous when
+ * two catalog entries share a provider string).
+ */
+export type ModelLookup =
+  | { kind: "canonical"; specifier: string }
+  | { kind: "legacy"; providerModel: string };
+
+export function lookupKey(lookup: ModelLookup): string {
+  return lookup.kind === "canonical" ? lookup.specifier : lookup.providerModel;
+}
+
+export function deploymentLookup(d: { specifier?: string | null; modelSpecifier: string }): ModelLookup;
+export function deploymentLookup(d: { specifier?: string | null; modelSpecifier?: string | null }): ModelLookup | null;
+export function deploymentLookup(d: { specifier?: string | null; modelSpecifier?: string | null }): ModelLookup | null {
+  if (d.specifier) return { kind: "canonical", specifier: d.specifier };
+  if (d.modelSpecifier) return { kind: "legacy", providerModel: d.modelSpecifier };
+  return null;
+}
+
+export function deploymentEarlyLookup(d: { earlySpecifier?: string | null; earlyModelSpecifier?: string | null }): ModelLookup | null {
+  if (d.earlySpecifier) return { kind: "canonical", specifier: d.earlySpecifier };
+  if (d.earlyModelSpecifier) return { kind: "legacy", providerModel: d.earlyModelSpecifier };
+  return null;
+}
+
+export function installationLookup(i: { specifier?: string | null; model: string }): ModelLookup {
+  return i.specifier ? { kind: "canonical", specifier: i.specifier } : { kind: "legacy", providerModel: i.model };
+}
+
+export function installationKey(i: { specifier?: string | null; model: string }): string {
+  return lookupKey(installationLookup(i));
+}


### PR DESCRIPTION
## Description

Introduces a new deployment+installation specifier on the model schema and a dedicated lookup type in `xinity-infoserver`, then migrates the gateway, daemon, and dashboard off the legacy lookup. Also bundles a few smaller dashboard fixes that surfaced during the rework.

## Type of change

Bug fix

## Testing

 - `bun test` across the touched packages (`xinity-infoserver`,                                                                                             
    `xinity-ai-gateway`, `xinity-ai-daemon`, `xinity-ai-dashboard`)
- New unit tests for `lookup-helpers` and updated coverage in                                                                                              
    `client.test.ts`, `model-data.test.ts`, `vllm.test.ts`, and                                                                                              
    `orchestration.test.ts`                                                                                                                                  
- Manual check of the deployment form flow in the dashboard and the                                                                                        
    login page error state when the dashboard URL is misconfigured  

## Checklist

- [x] Tests pass locally (`bun test`), or no testable code was changed
- [x] New or changed behavior is covered by tests, or this change does not require tests
- [x] Documentation is updated, or no user-facing behavior or configuration was changed
- [x] There are no breaking changes, or they are marked with `!` in the commit type and described above
- [x] No security-sensitive changes (authentication, credentials, input handling), or they have been reviewed
- [x] No new dependencies were added, or they have been reviewed for license and maintenance status