### PR TITLE
fix: security hardening and various fixes

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -92,6 +92,9 @@ jobs:
 
             zip "${{ matrix.package }}-${suffix}.zip" "${BINARY_NAME}" *.map 2>/dev/null || \
               zip "${{ matrix.package }}-${suffix}.zip" "${BINARY_NAME}"
+            # v1.0.0+ packaging (TODO flip on at 1.0.0, drop the zip lines above):
+            # tar -czf "${{ matrix.package }}-${suffix}.tar.gz" "${BINARY_NAME}" *.map 2>/dev/null || \
+            #   tar -czf "${{ matrix.package }}-${suffix}.tar.gz" "${BINARY_NAME}"
             rm -f "${BINARY_NAME}" *.map
 
             echo "::endgroup::"
@@ -101,7 +104,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.package }}
-          path: ${{ matrix.workdir }}/*.zip
+          path: |
+            ${{ matrix.workdir }}/*.zip
+            ${{ matrix.workdir }}/*.tar.gz
           retention-days: 1
 
   # ---------------------------------------------------------------------------

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 # Finder (MacOS) folder config
 .DS_Store
+
+# Local-only notes and overrides
+/.local/
+CLAUDE.local.md

--- a/packages/common-env/src/index.ts
+++ b/packages/common-env/src/index.ts
@@ -107,7 +107,7 @@ export const tlsEnvSchema = z.object({
     .meta(secret()),
   XINITY_TLS_KEY: z.string().optional()
     .describe("PEM-encoded TLS private key (enables HTTPS). See docs/security/mtls.md")
-    .meta(secret()),
+    .meta({...secret(), ...expert()}),
 });
 
 /** Returns `{ cert, key }` if TLS is fully configured, `undefined` otherwise. Throws on partial config. */

--- a/packages/xinity-ai-daemon/src/modules/statekeeper.ts
+++ b/packages/xinity-ai-daemon/src/modules/statekeeper.ts
@@ -57,18 +57,20 @@ export async function getNodeDriverVersions(): Promise<Record<string, string>> {
 
   if (env.VLLM_DOCKER_IMAGE) {
     try {
-      const output = await $`docker run --rm --entrypoint vllm ${env.VLLM_DOCKER_IMAGE} version`
+      const output = await $`docker run --rm --gpus all --entrypoint vllm ${env.VLLM_DOCKER_IMAGE} --version`
         .throws(false).text();
       const match = output.match(/(\d+\.\d+\.\d+\S*)/);
       if (match) versions["vllm"] = normalizePep440(match[1]);
+      else log.warn({ output }, "vLLM Docker version output did not match expected format");
     } catch (err) {
       log.debug({ err }, "Failed to detect vLLM Docker version");
     }
   } else if (env.VLLM_PATH) {
     try {
-      const output = await $`${env.VLLM_PATH} version`.throws(false).text();
+      const output = await $`${env.VLLM_PATH} --version`.throws(false).text();
       const match = output.match(/(\d+\.\d+\.\d+\S*)/);
       if (match) versions["vllm"] = normalizePep440(match[1]);
+      else log.warn({ output }, "vLLM version output did not match expected format");
     } catch (err) {
       log.debug({ err }, "Failed to detect vLLM version");
     }

--- a/packages/xinity-ai-dashboard/e2e/api/cross-org-access.test.ts
+++ b/packages/xinity-ai-dashboard/e2e/api/cross-org-access.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Regression tests: an admin of one organization cannot mutate members of
+ * another organization.
+ *
+ * Two distinct users each own their own organization. The "attacker" tries to
+ * remove or re-role the "victim" by smuggling the victim's `organizationId`
+ * and `memberId` into the request body. Both calls must fail and the victim's
+ * org must be untouched.
+ */
+import { describe, test, expect, beforeAll } from "bun:test";
+import { ensureE2EReady } from "../guard";
+import { BASE_URL } from "../utils/test-data";
+
+const ATTACKER = {
+  name: "Cross-Org Attacker",
+  email: "e2e-cross-org-attacker@xinity-test.local",
+  password: "TestPassword123!",
+  orgName: "Cross-Org Attacker Org",
+} as const;
+
+const VICTIM = {
+  name: "Cross-Org Victim",
+  email: "e2e-cross-org-victim@xinity-test.local",
+  password: "TestPassword123!",
+  orgName: "Cross-Org Victim Org",
+} as const;
+
+const AUTH_HEADERS = {
+  "Content-Type": "application/json",
+  Origin: BASE_URL,
+} as const;
+
+interface OrgRow { id: string; name: string; slug: string }
+interface MemberRow { id: string; role: string; userId: string; user: { email: string } }
+interface FullOrg { id: string; members: MemberRow[] }
+
+let attackerCookies: string;
+let victimOrgId: string;
+let victimMemberId: string;
+let originalVictimRole: string;
+
+async function ensureUser(user: typeof ATTACKER): Promise<void> {
+  const res = await fetch(`${BASE_URL}/api/onboarding/cli`, {
+    method: "POST",
+    headers: AUTH_HEADERS,
+    body: JSON.stringify({
+      name: user.name,
+      email: user.email,
+      password: user.password,
+      orgName: user.orgName,
+    }),
+  });
+  // 409 means the user already exists from a previous run, which is fine
+  if (!res.ok && res.status !== 409) {
+    throw new Error(`Onboarding failed for ${user.email}: ${res.status} ${await res.text()}`);
+  }
+}
+
+function extractCookies(res: Response): string {
+  return res.headers.getSetCookie()
+    .map((h) => h.split(";")[0] ?? "")
+    .filter(Boolean)
+    .join("; ");
+}
+
+function mergeCookies(prev: string, res: Response): string {
+  const merged = new Map<string, string>();
+  for (const c of prev.split("; ")) {
+    const i = c.indexOf("=");
+    if (i !== -1) merged.set(c.slice(0, i), c.slice(i + 1));
+  }
+  for (const h of res.headers.getSetCookie()) {
+    const kv = h.split(";")[0] ?? "";
+    const i = kv.indexOf("=");
+    if (i !== -1) merged.set(kv.slice(0, i), kv.slice(i + 1));
+  }
+  return [...merged.entries()].map(([k, v]) => `${k}=${v}`).join("; ");
+}
+
+async function signIn(email: string, password: string): Promise<string> {
+  const res = await fetch(`${BASE_URL}/api/auth/sign-in/email`, {
+    method: "POST",
+    headers: AUTH_HEADERS,
+    body: JSON.stringify({ email, password }),
+    redirect: "manual",
+  });
+  if (!res.ok && res.status !== 302) {
+    throw new Error(`Sign-in failed for ${email}: ${res.status} ${await res.text()}`);
+  }
+  return extractCookies(res);
+}
+
+async function listOrgs(cookies: string): Promise<OrgRow[]> {
+  const res = await fetch(`${BASE_URL}/api/auth/organization/list`, {
+    headers: { Cookie: cookies, Origin: BASE_URL },
+  });
+  if (!res.ok) throw new Error(`listOrgs failed: ${res.status}`);
+  return (await res.json()) as OrgRow[];
+}
+
+async function setActive(orgId: string, cookies: string): Promise<string> {
+  const res = await fetch(`${BASE_URL}/api/auth/organization/set-active`, {
+    method: "POST",
+    headers: { ...AUTH_HEADERS, Cookie: cookies },
+    body: JSON.stringify({ organizationId: orgId }),
+    redirect: "manual",
+  });
+  if (!res.ok && res.status !== 302) {
+    throw new Error(`set-active failed: ${res.status} ${await res.text()}`);
+  }
+  return mergeCookies(cookies, res);
+}
+
+async function getFullOrg(cookies: string): Promise<FullOrg> {
+  const res = await fetch(`${BASE_URL}/api/auth/organization/get-full-organization`, {
+    headers: { Cookie: cookies, Origin: BASE_URL },
+  });
+  if (!res.ok) throw new Error(`getFullOrg failed: ${res.status}`);
+  return (await res.json()) as FullOrg;
+}
+
+async function findVictimMember(): Promise<MemberRow | null> {
+  let cookies = await signIn(VICTIM.email, VICTIM.password);
+  cookies = await setActive(victimOrgId, cookies);
+  const full = await getFullOrg(cookies);
+  return full.members.find((m) => m.id === victimMemberId) ?? null;
+}
+
+async function attackerFetch(path: string, init?: RequestInit): Promise<Response> {
+  return fetch(`${BASE_URL}${path}`, {
+    ...init,
+    headers: {
+      ...AUTH_HEADERS,
+      Cookie: attackerCookies,
+      ...init?.headers,
+    },
+  });
+}
+
+beforeAll(async () => {
+  await ensureE2EReady();
+
+  await ensureUser(ATTACKER);
+  await ensureUser(VICTIM);
+
+  // Attacker: sign in and lock onto their own org so withOrganization is happy.
+  let aCookies = await signIn(ATTACKER.email, ATTACKER.password);
+  const aOrgs = await listOrgs(aCookies);
+  const aOrg = aOrgs.find((o) => o.name === ATTACKER.orgName);
+  if (!aOrg) throw new Error(`Attacker's org not found. Got: ${aOrgs.map((o) => o.name).join(", ")}`);
+  aCookies = await setActive(aOrg.id, aCookies);
+  attackerCookies = aCookies;
+
+  // Victim: discover their org id and own memberId so the test has concrete targets.
+  let vCookies = await signIn(VICTIM.email, VICTIM.password);
+  const vOrgs = await listOrgs(vCookies);
+  const vOrg = vOrgs.find((o) => o.name === VICTIM.orgName);
+  if (!vOrg) throw new Error(`Victim's org not found. Got: ${vOrgs.map((o) => o.name).join(", ")}`);
+  victimOrgId = vOrg.id;
+  vCookies = await setActive(victimOrgId, vCookies);
+  const full = await getFullOrg(vCookies);
+  const me = full.members.find((m) => m.user.email === VICTIM.email);
+  if (!me) throw new Error("Victim's own member row not found in their org");
+  victimMemberId = me.id;
+  originalVictimRole = me.role;
+});
+
+describe("Organization member mutation: cross-org access", () => {
+  test("removeMember refuses to act on a member of a different org", async () => {
+    const res = await attackerFetch("/api/organization/remove-member", {
+      method: "POST",
+      // organizationId is intentionally smuggled: the input schema must strip it
+      // and the handler must use context.activeOrganizationId (attacker's own org).
+      body: JSON.stringify({
+        memberId: victimMemberId,
+        organizationId: victimOrgId,
+      }),
+    });
+
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(res.status).toBeLessThan(500);
+
+    const after = await findVictimMember();
+    expect(after).not.toBeNull();
+    expect(after!.id).toBe(victimMemberId);
+  });
+
+  test("updateMemberRole refuses to act on a member of a different org", async () => {
+    const res = await attackerFetch("/api/organization/update-role", {
+      method: "POST",
+      body: JSON.stringify({
+        memberId: victimMemberId,
+        role: "viewer",
+        organizationId: victimOrgId,
+      }),
+    });
+
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(res.status).toBeLessThan(500);
+
+    const after = await findVictimMember();
+    expect(after).not.toBeNull();
+    expect(after!.role).toBe(originalVictimRole);
+  });
+});

--- a/packages/xinity-ai-dashboard/e2e/data/data-page.test.ts
+++ b/packages/xinity-ai-dashboard/e2e/data/data-page.test.ts
@@ -1,0 +1,78 @@
+import { describe, test, expect } from "bun:test";
+import { ownerFetch } from "../api/api-helpers";
+import { ownerPage } from "../utils/browser";
+import { expectVisible } from "../utils/helpers";
+
+interface CreatedKey {
+  fullKey: string;
+  name: string;
+  specifier: string;
+  applicationId: string | null;
+}
+
+interface ListedKey {
+  id: string;
+  specifier: string;
+  applicationId: string | null;
+}
+
+describe("Data page", () => {
+  test("renders seeded api calls without svelte async-required errors", async () => {
+    const suffix = Date.now();
+
+    const createRes = await ownerFetch("/api/api-key/", {
+      method: "POST",
+      body: JSON.stringify({
+        name: `data-page-regression-${suffix}`,
+        enabled: true,
+        createApplication: {
+          name: `Data Page Regression ${suffix}`,
+          description: "Created by data-page regression test",
+        },
+      }),
+    });
+    expect(createRes.status).toBe(200);
+    const created = (await createRes.json()) as CreatedKey;
+    const applicationId = created.applicationId;
+    if (!applicationId) throw new Error("createApiKey did not return applicationId");
+
+    const listRes = await ownerFetch("/api/api-key/", { method: "GET" });
+    expect(listRes.status).toBe(200);
+    const keys = (await listRes.json()) as ListedKey[];
+    const keyRow = keys.find((k) => k.specifier === created.specifier);
+    if (!keyRow) throw new Error(`could not find created key with specifier ${created.specifier}`);
+    const apiKeyId = keyRow.id;
+
+    const seedRes = await ownerFetch("/api/api-call/add-example-data", {
+      method: "POST",
+      body: JSON.stringify({ apiKeyId, applicationId }),
+    });
+    expect(seedRes.status).toBe(200);
+
+    const { page, context } = await ownerPage();
+    try {
+      const pageErrors: Error[] = [];
+      page.on("pageerror", (err) => pageErrors.push(err));
+
+      await page.goto(`/data/${applicationId}/`, {
+        waitUntil: "domcontentloaded",
+        timeout: 90_000,
+      });
+
+      await expectVisible(page.getByText("Recent API Calls"), 60_000);
+      await expectVisible(page.locator('[role="listitem"]').first(), 60_000);
+      await expectVisible(page.getByText(/Showing 7 of 7 calls/), 60_000);
+
+      const asyncErr = pageErrors.find((e) =>
+        /experimental_async_required/.test(e.message),
+      );
+      if (asyncErr) {
+        throw new Error(
+          `Data page threw experimental_async_required. This usually means SvelteKit's remote query() is reaching svelte.hydratable() without compilerOptions.experimental.async being set in svelte.config.js. Original error: ${asyncErr.message}`,
+        );
+      }
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/packages/xinity-ai-dashboard/src/hooks.server.ts
+++ b/packages/xinity-ai-dashboard/src/hooks.server.ts
@@ -59,11 +59,9 @@ const migrationGuard: Handle = ({ event, resolve }) => {
  */
 const fillLocals: Handle = ({ event, resolve }) => {
   event.locals.request = event.request;
-  let incoming = event.request.headers.get("x-trace-id");
-  if(incoming && incoming.length > 300){
-    incoming = incoming.slice(0, 300);
-  }
-  const traceId = incoming || `trc_${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
+  const incoming = event.request.headers.get("x-trace-id");
+  const sanitized = incoming?.replace(/[^A-Za-z0-9_.:-]/g, "").slice(0, 300);
+  const traceId = sanitized || `trc_${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
   event.locals.traceId = traceId;
   return resolve(event);
 };

--- a/packages/xinity-ai-dashboard/src/lib/components/LicenseBanner.svelte
+++ b/packages/xinity-ai-dashboard/src/lib/components/LicenseBanner.svelte
@@ -7,36 +7,28 @@
   let vramDismissed = $state(false);
 </script>
 
-{#if license.originMismatch}
-  <div class="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/70 p-6" role="dialog" aria-modal="true" aria-label="License origin mismatch">
-    <div class="relative w-full max-w-2xl rounded-xl border border-red-200 bg-card p-8 shadow-2xl">
-      <div class="flex items-center gap-3">
-        <div class="rounded-full bg-red-100 p-3 text-red-700">
-          <svg viewBox="0 0 24 24" class="h-6 w-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <path d="M12 9v4"></path>
-            <path d="M12 17h.01"></path>
-            <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path>
-          </svg>
-        </div>
-        <div>
-          <p class="text-sm font-semibold uppercase tracking-wide text-red-700">
-            License configuration error
-          </p>
-          <h2 class="mt-1 text-2xl font-semibold text-slate-900">
-            Origin mismatch
-          </h2>
-        </div>
-      </div>
-      <p class="mt-4 text-slate-600">
-        The dashboard's <code class="rounded bg-slate-100 px-1.5 py-0.5 text-sm font-mono">ORIGIN</code> does not match the origin in your license key.
-        Please update your <code class="rounded bg-slate-100 px-1.5 py-0.5 text-sm font-mono">ORIGIN</code> environment variable to match the URL specified in your license, or contact Xinity to update your license key.
-      </p>
-      <p class="mt-3 text-sm text-slate-500">
-        The dashboard is idling until this is resolved. Check your server logs for details.
-      </p>
-    </div>
+{#if license.originMismatch || license.instanceMismatch}
+  <div
+    class="rounded-md border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-900 mx-4 mt-4"
+    role="status"
+    aria-live="polite"
+  >
+    <p class="font-semibold">
+      License key doesn't match this {license.originMismatch ? "origin" : "instance"} — running in free tier.
+    </p>
+    <p class="mt-1 text-red-800">
+      {#if license.originMismatch}
+        The dashboard's <code class="rounded bg-red-100 px-1 py-0.5 font-mono text-xs">ORIGIN</code> does not match any origin in your license key.
+        Update <code class="rounded bg-red-100 px-1 py-0.5 font-mono text-xs">ORIGIN</code> to match the licensed URL, or contact Xinity to update your license key.
+      {:else}
+        Your license key was issued for a different deployment instance. Contact Xinity to reissue the key for this deployment.
+      {/if}
+      Check your server logs for details.
+    </p>
   </div>
-{:else if !dismissed && license.expired && license.inGracePeriod}
+{/if}
+
+{#if !dismissed && license.expired && license.inGracePeriod}
   <div class="fixed right-4 top-4 z-40">
     <div
       class="flex items-center gap-2 rounded-full border border-amber-300 bg-amber-50 px-3 py-1 text-xs font-semibold text-amber-800 shadow-sm"

--- a/packages/xinity-ai-dashboard/src/lib/server/better-auth-errors.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/better-auth-errors.ts
@@ -1,0 +1,14 @@
+import { APIError } from "better-auth";
+
+export interface BetterAuthErrorBody {
+  code: string | undefined;
+  message: string | undefined;
+}
+
+export function betterAuthErrorBody(err: unknown): BetterAuthErrorBody | null {
+  if (!(err instanceof APIError)) return null;
+  return {
+    code: typeof err.body?.code === "string" ? err.body.code : undefined,
+    message: typeof err.body?.message === "string" ? err.body.message : undefined,
+  };
+}

--- a/packages/xinity-ai-dashboard/src/lib/server/deployment-id.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/deployment-id.ts
@@ -7,6 +7,22 @@ const log = rootLogger.child({ name: "deployment-id" });
 let cachedInstanceId: string | null = null;
 let loadPromise: Promise<string> | null = null;
 
+async function raceSafeInsertSingleton(): Promise<{ row: { instanceId: string }; inserted: boolean }> {
+  const db = getDB();
+  const inserted = await db
+    .insert(deploymentConfigT)
+    .values({ singleton: 1 })
+    .onConflictDoNothing({ target: deploymentConfigT.singleton })
+    .returning();
+  if (inserted.length > 0) return { row: inserted[0], inserted: true };
+
+  const existing = await db.select().from(deploymentConfigT).limit(1);
+  if (existing.length === 0) {
+    throw new Error("deployment_config row missing after singleton upsert");
+  }
+  return { row: existing[0], inserted: false };
+}
+
 /**
  * Reads the singleton row from `deployment_config`, inserting one if missing,
  * and caches the resulting instance ID for the process lifetime.
@@ -28,24 +44,11 @@ export async function loadDeploymentId(): Promise<string> {
         return cachedInstanceId;
       }
 
-      // Atomic upsert + re-select so concurrent multi-process startups converge on
-      // the same row instead of one losing to a primary-key conflict.
-      const inserted = await db
-        .insert(deploymentConfigT)
-        .values({ singleton: 1 })
-        .onConflictDoNothing({ target: deploymentConfigT.singleton })
-        .returning();
-      const rows = inserted.length > 0
-        ? inserted
-        : await db.select().from(deploymentConfigT).limit(1);
-      if (rows.length === 0) {
-        throw new Error("deployment_config row missing after singleton upsert");
-      }
-
-      cachedInstanceId = rows[0].instanceId;
+      const { row, inserted } = await raceSafeInsertSingleton();
+      cachedInstanceId = row.instanceId;
       log.info(
         { instanceId: cachedInstanceId },
-        inserted.length > 0 ? "Generated deployment instance ID" : "Loaded deployment instance ID",
+        inserted ? "Generated deployment instance ID" : "Loaded deployment instance ID",
       );
       return cachedInstanceId;
     } finally {

--- a/packages/xinity-ai-dashboard/src/lib/server/lib/orchestration.mod.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/lib/orchestration.mod.ts
@@ -24,6 +24,22 @@ interface ClusterState {
 export type ModelRequirement = { lookup: ModelLookup; replicas: number; kvCacheSize: number | null; preferredDriver: Provider | null };
 export type ModelRequirementTable = Record<string, ModelRequirement>;
 
+function mergeRequirementsByLookupKey(entries: ModelRequirement[]): ModelRequirementTable {
+  return entries.reduce((agg, entry) => {
+    const key = lookupKey(entry.lookup);
+    const existing = agg[key];
+    if (!existing) {
+      agg[key] = entry;
+      return agg;
+    }
+    if (entry.replicas > existing.replicas) existing.replicas = entry.replicas;
+    if (entry.kvCacheSize != null && (existing.kvCacheSize == null || entry.kvCacheSize > existing.kvCacheSize)) {
+      existing.kvCacheSize = entry.kvCacheSize;
+    }
+    return agg;
+  }, {} as ModelRequirementTable);
+}
+
 /** Builds the replica requirement table based on enabled deployments. */
 export async function assembleModelRequirementTable(): Promise<ModelRequirementTable> {
   const enabledDeployments = await getDB().select().from(modelDeploymentT).where(sql`
@@ -56,21 +72,7 @@ export async function assembleModelRequirementTable(): Promise<ModelRequirementT
       preferredDriver: deployment.preferredDriver,
     }]
   });
-  // Take the maximum replica count and kvCacheSize when the same lookup key appears in multiple deployments
-  const modelRequirements = models.reduce((agg, entry) => {
-    const key = lookupKey(entry.lookup);
-    const existing = agg[key];
-    if (existing) {
-      if (entry.replicas > existing.replicas) existing.replicas = entry.replicas;
-      if (entry.kvCacheSize != null && (existing.kvCacheSize == null || entry.kvCacheSize > existing.kvCacheSize)) {
-        existing.kvCacheSize = entry.kvCacheSize;
-      }
-    } else {
-      agg[key] = entry;
-    }
-    return agg;
-  }, {} as ModelRequirementTable);
-  return modelRequirements;
+  return mergeRequirementsByLookupKey(models);
 }
 
 /** Indexes existing installations by lookup key and by server, and initialises capacity tracking. */

--- a/packages/xinity-ai-dashboard/src/lib/server/license/index.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/license/index.ts
@@ -2,6 +2,7 @@ export {
   parseLicense,
   getLicense,
   resetLicenseCache,
+  isLicenseEffective,
   hasFeature,
   maxVramGb,
   tierName,

--- a/packages/xinity-ai-dashboard/src/lib/server/license/license.test.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/license/license.test.ts
@@ -30,7 +30,7 @@ mock.module("$lib/server/deployment-id", () => ({
 }));
 
 // Now import the module under test (after mocks are in place).
-const { parseLicense, resetLicenseCache, hasFeature, maxVramGb, tierName, licenseeName, isExpired, isInGracePeriod, hasOriginMismatch, hasInstanceMismatch, getLicenseSummary } = await import("./license");
+const { parseLicense, resetLicenseCache, isLicenseEffective, hasFeature, maxVramGb, tierName, licenseeName, isExpired, isInGracePeriod, hasOriginMismatch, hasInstanceMismatch, getLicenseSummary } = await import("./license");
 
 const MS_PER_DAY = 1000 * 60 * 60 * 24;
 
@@ -378,5 +378,73 @@ describe("getLicenseSummary", () => {
 
     const summary = getLicenseSummary();
     expect(summary.instanceMismatch).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mismatch enforcement: a mismatched key must behave as free tier server-side
+// while still surfacing the mismatch in the summary so the banner can appear.
+// ---------------------------------------------------------------------------
+
+describe("mismatch enforcement", () => {
+  const ID_A = "11111111-1111-4111-8111-111111111111";
+  const ID_B = "22222222-2222-4222-8222-222222222222";
+
+  beforeEach(() => {
+    resetLicenseCache();
+    const { serverEnv } = require("$lib/server/serverenv");
+    serverEnv.LICENSE_KEY = undefined;
+    serverEnv.ORIGIN = "https://dashboard.example.com";
+    deploymentIdMock.id = null;
+  });
+
+  test("origin mismatch downgrades feature gates to free tier", () => {
+    const { serverEnv } = require("$lib/server/serverenv");
+    serverEnv.LICENSE_KEY = signLicense(validPayload({
+      origins: ["https://other.example.com"],
+    }));
+
+    expect(isLicenseEffective()).toBe(false);
+    expect(tierName()).toBe("free");
+    expect(maxVramGb()).toBe(120);
+    expect(licenseeName()).toBeNull();
+    expect(hasFeature("multi-org")).toBe(false);
+    expect(hasFeature("sso")).toBe(false);
+    expect(hasFeature("all-roles")).toBe(false);
+
+    const summary = getLicenseSummary();
+    expect(summary.originMismatch).toBe(true);
+    expect(summary.tier).toBe("free");
+    expect(summary.features.multiOrg).toBe(false);
+  });
+
+  test("instance mismatch downgrades feature gates to free tier", () => {
+    const { serverEnv } = require("$lib/server/serverenv");
+    serverEnv.LICENSE_KEY = signLicense(validPayload({ instanceId: ID_A }));
+    deploymentIdMock.id = ID_B;
+
+    expect(isLicenseEffective()).toBe(false);
+    expect(tierName()).toBe("free");
+    expect(maxVramGb()).toBe(120);
+    expect(licenseeName()).toBeNull();
+    expect(hasFeature("multi-org")).toBe(false);
+    expect(hasFeature("sso")).toBe(false);
+    expect(hasFeature("all-roles")).toBe(false);
+
+    const summary = getLicenseSummary();
+    expect(summary.instanceMismatch).toBe(true);
+    expect(summary.tier).toBe("free");
+    expect(summary.features.multiOrg).toBe(false);
+  });
+
+  test("matching origin and instance keeps the paid tier effective", () => {
+    const { serverEnv } = require("$lib/server/serverenv");
+    serverEnv.LICENSE_KEY = signLicense(validPayload({ instanceId: ID_A }));
+    deploymentIdMock.id = ID_A;
+
+    expect(isLicenseEffective()).toBe(true);
+    expect(tierName()).toBe("enterprise-sm");
+    expect(hasFeature("multi-org")).toBe(true);
+    expect(maxVramGb()).toBe(500);
   });
 });

--- a/packages/xinity-ai-dashboard/src/lib/server/license/license.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/license/license.ts
@@ -121,7 +121,7 @@ export function getLicense(): LicenseInfo {
     if (hasOriginMismatch()) {
       log.error(
         { allowedOrigins: cachedLicense.payload.origins, actual: serverEnv.ORIGIN },
-        "LICENSE ORIGIN MISMATCH: The dashboard ORIGIN does not match the licensed origin. The dashboard will idle until this is corrected.",
+        "LICENSE ORIGIN MISMATCH: The dashboard ORIGIN does not match the licensed origin. Treating as free tier until this is corrected.",
       );
     }
 
@@ -129,7 +129,7 @@ export function getLicense(): LicenseInfo {
     if (hasInstanceMismatch()) {
       log.error(
         { licensedInstanceId: cachedLicense.payload.instanceId, actual: getDeploymentId() },
-        "LICENSE INSTANCE MISMATCH: The dashboard instance ID does not match the licensed instance ID. The dashboard will idle until this is corrected.",
+        "LICENSE INSTANCE MISMATCH: The dashboard instance ID does not match the licensed instance ID. Treating as free tier until this is corrected.",
       );
     }
   } else {
@@ -145,38 +145,50 @@ export function resetLicenseCache(): void {
 }
 
 /**
+ * Returns true when the parsed license is considered to be fully valid.
+ */
+export function isLicenseEffective(): boolean {
+  const license = getLicense();
+  if (!license.valid) return false;
+  if (license.expired && !license.inGracePeriod) return false;
+  if (hasOriginMismatch()) return false;
+  if (hasInstanceMismatch()) return false;
+  return true;
+}
+
+/**
  * Returns true if the active license includes the given feature.
  * Expired licenses beyond grace period are treated as free tier (no features).
  */
 export function hasFeature(feature: LicenseFeature): boolean {
+  if (!isLicenseEffective()) return false;
   const license = getLicense();
   if (!license.valid) return false;
-  if (license.expired && !license.inGracePeriod) return false;
   return license.payload.features.includes(feature);
 }
 
 /** Returns the maximum total VRAM (in GB) allowed by the current license. */
 export function maxVramGb(): number {
+  if (!isLicenseEffective()) return FREE_MAX_VRAM_GB;
   const license = getLicense();
   if (!license.valid) return FREE_MAX_VRAM_GB;
-  if (license.expired && !license.inGracePeriod) return FREE_MAX_VRAM_GB;
   if (license.payload.maxVramGb === -1) return Infinity;
   return license.payload.maxVramGb;
 }
 
 /** Returns the current tier name. */
 export function tierName(): "free" | "startup" | "enterprise-sm" | "enterprise-lg" {
+  if (!isLicenseEffective()) return "free";
   const license = getLicense();
   if (!license.valid) return "free";
-  if (license.expired && !license.inGracePeriod) return "free";
   return license.payload.tier;
 }
 
 /** Returns the licensee name, or null if on free tier. */
 export function licenseeName(): string | null {
+  if (!isLicenseEffective()) return null;
   const license = getLicense();
   if (!license.valid) return null;
-  if (license.expired && !license.inGracePeriod) return null;
   return license.payload.licensee;
 }
 

--- a/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/deployment.procedure.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/deployment.procedure.ts
@@ -213,6 +213,30 @@ async function queryDeploymentsWithStatus(where: ReturnType<typeof sql>): Promis
   });
 }
 
+async function lookupIsMissingFromCatalog(lookup: ModelLookup | null): Promise<boolean> {
+  if (!lookup || !infoClient) return false;
+  try {
+    const status = await infoClient.fetchModelStatus(lookup);
+    return status.status === "not_found";
+  } catch {
+    return false;
+  }
+}
+
+async function markDeploymentsMissingFromCatalog(deployments: DeploymentWithStatus[]): Promise<void> {
+  if (!infoClient) return;
+  const candidates = deployments.filter(d => !d.status && d.enabled);
+  await Promise.all(candidates.map(async (entry) => {
+    const [primaryMissing, earlyMissing] = await Promise.all([
+      lookupIsMissingFromCatalog(deploymentLookup(entry)),
+      lookupIsMissingFromCatalog(deploymentEarlyLookup(entry)),
+    ]);
+    if (primaryMissing || earlyMissing) {
+      entry.status = { phase: "not_in_catalog", progress: null, error: null };
+    }
+  }));
+}
+
 const listDeployments = rootOs.use(withOrganization)
   .use(requirePermission({ modelDeployment: ["read"] }))
   .route({ path: "/", method: "GET", tags, summary: "List Deployments", description: "Lists deployments accessible to the current user" })
@@ -222,33 +246,7 @@ const listDeployments = rootOs.use(withOrganization)
     const orgCondition = sql`${modelDeploymentT.organizationId} = ${context.activeOrganizationId} AND ${modelDeploymentT.deletedAt} IS NULL`;
     if (input?.withStatus) {
       const results = await queryDeploymentsWithStatus(orgCondition);
-
-      // For enabled deployments with no installations at all, check whether the
-      // model still exists in the catalog. If it has been removed, surface that
-      // as a distinct "not_in_catalog" phase so the UI can warn the operator.
-      const noStatusEnabled = results.filter(r => !r.status && r.enabled);
-      if (noStatusEnabled.length > 0 && infoClient) {
-        const client = infoClient;
-        const isMissing = async (lookup: ModelLookup | null): Promise<boolean> => {
-          if (!lookup) return false;
-          try {
-            const status = await client.fetchModelStatus(lookup);
-            return status.status === "not_found";
-          } catch {
-            return false;
-          }
-        };
-        await Promise.all(noStatusEnabled.map(async (entry) => {
-          const [primaryMissing, earlyMissing] = await Promise.all([
-            isMissing(deploymentLookup(entry)),
-            isMissing(deploymentEarlyLookup(entry)),
-          ]);
-          if (primaryMissing || earlyMissing) {
-            entry.status = { phase: "not_in_catalog", progress: null, error: null };
-          }
-        }));
-      }
-
+      await markDeploymentsMissingFromCatalog(results);
       return results;
     }
     return await getDB().select().from(modelDeploymentT).where(orgCondition);

--- a/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/deployment.procedure.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/deployment.procedure.ts
@@ -28,14 +28,15 @@ async function deriveProviderModel(lookup: ModelLookup, preferredDriver: Provide
   return resolveDefaultProvider(model)?.providerModel;
 }
 
-/** Validates that primary and canary models share the same type. */
-async function validateCanaryModelTypes(primary: ModelLookup, early: ModelLookup | null) {
-  if (!early) return;
+/** Validates that primary and canary models share the same type. Returns an error message or null. */
+async function validateCanaryModelTypes(primary: ModelLookup, early: ModelLookup | null): Promise<string | null> {
+  if (!early) return null;
   const primaryModel = await infoClient?.fetchModel(primary);
   const earlyModel = await infoClient?.fetchModel(early);
   if (primaryModel?.type && earlyModel?.type && primaryModel.type !== earlyModel.type) {
-    throw new Error(`Cannot mix model types in a canary deployment: primary is "${primaryModel.type}" but canary is "${earlyModel.type}"`);
+    return `Cannot mix model types in a canary deployment: primary is "${primaryModel.type}" but canary is "${earlyModel.type}"`;
   }
+  return null;
 }
 
 const CapacityCheckInput = z.object({
@@ -265,11 +266,8 @@ const updateDeployment = rootOs
   .handler(async ({ context, input, errors }) => {
     const rlog = log.child({ traceId: context.traceId });
     if (input.modelSpecifier) {
-      try {
-        await validateCanaryModelTypes(deploymentLookup(input), deploymentEarlyLookup(input));
-      } catch (err: unknown) {
-        throw errors.BAD_REQUEST({ message: err instanceof Error ? err.message : String(err) });
-      }
+      const mismatch = await validateCanaryModelTypes(deploymentLookup(input), deploymentEarlyLookup(input));
+      if (mismatch) throw errors.BAD_REQUEST({ message: mismatch });
     }
 
     // Fetch current state for validation
@@ -475,11 +473,8 @@ export const createDeployment = rootOs
     }
 
     const rlog = log.child({ traceId: context.traceId });
-    try {
-      await validateCanaryModelTypes(primaryLookup, earlyLookup);
-    } catch (err: any) {
-      throw errors.BAD_REQUEST({ message: err.message });
-    }
+    const mismatch = await validateCanaryModelTypes(primaryLookup, earlyLookup);
+    if (mismatch) throw errors.BAD_REQUEST({ message: mismatch });
 
     const derivedModelSpecifier = await deriveProviderModel(primaryLookup, input.preferredDriver ?? null) ?? input.modelSpecifier;
     const derivedEarlyModelSpecifier = earlyLookup

--- a/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/onboarding.procedure.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/onboarding.procedure.ts
@@ -26,6 +26,40 @@ async function assertSlugAvailable(slug: string, errors: { CONFLICT: (opts: { me
   }
 }
 
+async function markEmailVerified(userId: string): Promise<void> {
+  await getDB().update(userT).set({ emailVerified: true }).where(eq(userT.id, userId));
+}
+
+async function createOrgWithOwnerMembership(
+  orgName: string,
+  ownerUserId: string,
+  errors: { CONFLICT: (opts: { message: string }) => Error },
+): Promise<{ orgId: string; orgSlug: string }> {
+  const slug = createSlug(orgName);
+  await assertSlugAvailable(slug, errors);
+  const orgId = crypto.randomUUID();
+  const db = getDB();
+  await db.insert(organizationT).values({ id: orgId, name: orgName, slug });
+  await db.insert(memberT).values({
+    id: crypto.randomUUID(),
+    userId: ownerUserId,
+    organizationId: orgId,
+    role: "owner",
+  });
+  return { orgId, orgSlug: slug };
+}
+
+async function issueServerSideDashboardApiKey(userId: string, organizationId: string) {
+  return await auth.api.createApiKey({
+    query: { greenlitCallId: getGreenlitCallId() },
+    body: {
+      name: "Xinity CLI",
+      userId,
+      metadata: { organizationId },
+    },
+  });
+}
+
 const setupOnboarding = rootOs
   .meta({ mcp: false })
   .use(withAuth)
@@ -137,56 +171,18 @@ const cli = rootOs
     const userId = signupResult.user.id;
     rlog.info({ userId, email: input.email }, "CLI onboarding: user created");
 
-    const db = getDB();
+    await markEmailVerified(userId);
+    const { orgId, orgSlug } = await createOrgWithOwnerMembership(input.orgName, userId, errors);
+    rlog.info({ userId, orgId, orgSlug }, "CLI onboarding: organization created");
 
-    // 2. Mark email as verified (CLI setup bypasses email verification flow)
-    await db.update(userT).set({ emailVerified: true }).where(eq(userT.id, userId));
-
-    // 3. Create organization + owner membership directly via DB
-    //    (Better Auth's createOrganization API requires session headers
-    //    which we don't have in this unauthenticated context)
-    const slug = createSlug(input.orgName);
-
-    // Check slug availability before creating
-    await assertSlugAvailable(slug, errors);
-
-    const orgId = crypto.randomUUID();
-    await db.insert(organizationT).values({
-      id: orgId,
-      name: input.orgName,
-      slug,
-    });
-    await db.insert(memberT).values({
-      id: crypto.randomUUID(),
-      userId,
-      organizationId: orgId,
-      role: "owner",
-    });
-
-    rlog.info({ userId, orgId, orgSlug: slug }, "CLI onboarding: organization created");
-
-    // 4. Create a dashboard API key via Better Auth's apiKey plugin.
-    //    Omitting headers makes this a server-side call, so Better Auth
-    //    resolves the user from the body's userId instead of a session cookie.
-    //    greenlitCallId bypasses the "API Key Creation only Serverside" hook guard.
-    const apiKeyResult = await auth.api.createApiKey({
-      query: { greenlitCallId: getGreenlitCallId() },
-      body: {
-        name: "Xinity CLI",
-        userId,
-        metadata: {
-          organizationId: orgId,
-        },
-      },
-    });
-
+    const apiKeyResult = await issueServerSideDashboardApiKey(userId, orgId);
     rlog.info({ userId }, "CLI onboarding: dashboard API key created");
 
     return {
       dashboardApiKey: apiKeyResult.key,
       userId,
       orgId,
-      orgSlug: slug,
+      orgSlug,
     };
   });
 

--- a/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/organization.procedure.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/organization.procedure.ts
@@ -150,18 +150,23 @@ const removeMember = rootOs
   .use(withOrganization)
   .use(requirePermission({ member: ["delete"] }))
   .route({ path: "/remove-member", method: "POST", tags, summary: "Remove Member" })
+  .errors({ NOT_FOUND: {} })
   .input(z.object({
     memberId: z.string(),
   }))
-  .handler(async ({ input, context }) => {
+  .handler(async ({ input, context, errors }) => {
     const rlog = log.child({ traceId: context.traceId });
-    // Look up member name and org name before removal; the member row is deleted by Better Auth
+    // Member lookup must be scoped to the active org: a memberId from another org would otherwise reach Better Auth and surface as 500.
     const [[member], [org]] = await Promise.all([
       getDB()
         .select({ name: userT.name })
         .from(memberT)
         .innerJoin(userT, sql`${userT.id} = ${memberT.userId}`)
-        .where(sql`${memberT.id} = ${input.memberId}`)
+        .where(sql`
+            ${memberT.id} = ${input.memberId} 
+          AND 
+            ${memberT.organizationId} = ${context.activeOrganizationId}
+        `)
         .limit(1),
       getDB()
         .select({ name: organizationT.name })
@@ -169,6 +174,10 @@ const removeMember = rootOs
         .where(sql`${organizationT.id} = ${context.activeOrganizationId}`)
         .limit(1),
     ]);
+
+    if (!member) {
+      throw errors.NOT_FOUND({ message: "Member not found in this organization" });
+    }
 
     await auth.api.removeMember({
       body: {

--- a/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/organization.procedure.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/organization.procedure.ts
@@ -9,6 +9,7 @@ import { NotificationType } from "$lib/server/notifications/events";
 import { memberT, userT, organizationT, invitationT, sql } from "common-db";
 import { isRoleAvailable } from "$lib/server/roles";
 import { hasFeature } from "$lib/server/license";
+import { betterAuthErrorBody } from "$lib/server/better-auth-errors";
 
 const log = rootLogger.child({ name: "organization.procedure" });
 const tags = ["Organization"];
@@ -124,11 +125,9 @@ const inviteMember = rootOs
       }
 
       return { success: true };
-    } catch (err: unknown) {
-      const body = (err as Record<string, any>)?.body;
-      const code = body?.code as string | undefined;
-
-      switch (code) {
+    } catch (err) {
+      const body = betterAuthErrorBody(err);
+      switch (body?.code) {
         case "USER_IS_ALREADY_INVITED_TO_THIS_ORGANIZATION":
           throw errors.CONFLICT({ message: "This email already has a pending invitation to this organization" });
         case "USER_IS_ALREADY_A_MEMBER_OF_THIS_ORGANIZATION":
@@ -139,10 +138,10 @@ const inviteMember = rootOs
           throw errors.FORBIDDEN({ message: "You are not allowed to invite users with this role" });
         case "ROLE_NOT_FOUND":
           throw errors.BAD_REQUEST({ message: "The specified role does not exist" });
-        default: {
-          const message = (body?.message ?? (err as Error)?.message) as string | undefined;
-          throw errors.INTERNAL_SERVER_ERROR({ message: message || "Failed to send invitation" });
-        }
+        default:
+          throw errors.INTERNAL_SERVER_ERROR({
+            message: body?.message ?? (err instanceof Error ? err.message : null) ?? "Failed to send invitation",
+          });
       }
     }
   });

--- a/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/organization.procedure.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/organization.procedure.ts
@@ -6,7 +6,7 @@ import { isInstanceAdmin, serverEnv } from "$lib/server/serverenv";
 import { getDB } from "$lib/server/db";
 import { notifyOrgMembers } from "$lib/server/notifications/notification.service";
 import { NotificationType } from "$lib/server/notifications/events";
-import { memberT, userT, organizationT, sql } from "common-db";
+import { memberT, userT, organizationT, invitationT, sql } from "common-db";
 import { isRoleAvailable } from "$lib/server/roles";
 import { hasFeature } from "$lib/server/license";
 
@@ -261,7 +261,13 @@ const cancelInvitation = rootOs
   .input(z.object({
     invitationId: z.string(),
   }))
+  .errors({ NOT_FOUND: {} })
   .handler(async ({ input, context, errors }) => {
+    const invitation = await findInvitationInOrg(input.invitationId, context.activeOrganizationId);
+    if (!invitation) {
+      throw errors.NOT_FOUND({ message: "Invitation not found" });
+    }
+
     const result = await auth.api.cancelInvitation({
       body: {
         invitationId: input.invitationId,
@@ -313,3 +319,12 @@ export const organizationRouter = rootOs.prefix("/organization").router({
   cancelInvitation,
   delete: deleteOrganization,
 });
+
+async function findInvitationInOrg(invitationId: string, organizationId: string): Promise<{ id: string } | null> {
+  const [row] = await getDB()
+    .select({ id: invitationT.id })
+    .from(invitationT)
+    .where(sql`${invitationT.id} = ${invitationId} AND ${invitationT.organizationId} = ${organizationId}`)
+    .limit(1);
+  return row ?? null;
+}

--- a/packages/xinity-ai-dashboard/src/lib/server/serverenv.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/serverenv.ts
@@ -8,22 +8,23 @@ import { dashboardEnvSchema } from "./env-schema.ts";
 /**
  * Parsed environment variables. Avoid reading from `process.env` elsewhere.
  */
-const rawEnv = { ...process.env } as Record<string, string | undefined>;
-// Backwards compat: migrate PUBLIC_LLM_API_URL to GATEWAY_URL.
-// The old variable conventionally included a trailing /v1; the new one does not.
-// Strip it so values copied verbatim still produce a correct GATEWAY_URL.
-if (!rawEnv.GATEWAY_URL && rawEnv.PUBLIC_LLM_API_URL) {
-  // We have to use console here, as the logging module is not yet able to load
-  console.warn("PUBLIC_LLM_API_URL is depricated and will be removed in 1.0.0. Change the variable to GATEWAY_URL (without the /v1 suffix)")
-  rawEnv.GATEWAY_URL = rawEnv.PUBLIC_LLM_API_URL.replace(/\/v1\/?$/, "");
+type RawEnv = Record<string, string | undefined>;
+
+function migrateLegacyPublicLlmApiUrl(env: RawEnv): void {
+  if (env.GATEWAY_URL || !env.PUBLIC_LLM_API_URL) return;
+  console.warn("PUBLIC_LLM_API_URL is depricated and will be removed in 1.0.0. Change the variable to GATEWAY_URL (without the /v1 suffix)");
+  env.GATEWAY_URL = env.PUBLIC_LLM_API_URL.replace(/\/v1\/?$/, "");
 }
-// Defensive normalization: GATEWAY_URL must not include /v1; warn and strip
-// so a misconfigured deployment fails loudly rather than 404ing on every
-// request that builds `${GATEWAY_URL}/v1/...`.
-if (rawEnv.GATEWAY_URL && /\/v1\/?$/.test(rawEnv.GATEWAY_URL)) {
+
+function stripV1SuffixFromGatewayUrl(env: RawEnv): void {
+  if (!env.GATEWAY_URL || !/\/v1\/?$/.test(env.GATEWAY_URL)) return;
   console.warn("GATEWAY_URL must not end with /v1 - the /v1 segment is appended by the dashboard where needed. Stripping for compatibility, but please update your configuration.");
-  rawEnv.GATEWAY_URL = rawEnv.GATEWAY_URL.replace(/\/v1\/?$/, "");
+  env.GATEWAY_URL = env.GATEWAY_URL.replace(/\/v1\/?$/, "");
 }
+
+const rawEnv: RawEnv = { ...process.env };
+migrateLegacyPublicLlmApiUrl(rawEnv);
+stripV1SuffixFromGatewayUrl(rawEnv);
 
 export const serverEnv = parseEnv(dashboardEnvSchema, rawEnv);
 

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/+layout.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/+layout.svelte
@@ -12,15 +12,11 @@
   $effect(()=> { permissions.setRole(data.memberRole); });
 </script>
 
-{#if data.license.originMismatch}
+<Sidebar isInstanceAdmin={data.isInstanceAdmin} license={data.license} />
+<main class="sm:ml-64 ml-14 min-w-0">
+  <VersionNotice versioning={data.versioning} />
   <LicenseBanner license={data.license} totalVramGb={data.totalVramGb} />
-{:else}
-  <Sidebar isInstanceAdmin={data.isInstanceAdmin} license={data.license} />
-  <main class="sm:ml-64 ml-14 min-w-0">
-    <VersionNotice versioning={data.versioning} />
-    <LicenseBanner license={data.license} totalVramGb={data.totalVramGb} />
-    {@render children()}
-  </main>
+  {@render children()}
+</main>
 
-  <ToastContainer />
-{/if}
+<ToastContainer />

--- a/packages/xinity-ai-dashboard/src/routes/api/[...rest]/+server.ts
+++ b/packages/xinity-ai-dashboard/src/routes/api/[...rest]/+server.ts
@@ -2,6 +2,7 @@
  * OpenAPI-compatible REST handler for ORPC procedures under `/api`.
  */
 import { OpenAPIHandler } from "@orpc/openapi/fetch";
+import { BodyLimitPlugin } from "@orpc/server/fetch";
 import type { RequestHandler } from "./$types";
 import { router } from "$lib/server/orpc/router";
 import { onError, ORPCError } from "@orpc/server";
@@ -10,7 +11,7 @@ import { rootLogger } from "$lib/server/logging";
 const log = rootLogger.child({ name: "orpc.api.root" });
 
 const handler = new OpenAPIHandler<App.Locals>(router, {
-  // plugins: [new BodyLimitPlugin({ maxBodySize: 1024 * 1024 })],
+  plugins: [new BodyLimitPlugin({ maxBodySize: 1024 * 1024 })],
   interceptors: [
     onError(err => {
       if (err instanceof ORPCError) {

--- a/packages/xinity-ai-dashboard/src/routes/mcp/+server.ts
+++ b/packages/xinity-ai-dashboard/src/routes/mcp/+server.ts
@@ -10,8 +10,12 @@
  *   { "url": "https://dashboard.example.com/mcp", "headers": { "x-api-key": "sk_..." } }
  */
 import { json, type RequestHandler } from "@sveltejs/kit";
+import { toORPCError } from "@orpc/client";
 import { mcpTools, callMcpTool, type McpTool } from "$lib/server/mcp";
 import { serverEnv } from "$lib/server/serverenv";
+import { rootLogger } from "$lib/server/logging";
+
+const log = rootLogger.child({ name: "mcp" });
 
 const SERVER_INFO = { name: "xinity-ai", version: "0.1.0" };
 const PROTOCOL_VERSION = "2024-11-05";
@@ -74,6 +78,16 @@ async function handleMessage(
 			if (!name) {
 				return { jsonrpc, id, error: { code: -32602, message: "Invalid params: missing name" } };
 			}
+			if (!mcpTools.some((t) => t.name === name)) {
+				return {
+					jsonrpc,
+					id,
+					result: {
+						content: [{ type: "text", text: `Unknown tool: ${name}` }],
+						isError: true,
+					},
+				};
+			}
 			try {
 				const result = await callMcpTool(name, args, apiKey);
 				return {
@@ -82,11 +96,26 @@ async function handleMessage(
 					result: { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] },
 				};
 			} catch (err) {
+				// Surface developer-declared errors (e.g. NOT_FOUND, FORBIDDEN with curated
+				// messages) verbatim. Everything else is logged server-side and returned as
+				// a generic message so DB/validation internals don't leak to clients.
+				const orpcErr = toORPCError(err);
+				if (orpcErr.defined) {
+					return {
+						jsonrpc,
+						id,
+						result: {
+							content: [{ type: "text", text: `${orpcErr.code}: ${orpcErr.message}` }],
+							isError: true,
+						},
+					};
+				}
+				log.error({ err, tool: name }, "MCP tool execution failed");
 				return {
 					jsonrpc,
 					id,
 					result: {
-						content: [{ type: "text", text: String(err) }],
+						content: [{ type: "text", text: "Tool execution failed" }],
 						isError: true,
 					},
 				};

--- a/packages/xinity-ai-dashboard/svelte.config.js
+++ b/packages/xinity-ai-dashboard/svelte.config.js
@@ -10,6 +10,12 @@ const config = {
 	// for more information about preprocessors
 	preprocess: vitePreprocess(),
 
+	compilerOptions: {
+		experimental: {
+			async: true,
+		},
+	},
+
 	kit: {
 		adapter: adapter({ bundler: 'bun' }),
 		version: { name: pkg.version },

--- a/packages/xinity-ai-gateway/src/llm-forward/auth.test.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/auth.test.ts
@@ -62,7 +62,7 @@ function makeBearerHeader(prefix?: string): string {
 
 // --- Redis spies ---
 
-let mockRedisGetex: ReturnType<typeof spyOn>;
+let mockRedisGet: ReturnType<typeof spyOn>;
 let mockRedisSet: ReturnType<typeof spyOn>;
 
 // --- Helpers ---
@@ -86,12 +86,12 @@ describe("checkAuth", () => {
     mockQueryResult.length = 0;
 
     // Default: cache miss, set succeeds
-    mockRedisGetex = spyOn(redis, "getex").mockResolvedValue(null);
+    mockRedisGet = spyOn(redis, "get").mockResolvedValue(null);
     mockRedisSet = spyOn(redis, "set").mockResolvedValue("OK" as any);
   });
 
   afterEach(() => {
-    mockRedisGetex.mockRestore();
+    mockRedisGet.mockRestore();
     mockRedisSet.mockRestore();
   });
 
@@ -112,7 +112,7 @@ describe("checkAuth", () => {
       applicationId: "cached-app",
       collectData: false,
     };
-    mockRedisGetex.mockResolvedValue(JSON.stringify(cached));
+    mockRedisGet.mockResolvedValue(JSON.stringify(cached));
 
     const result = await checkAuth(makeBearerHeader());
 
@@ -133,7 +133,7 @@ describe("checkAuth", () => {
       applicationId: null,
       // collectData intentionally omitted
     };
-    mockRedisGetex.mockResolvedValue(JSON.stringify(cached));
+    mockRedisGet.mockResolvedValue(JSON.stringify(cached));
 
     const result = await checkAuth(makeBearerHeader());
 

--- a/packages/xinity-ai-gateway/src/llm-forward/auth.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/auth.ts
@@ -79,20 +79,22 @@ export async function checkAuth(authHeader: string): Promise<Response | AuthResu
 
 type PartialApiKey = Pick<AIAPIKeyT, "organizationId" | "id" | "applicationId" | "collectData">;
 const pickAttrs = pick(["organizationId", "id", "applicationId", "collectData"] satisfies (keyof AIAPIKeyT)[]);
+const API_KEY_CACHE_TTL_SECONDS = 120;
+
 function setApiKeyCache(
   identifier: string,
   data: AIAPIKeyT,
-  ttlSeconds: number = 60 * 60,
+  ttlSeconds: number = API_KEY_CACHE_TTL_SECONDS,
 ): void {
   const key = `apikey:${identifier}`;
   void redis.set(key, JSON.stringify(pickAttrs(data)), "EX", ttlSeconds)
     .catch((err: unknown) => log.warn({ err }, "Redis error in setApiKeyCache"));
 }
 
-async function getApiKeyCache(identifier: string, ttlSeconds = 60 * 60): Promise<PartialApiKey | null> {
+async function getApiKeyCache(identifier: string): Promise<PartialApiKey | null> {
   try {
     const key = `apikey:${identifier}`;
-    const result = await redis.getex(key, "EX", ttlSeconds);
+    const result = await redis.get(key);
     if (!result) return null;
     const parsed = JSON.parse(result);
     // Handle old cache entries missing collectData (safe default during rolling deploy)

--- a/packages/xinity-ai-gateway/src/llm-forward/auth.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/auth.ts
@@ -28,6 +28,9 @@ export type AuthResult = {
   collectData: boolean;
 }
 
+/** map to keep track of ongoing auth checks, to deal with sudden bursts of requests from the same key */
+const inflightAuth = new Map<string, Promise<Response | AuthResult>>();
+
 export async function checkAuth(authHeader: string): Promise<Response | AuthResult> {
   if (!authHeader.startsWith("Bearer ")) {
     return genericUnauthorized("Missing API Key");
@@ -43,6 +46,14 @@ export async function checkAuth(authHeader: string): Promise<Response | AuthResu
       collectData: secret.collectData ?? true,
     };
   }
+  const inflight = inflightAuth.get(key);
+  if (inflight) return inflight;
+  const promise = verifyKeyAgainstDb(key, prefix).finally(() => inflightAuth.delete(key));
+  inflightAuth.set(key, promise);
+  return promise;
+}
+
+async function verifyKeyAgainstDb(key: string, prefix: string): Promise<Response | AuthResult> {
   const [apiKeyObj] = await getDB()
     .select()
     .from(aiApiKeyT)

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-chatCompletion.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-chatCompletion.ts
@@ -51,6 +51,39 @@ const ChatCompletionBodySchema = z.looseObject({
   ]).optional(),
 });
 
+const NonStreamingChoicesSchema = z.array(z.looseObject({
+  index: z.number(),
+  message: z.looseObject({
+    role: z.string(),
+    content: z.string().nullable().optional(),
+    tool_calls: z.array(z.looseObject({
+      id: z.string(),
+      type: z.string(),
+      function: z.looseObject({ name: z.string(), arguments: z.string() }),
+    })).optional(),
+  }),
+  finish_reason: z.string().nullable().optional(),
+}));
+
+function logNonStreamingChatResponse(
+  raw: Record<string, unknown>,
+  originalModel: string,
+  logFields: Omit<Parameters<typeof logChatUsage>[0], "usage" | "outputData" | "stream">,
+): void {
+  const choicesResult = NonStreamingChoicesSchema.safeParse(raw.choices);
+  const usageResult = BackendUsageSchema.safeParse(raw.usage);
+  if (!choicesResult.success) {
+    log.warn({ issues: choicesResult.error.issues }, "Could not extract choices for logging");
+    return;
+  }
+  logChatUsage({
+    ...logFields,
+    usage: usageResult.success ? usageResult.data : undefined,
+    outputData: { model: originalModel, choices: choicesResult.data },
+    stream: false,
+  });
+}
+
 export async function handleChatCompletion(req: Request) {
   try {
     const resolved = await resolveModel(req);
@@ -79,8 +112,6 @@ export async function handleChatCompletion(req: Request) {
 
     const callStartTime = Date.now();
 
-    // Process images: resolve to data URIs for the inference node, store S3
-    // refs (or original URLs) in the DB version.
     const { messagesForLLM, messagesForDB } = await processMessageImages(
       body.messages as ApiCallInputMessage[],
       auth.orgId,
@@ -210,38 +241,8 @@ export async function handleChatCompletion(req: Request) {
         return errorResponse("Backend returned an invalid response", 502);
       }
 
-      // Override model with the user-facing specifier
       raw.model = originalModel;
-
-      // Field-by-field extraction for logging each field independent so one
-      // malformed field can't block extraction of the others
-      const choicesResult = z.array(z.looseObject({
-        index: z.number(),
-        message: z.looseObject({
-          role: z.string(),
-          content: z.string().nullable().optional(),
-          tool_calls: z.array(z.looseObject({
-            id: z.string(),
-            type: z.string(),
-            function: z.looseObject({ name: z.string(), arguments: z.string() }),
-          })).optional(),
-        }),
-        finish_reason: z.string().nullable().optional(),
-      })).safeParse(raw.choices);
-
-      const usageResult = BackendUsageSchema.safeParse(raw.usage);
-
-      if (choicesResult.success) {
-        logChatUsage({
-          ...logFields,
-          usage: usageResult.success ? usageResult.data : undefined,
-          outputData: { model: originalModel, choices: choicesResult.data },
-          stream: false,
-        });
-      } else {
-        log.warn({ issues: choicesResult.error.issues }, "Could not extract choices for logging");
-      }
-
+      logNonStreamingChatResponse(raw, originalModel, logFields);
       return Response.json(raw);
     }
 

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-responses.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-responses.ts
@@ -1,6 +1,6 @@
 import { generateText, streamText } from "ai";
 import { resolveAuthorizedModel } from "../ai-sdk";
-import { errorResponse, logChatUsage, validateModelType, toModelMessages, SSE_RESPONSE_HEADERS, validationError } from "../util";
+import { errorResponse, logChatUsage, validateModelType, toModelMessages, SSE_RESPONSE_HEADERS, validationError, isUpstreamError } from "../util";
 import type { ApiCallInputMessage } from "common-db";
 import { checkAuth, type AuthResult } from "../auth";
 import { deleteResponse, getResponse, saveResponse } from "../response-store";
@@ -318,17 +318,15 @@ export async function handleCreateResponseRequest(req: Request): Promise<Respons
 
     return Response.json(responseBody);
   } catch (error) {
-    const isUpstreamError = error instanceof Error && (
-      "statusCode" in error || "status" in error || error.name === "APICallError"
-    );
-    if (isUpstreamError) {
-      const status = (error as Record<string, unknown>).statusCode ?? (error as Record<string, unknown>).status;
+    if (isUpstreamError(error) && error instanceof Error) {
+      const errObj = error as unknown as Record<string, unknown>;
+      const status = errObj.statusCode ?? errObj.status;
       const code = typeof status === "number" && status >= 400 && status < 600 ? status : 502;
       log.error({ err: error }, "Upstream error");
       return errorResponse(error.message || "Bad Gateway", code as number);
     }
     log.error({ err: error }, "Internal gateway error");
-    return errorResponse(error instanceof Error ? error.message : "Internal Server Error", 500);
+    return errorResponse("Internal Server Error", 500);
   }
 }
 
@@ -378,9 +376,15 @@ async function runBackground(
       stream: false,
     });
   } catch (error) {
+    if (!isUpstreamError(error)) {
+      log.error({ err: error, responseId }, "Background response generation failed");
+    }
+    const message = isUpstreamError(error) && error instanceof Error
+      ? error.message
+      : "Gateway error";
     const failedResponse = markResponseFailed(
       createResponseObject({ responseId, createdAt, model: originalModel, status: "failed", body }),
-      error instanceof Error ? error.message : "Gateway error",
+      message,
     );
     await saveResponse(orgId, responseId, failedResponse)
       .catch((err) => log.error({ err, responseId }, "Failed to persist failed response"));

--- a/packages/xinity-ai-gateway/src/llm-forward/responses/stream.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/responses/stream.ts
@@ -17,7 +17,7 @@ import {
 } from "./builders";
 import { saveResponse } from "../response-store";
 import { rootLogger } from "../../logger";
-import { isAbortError, isTimeoutError } from "../util";
+import { isAbortError, isTimeoutError, isUpstreamError } from "../util";
 
 const log = rootLogger.child({ name: "response-stream" });
 
@@ -190,7 +190,12 @@ export function createResponseStream(params: StreamResponseParams): ReadableStre
           try { controller.close(); } catch {}
           return;
         }
-        const message = error instanceof Error ? error.message : "Gateway error";
+        if (!isUpstreamError(error)) {
+          log.error({ err: error, responseId }, "Internal error in response stream");
+        }
+        const message = isUpstreamError(error) && error instanceof Error
+          ? error.message
+          : "Gateway error";
         try {
           emitStreamError(controller, message, seq);
           emitResponseFailed(controller, markResponseFailed(baseResponse, message), seq);

--- a/packages/xinity-ai-gateway/src/llm-forward/util.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/util.ts
@@ -424,6 +424,12 @@ export function isConnectionRefused(error: unknown): boolean {
   return error instanceof Error && (error as { code?: string }).code === "ConnectionRefused";
 }
 
+export function isUpstreamError(error: unknown): boolean {
+  return error instanceof Error && (
+    "statusCode" in error || "status" in error || error.name === "APICallError"
+  );
+}
+
 /** Seconds to advertise in Retry-After when a backend node is unreachable (covers typical vLLM restart time). */
 export const BACKEND_RESTART_RETRY_AFTER = 120;
 
@@ -452,7 +458,9 @@ export function handleEndpointError(
     );
   }
   log.error({ err: error }, "Internal gateway error");
-  return errorResponse(error instanceof Error ? error.message : "Internal Server Error", 500);
+  // Generic message: error.message can include DB/SDK internals that must not
+  // reach the client. Full error is logged above for debugging.
+  return errorResponse("Internal Server Error", 500);
 }
 
 export function validateModelType(

--- a/packages/xinity-cli/src/commands/update.ts
+++ b/packages/xinity-cli/src/commands/update.ts
@@ -7,7 +7,7 @@ import pc from "picocolors";
 
 import { version } from "../../../../package.json";
 const CLI_VERSION = `v${version}`;
-import { fetchRelease, getAssetName, type Release } from "../lib/github.ts";
+import { fetchRelease, pickReleaseAsset, type Release } from "../lib/github.ts";
 import { downloadAndVerify } from "../lib/installer.ts";
 import { pass, fail } from "../lib/output.ts";
 import { createLocalHost } from "../lib/host.ts";
@@ -15,7 +15,13 @@ import { createLocalHost } from "../lib/host.ts";
 // ─── Self-update ────────────────────────────────────────────────────────────
 
 async function selfUpdate(release: Release): Promise<boolean> {
-  const assetName = getAssetName("cli");
+  let assetName: string;
+  try {
+    assetName = pickReleaseAsset(release, "cli");
+  } catch (err) {
+    fail("Self-update", (err as Error).message);
+    return false;
+  }
 
   const tmpDir = join(tmpdir(), `xinity-cli-update-${Date.now()}`);
   mkdirSync(tmpDir, { recursive: true });
@@ -23,13 +29,15 @@ async function selfUpdate(release: Release): Promise<boolean> {
   const filePath = await downloadAndVerify(release, assetName, tmpDir);
   if (!filePath) return false;
 
-  // Extract zip
   const extractDir = join(tmpDir, "extracted");
   mkdirSync(extractDir, { recursive: true });
   const local = createLocalHost();
-  const unzip = await local.run(["unzip", "-o", filePath, "-d", extractDir]);
-  if (!unzip.ok) {
-    fail("Extract", "Failed to extract zip archive");
+  const extractCmd = filePath.endsWith(".tar.gz")
+    ? ["tar", "-xzf", filePath, "-C", extractDir]
+    : ["unzip", "-o", filePath, "-d", extractDir];
+  const extracted = await local.run(extractCmd);
+  if (!extracted.ok) {
+    fail("Extract", "Failed to extract archive");
     return false;
   }
 

--- a/packages/xinity-cli/src/lib/config.ts
+++ b/packages/xinity-cli/src/lib/config.ts
@@ -1,7 +1,7 @@
 /**
  * Persistent CLI configuration stored at ~/.config/xinity/config.json.
  */
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 import * as p from "./clack.ts";
@@ -68,8 +68,10 @@ export function loadConfig(): CliConfig {
 
 /** Write the full config object to disk, creating the directory if needed. */
 export function saveConfig(config: CliConfig): void {
-  mkdirSync(CONFIG_DIR, { recursive: true });
-  writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2) + "\n");
+  mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 });
+  chmodSync(CONFIG_DIR, 0o700);
+  writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2) + "\n", { mode: 0o600 });
+  chmodSync(CONFIG_PATH, 0o600);
 }
 
 /** Merge partial updates into the existing config and persist. */

--- a/packages/xinity-cli/src/lib/env-prompt.ts
+++ b/packages/xinity-cli/src/lib/env-prompt.ts
@@ -250,12 +250,95 @@ function displayValue(field: EnvField, value: string | undefined, locked = false
   return pc.yellow("(not set)");
 }
 
+export interface MenuEditOptions {
+  /** Keys flagged as "new" — highlighted in label and required to be set before save. */
+  newKeys?: Set<string>;
+  /** Secrets we couldn't read because elevation was skipped — shown as (locked). */
+  secretsLocked?: boolean;
+  /** Message displayed above the menu. */
+  message?: string;
+}
+
+/**
+ * Menu-based env editor. Returns the merged { config, secrets } without
+ * persisting anything. Returns null if the user cancels.
+ *
+ * Used by both `xinity configure` (where the caller writes to disk and
+ * restarts the service) and the `xinity up` update flow (where the caller
+ * passes the result through the installer's existing write path).
+ */
+export async function menuEditEnv(
+  schema: z.ZodObject<any>,
+  existing: Record<string, string>,
+  opts?: MenuEditOptions,
+): Promise<{ config: Record<string, string>; secrets: Record<string, string> } | null> {
+  const fields = analyzeEnvSchema(schema);
+  const newKeys = opts?.newKeys ?? new Set<string>();
+  const secretsLocked = opts?.secretsLocked ?? false;
+  const values: Record<string, string | undefined> = { ...existing };
+
+  const newMarker = pc.yellow("● new ");
+
+  while (true) {
+    const options = fields.map((field) => {
+      const marker = newKeys.has(field.key) ? newMarker : "";
+      return {
+        value: field.key,
+        label: `${marker}${field.key}  ${displayValue(field, values[field.key], secretsLocked && field.isSecret)}`,
+        hint: field.description,
+      };
+    });
+    options.push({ value: "__save__", label: pc.green("Save & exit"), hint: undefined });
+
+    const choice = await p.select({
+      message: opts?.message ?? "Select a value to update",
+      options,
+    });
+
+    if (p.isCancel(choice)) return null;
+
+    if (choice === "__save__") {
+      const unsetRequiredNew = fields.filter(
+        (f) =>
+          newKeys.has(f.key) &&
+          !f.isOptional &&
+          !f.hasDefault &&
+          (values[f.key] === undefined || values[f.key] === ""),
+      );
+      if (unsetRequiredNew.length > 0) {
+        p.log.warn(
+          `These new variables are required and not set: ${unsetRequiredNew.map((f) => f.key).join(", ")}`,
+        );
+        continue;
+      }
+      break;
+    }
+
+    const field = fields.find((f) => f.key === choice)!;
+    const newValue = await promptField(field, values[field.key]);
+    if (newValue !== undefined) {
+      values[field.key] = newValue;
+    } else {
+      delete values[field.key];
+    }
+  }
+
+  const config: Record<string, string> = {};
+  const secrets: Record<string, string> = {};
+  for (const field of fields) {
+    const val = values[field.key];
+    if (val === undefined) continue;
+    if (field.isSecret) secrets[field.key] = val;
+    else config[field.key] = val;
+  }
+  return { config, secrets };
+}
+
 /**
  * Menu-based interactive configuration for a component's env vars.
  *
- * Shows all fields in a select menu with current values. The user picks
- * a field to edit, updates it, then returns to the menu. "Save & exit"
- * persists the config to disk.
+ * Loads current values from disk, opens the menu editor, and on save
+ * persists the result and restarts the service.
  */
 export async function menuConfigureEnv(
   component: Component,
@@ -269,7 +352,6 @@ export async function menuConfigureEnv(
 
   p.intro(`xinity configure ${pc.cyan(component)}`);
 
-  // Load existing values from the host
   const envPath = `${ENV_DIR}/${component}.env`;
   const envContent = await h.readFile(envPath);
   const existingConfig = envContent ? parseEnvString(envContent) : {};
@@ -281,49 +363,15 @@ export async function menuConfigureEnv(
     secretsLocked = sr.skipped;
   }
   const autoDefaults = getAutoDefaults(component);
-  const values: Record<string, string | undefined> = { ...autoDefaults, ...existingConfig, ...existingSecrets };
+  const existing: Record<string, string> = { ...autoDefaults, ...existingConfig, ...existingSecrets };
 
-  while (true) {
-    const options = fields.map((field) => ({
-      value: field.key,
-      label: `${field.key}  ${displayValue(field, values[field.key], secretsLocked && field.isSecret)}`,
-      hint: field.description,
-    }));
-    options.push({ value: "__save__", label: pc.green("Save & exit"), hint: undefined });
-
-    const choice = await p.select({
-      message: "Select a value to update",
-      options,
-    });
-
-    if (p.isCancel(choice)) {
-      p.cancel("Cancelled, no changes saved.");
-      return;
-    }
-
-    if (choice === "__save__") break;
-
-    const field = fields.find((f) => f.key === choice)!;
-    const newValue = await promptField(field, values[field.key]);
-    if (newValue !== undefined) {
-      values[field.key] = newValue;
-    } else {
-      // User cleared the value (empty input on optional field)
-      delete values[field.key];
-    }
+  const result = await menuEditEnv(schema, existing, { secretsLocked });
+  if (result === null) {
+    p.cancel("Cancelled, no changes saved.");
+    return;
   }
 
-  // Split into config and secrets for writing
-  const config: Record<string, string> = {};
-  const secrets: Record<string, string> = {};
-  for (const field of fields) {
-    const val = values[field.key];
-    if (val === undefined) continue;
-    if (field.isSecret) secrets[field.key] = val;
-    else config[field.key] = val;
-  }
-
-  const wrote = await writeEnvConfig(component, config, secrets, h);
+  const wrote = await writeEnvConfig(component, result.config, result.secrets, h);
   if (wrote) {
     await restartService(component, h);
   }

--- a/packages/xinity-cli/src/lib/github.ts
+++ b/packages/xinity-cli/src/lib/github.ts
@@ -185,21 +185,25 @@ export async function resolveDirectUrl(asset: ReleaseAsset): Promise<string> {
   throw new Error(`Failed to resolve download URL: ${res.status} ${res.statusText}`);
 }
 
-/** Determine the expected asset filename for a component on the given platform. */
-export function getAssetName(component: string, arch?: string): string {
+function assetPrefix(component: string, arch?: string): string {
   const resolved = (arch ?? process.arch) === "arm64" ? "arm64" : "x64";
+  if (component === "cli") return `xinity-cli-linux-${resolved}`;
+  if (component === "infoserver") return `xinity-infoserver-linux-${resolved}`;
+  return `xinity-ai-${component}-linux-${resolved}`;
+}
 
-  if (component === "cli") {
-    return `xinity-cli-linux-${resolved}.zip`;
-  }
-
+export function pickReleaseAsset(release: Release, component: string, arch?: string): string {
   if (component === "db") {
     return "db-migrations.tar.gz";
   }
 
-  if (component === "infoserver") {
-    return `xinity-infoserver-linux-${resolved}.zip`;
-  }
-
-  return `xinity-ai-${component}-linux-${resolved}.zip`;
+  const prefix = assetPrefix(component, arch);
+  const tarName = `${prefix}.tar.gz`;
+  const zipName = `${prefix}.zip`;
+  const names = new Set(release.assets.map((a) => a.name));
+  if (names.has(tarName)) return tarName;
+  if (names.has(zipName)) return zipName;
+  throw new Error(
+    `Neither ${tarName} nor ${zipName} found in release ${release.tagName}`,
+  );
 }

--- a/packages/xinity-cli/src/lib/installer.ts
+++ b/packages/xinity-cli/src/lib/installer.ts
@@ -10,7 +10,7 @@ import { mkdirSync } from "fs";
 import * as p from "./clack.ts";
 import pc from "picocolors";
 
-import { fetchRelease, downloadAsset, fetchChecksums, verifySha256, getAssetName, resolveDirectUrl, type Release } from "./github.ts";
+import { fetchRelease, downloadAsset, fetchChecksums, verifySha256, pickReleaseAsset, resolveDirectUrl, type Release } from "./github.ts";
 import { loadConfig } from "./config.ts";
 import { buildLocalArtifact } from "./local-build.ts";
 import { readManifest, updateManifestEntry, writeManifest } from "./manifest.ts";
@@ -70,13 +70,14 @@ export async function preflightCheck(
     await check("systemctl", "systemd is required to manage services");
   }
 
-  // unzip is needed for binary extraction (all service components)
-  const needsUnzip = components.some(
+  const needsExtractor = components.some(
     (c) => c === "all" || serviceComponents.includes(c),
   );
-  if (needsUnzip) {
+  if (needsExtractor) {
     const target = host.isRemote ? "the remote host" : "this machine";
-    await check("unzip", `required on ${target} for binary extraction`, "apt install unzip / dnf install unzip / pacman -S unzip");
+    await check("tar", `required on ${target} for binary extraction`, "apt install tar / dnf install tar / pacman -S tar");
+    // TODO drop unzip on v1.0.0
+    await check("unzip", `required on ${target} to install pre-1.0.0 releases`, "apt install unzip / dnf install unzip / pacman -S unzip");
   }
 
   // curl is needed on remote hosts for downloading release assets
@@ -442,14 +443,24 @@ async function downloadAndVerifyOnHost(
 
 // ─── Install binary ────────────────────────────────────────────────────────
 
+function extractCommand(archivePath: string, destDir: string): string {
+  if (archivePath.endsWith(".tar.gz")) return `tar -xzf ${archivePath} -C ${destDir}`;
+  if (archivePath.endsWith(".zip")) return `unzip -o ${archivePath} -d ${destDir}`;
+  throw new Error(`Unsupported archive format: ${archivePath}`);
+}
+
+function stripArchiveSuffix(path: string): string {
+  return path.replace(/\.tar\.gz$|\.zip$/, "");
+}
+
 async function installBinary(component: Component, archivePath: string, host: Host): Promise<boolean> {
   const binName = binaryBaseName(component);
 
   if (host.isRemote) {
     // Archive already on remote, extract and install directly
-    const tmpExtract = archivePath.replace(/\.zip$/, "");
+    const tmpExtract = stripArchiveSuffix(archivePath);
     const result = await host.withElevation(
-      `mkdir -p ${tmpExtract} && unzip -o ${archivePath} -d ${tmpExtract}` +
+      `mkdir -p ${tmpExtract} && ${extractCommand(archivePath, tmpExtract)}` +
       ` && mkdir -p ${BIN_DIR} && rm -f ${BIN_DIR}/${binName}` +
       ` && cp ${tmpExtract}/${binName} ${BIN_DIR}/${binName}` +
       ` && chmod +x ${BIN_DIR}/${binName}` +
@@ -463,16 +474,19 @@ async function installBinary(component: Component, archivePath: string, host: Ho
     if (result.skipped) return false;
   } else {
     // Local: extract locally, upload binary, place on host
-    const tmpExtract = archivePath.replace(/\.zip$/, "");
+    const tmpExtract = stripArchiveSuffix(archivePath);
     mkdirSync(tmpExtract, { recursive: true });
 
     const extractSpinner = p.spinner();
     extractSpinner.start("Extracting…");
     const local = createLocalHost();
-    const unzip = await local.run(["unzip", "-o", archivePath, "-d", tmpExtract]);
-    if (!unzip.ok) {
+    const extractCmd = archivePath.endsWith(".tar.gz")
+      ? ["tar", "-xzf", archivePath, "-C", tmpExtract]
+      : ["unzip", "-o", archivePath, "-d", tmpExtract];
+    const extracted = await local.run(extractCmd);
+    if (!extracted.ok) {
       extractSpinner.stop("Extract failed");
-      fail("Extract", unzip.output);
+      fail("Extract", extracted.output);
       return false;
     }
 
@@ -667,7 +681,7 @@ async function resolveArtifact(
       return { status: "ready", archivePath: buildResult.archivePath, versionString: buildResult.version, isUpdate };
     }
 
-    const remoteTmp = `/tmp/xinity-local-${Date.now()}.zip`;
+    const remoteTmp = `/tmp/xinity-local-${Date.now()}.tar.gz`;
     const uploadSpinner = p.spinner();
     uploadSpinner.start("Uploading artifact...");
     try {
@@ -701,7 +715,13 @@ async function resolveArtifact(
   }
 
   const hostArch = await host.getArch();
-  const assetName = getAssetName(component, hostArch);
+  let assetName: string;
+  try {
+    assetName = pickReleaseAsset(release, component, hostArch);
+  } catch (err) {
+    fail("Download", (err as Error).message);
+    return { status: "failed", version: release.tagName };
+  }
   let archivePath: string | null;
 
   if (host.isRemote) {
@@ -879,7 +899,12 @@ function dryRunSummary(
   isUpdate: boolean,
   arch?: string,
 ): InstallResult {
-  const assetName = getAssetName(component, arch);
+  let assetName: string;
+  try {
+    assetName = pickReleaseAsset(release, component, arch);
+  } catch {
+    assetName = `xinity-ai-${component}-linux-${arch ?? "x64"}.tar.gz`;
+  }
   const asset = release.assets.find((a) => a.name === assetName);
   const schema = ENV_SCHEMAS[component];
   const fields = analyzeEnvSchema(schema);

--- a/packages/xinity-cli/src/lib/installer.ts
+++ b/packages/xinity-cli/src/lib/installer.ts
@@ -15,7 +15,7 @@ import { loadConfig } from "./config.ts";
 import { buildLocalArtifact } from "./local-build.ts";
 import { readManifest, updateManifestEntry, writeManifest } from "./manifest.ts";
 import { generateUnit, getComponentConfig, unitName, type UnitConfig } from "./systemd.ts";
-import { analyzeEnvSchema, categorizeFields, promptForEnv } from "./env-prompt.ts";
+import { analyzeEnvSchema, categorizeFields, menuEditEnv, promptForEnv } from "./env-prompt.ts";
 import { parseEnvString } from "./env-file.ts";
 import { pass, fail, warn, info, cancelAndExit } from "./output.ts";
 import { type Host, createLocalHost, commandExistsOn, isUnitActiveOn, readSecrets } from "./host.ts";
@@ -535,10 +535,12 @@ async function configureEnv(
   // conservatively assume all secrets exist. Re-prompting for secrets the
   // user chose not to unlock would be worse than skipping a truly missing one.
   const secretsOnDisk = new Set<string>();
+  let secretsLocked = false;
   if (secretKeys.length > 0) {
     const sr = await readSecrets(host, SECRETS_DIR, secretKeys, "Read existing secrets");
     existingSecrets = sr.secrets;
     if (sr.skipped || sr.permissionDenied) {
+      secretsLocked = true;
       for (const key of secretKeys) secretsOnDisk.add(key);
     } else {
       for (const key of Object.keys(sr.secrets)) secretsOnDisk.add(key);
@@ -570,37 +572,27 @@ async function configureEnv(
 
   const isInstalled = !!(await readManifest(host)).components[component];
 
-  // If the component is already installed and has existing config,
-  // offer to skip re-entering already-configured variables
   if (isInstalled && hasExistingConfig) {
     if (missingRequired.length === 0) {
-      // All config variables are already set, offer to keep current configuration
       const action = await p.select({
         message: "All configuration variables are already set.",
         options: [
           { value: "skip", label: "Keep current configuration" },
-          { value: "reconfigure", label: "Reconfigure all variables" },
+          { value: "edit", label: "Edit configuration" },
         ],
       });
       if (p.isCancel(action)) cancelAndExit();
       if (action === "skip") return useExisting();
+      const result = await menuEditEnv(schema, existing, { secretsLocked });
+      return result ?? useExisting();
     } else {
-      // Some new variables need to be configured, offer to skip the rest
-      const alreadySetCount = fields.filter((f) => existing[f.key] !== undefined || secretsOnDisk.has(f.key)).length;
-      const action = await p.select({
-        message: `${alreadySetCount} of ${fields.length} variables are already configured. ${missingRequired.length} new variable(s) need to be set.`,
-        options: [
-          { value: "new-only", label: "Only configure new variables" },
-          { value: "reconfigure", label: "Reconfigure all variables" },
-        ],
-      });
-      if (p.isCancel(action)) cancelAndExit();
-      if (action === "new-only") {
-        const skipKeys = new Set(
-          fields.filter((f) => existing[f.key] !== undefined || secretsOnDisk.has(f.key)).map((f) => f.key),
-        );
-        return promptForEnv(component, schema, existing, skipKeys);
-      }
+      p.log.info(
+        `${missingRequired.length} new variable(s) need to be set. Edit any other values too if you like.`,
+      );
+      const newKeys = new Set(missingRequired.map((f) => f.key));
+      const result = await menuEditEnv(schema, existing, { newKeys, secretsLocked });
+      if (result === null) cancelAndExit();
+      return result;
     }
   } else if (hasExistingConfig && missingRequired.length === 0) {
     // Not in manifest but has existing config, preserve original behavior

--- a/packages/xinity-cli/src/lib/local-build.ts
+++ b/packages/xinity-cli/src/lib/local-build.ts
@@ -2,7 +2,7 @@
  * Build a component binary from a local monorepo checkout and package it
  * as a zip archive ready for installation via installBinary().
  */
-import { resolve, join } from "path";
+import { resolve, join, dirname, basename } from "path";
 import { existsSync } from "fs";
 import { tmpdir } from "os";
 import { $ } from "bun";
@@ -101,28 +101,26 @@ export async function buildLocalArtifact(
 
   spinner.stop(`Built ${binName}`);
 
-  // Package into zip (matches the format installBinary() expects)
-  const tmpZip = join(tmpdir(), `xinity-local-${component}-${Date.now()}.zip`);
-  const zipSpinner = p.spinner();
-  zipSpinner.start("Packaging...");
+  const tmpArchive = join(tmpdir(), `xinity-local-${component}-${Date.now()}.tar.gz`);
+  const packageSpinner = p.spinner();
+  packageSpinner.start("Packaging...");
 
-  const zipResult = await $`zip -j ${tmpZip} ${binPath}`.nothrow().quiet();
-  if (zipResult.exitCode !== 0) {
-    zipSpinner.stop("Packaging failed");
-    fail("Zip", zipResult.stderr.toString().trim());
+  const tarResult = await $`tar -czf ${tmpArchive} -C ${dirname(binPath)} ${basename(binPath)}`.nothrow().quiet();
+  if (tarResult.exitCode !== 0) {
+    packageSpinner.stop("Packaging failed");
+    fail("Tar", tarResult.stderr.toString().trim());
     return null;
   }
-  zipSpinner.stop("Packaged");
+  packageSpinner.stop("Packaged");
 
-  // Compute SHA256 of the zip
   const hasher = new Bun.CryptoHasher("sha256");
-  const zipBytes = await Bun.file(tmpZip).arrayBuffer();
-  hasher.update(zipBytes);
+  const archiveBytes = await Bun.file(tmpArchive).arrayBuffer();
+  hasher.update(archiveBytes);
   const sha256 = hasher.digest("hex");
 
   const version = await readVersion(absRepoPath);
   const versionString = `local-${version}`;
 
   pass("Local build", `${component} ${versionString} (${targetArch})`);
-  return { archivePath: tmpZip, version: versionString, sha256 };
+  return { archivePath: tmpArchive, version: versionString, sha256 };
 }

--- a/packages/xinity-cli/src/lib/migrator.ts
+++ b/packages/xinity-cli/src/lib/migrator.ts
@@ -14,7 +14,7 @@ import { migrate } from "drizzle-orm/postgres-js/migrator";
 import * as p from "./clack.ts";
 import pc from "picocolors";
 
-import { fetchRelease, getAssetName, type Release } from "./github.ts";
+import { fetchRelease, pickReleaseAsset, type Release } from "./github.ts";
 import { downloadAndVerify } from "./installer.ts";
 import { parseEnvString } from "./env-file.ts";
 import { fail, pass, info, warn } from "./output.ts";
@@ -221,7 +221,7 @@ export async function runMigrations(opts: {
   }
 
   // 3. Download & verify
-  const assetName = getAssetName("db");
+  const assetName = pickReleaseAsset(release, "db");
   const tmpDir = join(tmpdir(), `xinity-db-migrate-${Date.now()}`);
   mkdirSync(tmpDir, { recursive: true });
 

--- a/packages/xinity-cli/src/lib/remote-probe.ts
+++ b/packages/xinity-cli/src/lib/remote-probe.ts
@@ -31,7 +31,8 @@ export async function collectRemoteState(
 ): Promise<RemoteState> {
   const filesToCheck: string[] = [];
   const filesToRead: string[] = [];
-  const commandsToCheck: string[] = ["systemctl", "weed", "ollama", "docker", "nvidia-smi", "unzip", "curl"];
+  // TODO drop unzip on v1.0.0
+  const commandsToCheck: string[] = ["systemctl", "weed", "ollama", "docker", "nvidia-smi", "tar", "unzip", "curl"];
   const unitsToCheck: string[] = ["xinity-ai-seaweedfs.service", "ollama.service", "ollama"];
 
   // SeaweedFS paths

--- a/packages/xinity-cli/src/lib/service.ts
+++ b/packages/xinity-cli/src/lib/service.ts
@@ -14,6 +14,13 @@ import { unitName } from "./systemd.ts";
 import { pass, fail, info } from "./output.ts";
 import { type Host, createLocalHost, isUnitActiveOn, getUnitStatusOn } from "./host.ts";
 
+function applyEnvDerivations(component: Component, config: Record<string, string>): Record<string, string> {
+  if (component === "dashboard" && config.ORIGIN) {
+    return { ...config, HTTP_OVERRIDE_ORIGIN: config.ORIGIN };
+  }
+  return config;
+}
+
 /** Write component env config and secret files to disk via host elevation. */
 export async function writeEnvConfig(
   component: Component,
@@ -22,7 +29,7 @@ export async function writeEnvConfig(
   host: Host = createLocalHost(),
 ): Promise<boolean> {
   // Write config env file
-  const envContent = serializeEnvFile(config);
+  const envContent = serializeEnvFile(applyEnvDerivations(component, config));
   const envPath = `${ENV_DIR}/${component}.env`;
   let result = await host.withElevation(
     `mkdir -p ${ENV_DIR} && cat > ${envPath} << 'ENVEOF'\n${envContent}ENVEOF\nchmod 644 ${envPath}`,

--- a/packages/xinity-cli/tests/unit/github.test.ts
+++ b/packages/xinity-cli/tests/unit/github.test.ts
@@ -1,69 +1,78 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
-import { getAssetName, verifySha256 } from "../../src/lib/github.ts";
+import { pickReleaseAsset, verifySha256, type Release } from "../../src/lib/github.ts";
 import { createTempDir, type TempDir } from "../helpers/temp-config.ts";
 
+function makeRelease(assetNames: string[], tagName = "v0.1.0"): Release {
+  return {
+    tagName,
+    name: tagName,
+    assets: assetNames.map((name) => ({
+      name,
+      apiUrl: `https://api/${name}`,
+      browserDownloadUrl: `https://browser/${name}`,
+      size: 0,
+    })),
+  };
+}
+
 describe("github", () => {
-  describe("getAssetName", () => {
-    test("returns platform-specific zip for dashboard", () => {
-      const name = getAssetName("dashboard");
-      expect(name).toMatch(/^xinity-ai-dashboard-linux-(x64|arm64)\.zip$/);
+  describe("pickReleaseAsset", () => {
+    test("prefers tar.gz when both formats are present", () => {
+      const release = makeRelease([
+        "xinity-ai-gateway-linux-x64.zip",
+        "xinity-ai-gateway-linux-x64.tar.gz",
+      ]);
+      expect(pickReleaseAsset(release, "gateway", "x64")).toBe("xinity-ai-gateway-linux-x64.tar.gz");
     });
 
-    test("returns tar.gz for db migrations", () => {
-      expect(getAssetName("db")).toBe("db-migrations.tar.gz");
+    test("falls back to zip for pre-1.0.0 releases", () => {
+      const release = makeRelease(["xinity-ai-gateway-linux-x64.zip"]);
+      expect(pickReleaseAsset(release, "gateway", "x64")).toBe("xinity-ai-gateway-linux-x64.zip");
     });
 
-    test("returns platform-specific zip for gateway", () => {
-      const name = getAssetName("gateway");
-      expect(name).toMatch(/^xinity-ai-gateway-linux-(x64|arm64)\.zip$/);
+    test("picks tar.gz when only tar.gz is present", () => {
+      const release = makeRelease(["xinity-ai-gateway-linux-arm64.tar.gz"]);
+      expect(pickReleaseAsset(release, "gateway", "arm64")).toBe("xinity-ai-gateway-linux-arm64.tar.gz");
     });
 
-    test("returns platform-specific zip for daemon", () => {
-      const name = getAssetName("daemon");
-      expect(name).toMatch(/^xinity-ai-daemon-linux-(x64|arm64)\.zip$/);
+    test("throws when neither format is present", () => {
+      const release = makeRelease(["unrelated.txt"], "v0.5.0");
+      expect(() => pickReleaseAsset(release, "gateway", "x64")).toThrow(/v0\.5\.0/);
     });
 
-    test("returns platform-specific zip for cli", () => {
-      const name = getAssetName("cli");
-      expect(name).toMatch(/^xinity-cli-linux-(x64|arm64)\.zip$/);
+    test("returns db-migrations.tar.gz for db", () => {
+      const release = makeRelease(["db-migrations.tar.gz"]);
+      expect(pickReleaseAsset(release, "db")).toBe("db-migrations.tar.gz");
+      expect(pickReleaseAsset(release, "db", "arm64")).toBe("db-migrations.tar.gz");
     });
 
-    test("uses correct architecture suffix", () => {
-      const name = getAssetName("gateway");
-      const expectedArch = process.arch === "arm64" ? "arm64" : "x64";
-      expect(name).toContain(expectedArch);
+    test("uses correct prefix per component", () => {
+      const release = makeRelease([
+        "xinity-cli-linux-x64.zip",
+        "xinity-infoserver-linux-x64.zip",
+        "xinity-ai-daemon-linux-x64.zip",
+        "xinity-ai-dashboard-linux-x64.zip",
+      ]);
+      expect(pickReleaseAsset(release, "cli", "x64")).toBe("xinity-cli-linux-x64.zip");
+      expect(pickReleaseAsset(release, "infoserver", "x64")).toBe("xinity-infoserver-linux-x64.zip");
+      expect(pickReleaseAsset(release, "daemon", "x64")).toBe("xinity-ai-daemon-linux-x64.zip");
+      expect(pickReleaseAsset(release, "dashboard", "x64")).toBe("xinity-ai-dashboard-linux-x64.zip");
     });
 
-    test("dashboard asset name is architecture-specific", () => {
-      const name = getAssetName("dashboard");
-      const expectedArch = process.arch === "arm64" ? "arm64" : "x64";
-      expect(name).toContain(expectedArch);
+    test("only 'arm64' maps to arm64; everything else becomes x64", () => {
+      const release = makeRelease([
+        "xinity-ai-gateway-linux-x64.tar.gz",
+        "xinity-ai-gateway-linux-arm64.tar.gz",
+      ]);
+      expect(pickReleaseAsset(release, "gateway", "x86_64")).toBe("xinity-ai-gateway-linux-x64.tar.gz");
+      expect(pickReleaseAsset(release, "gateway", "aarch64")).toBe("xinity-ai-gateway-linux-x64.tar.gz");
+      expect(pickReleaseAsset(release, "gateway", "arm64")).toBe("xinity-ai-gateway-linux-arm64.tar.gz");
     });
 
-    test("db asset name is architecture-independent", () => {
-      expect(getAssetName("db")).not.toContain("x64");
-      expect(getAssetName("db")).not.toContain("arm64");
-    });
-
-    test("uses explicit arch parameter when provided", () => {
-      expect(getAssetName("gateway", "arm64")).toBe("xinity-ai-gateway-linux-arm64.zip");
-      expect(getAssetName("gateway", "x64")).toBe("xinity-ai-gateway-linux-x64.zip");
-      expect(getAssetName("daemon", "arm64")).toBe("xinity-ai-daemon-linux-arm64.zip");
-      expect(getAssetName("cli", "arm64")).toBe("xinity-cli-linux-arm64.zip");
-      expect(getAssetName("infoserver", "x64")).toBe("xinity-infoserver-linux-x64.zip");
-    });
-
-    test("maps non-standard arch names correctly", () => {
-      // aarch64 (uname -m output) should map to arm64
-      expect(getAssetName("gateway", "aarch64")).not.toContain("arm64");
-      // Only "arm64" is treated as arm64; everything else becomes x64
-      expect(getAssetName("gateway", "x86_64")).toBe("xinity-ai-gateway-linux-x64.zip");
-    });
-
-    test("dashboard respects explicit arch parameter, db does not", () => {
-      expect(getAssetName("dashboard", "arm64")).toBe("xinity-ai-dashboard-linux-arm64.zip");
-      expect(getAssetName("dashboard", "x64")).toBe("xinity-ai-dashboard-linux-x64.zip");
-      expect(getAssetName("db", "arm64")).toBe("db-migrations.tar.gz");
+    test("uses process.arch when arch is omitted", () => {
+      const expected = process.arch === "arm64" ? "arm64" : "x64";
+      const release = makeRelease([`xinity-ai-gateway-linux-${expected}.tar.gz`]);
+      expect(pickReleaseAsset(release, "gateway")).toBe(`xinity-ai-gateway-linux-${expected}.tar.gz`);
     });
   });
 

--- a/packages/xinity-infoserver/node-compat.test.ts
+++ b/packages/xinity-infoserver/node-compat.test.ts
@@ -49,10 +49,42 @@ describe("checkNodeCompatibility", () => {
     )).toBeNull();
   });
 
-  test("skips version check when node has no version info (fail-open)", () => {
+  test("skips version check when node has no version info (fail-open by default)", () => {
     expect(checkNodeCompatibility(
       makeNode({ driverVersions: {} }),
       makeReq({ minVersion: "0.19.1" }),
+    )).toBeNull();
+  });
+
+  test("returns version_unknown when requireKnownVersion is true and node has no version", () => {
+    expect(checkNodeCompatibility(
+      makeNode({ driverVersions: {} }),
+      makeReq({ minVersion: "0.19.1" }),
+      { requireKnownVersion: true },
+    )).toBe("version_unknown");
+  });
+
+  test("requireKnownVersion does not affect nodes whose reported version is sufficient", () => {
+    expect(checkNodeCompatibility(
+      makeNode({ driverVersions: { vllm: "0.20.0" } }),
+      makeReq({ minVersion: "0.19.1" }),
+      { requireKnownVersion: true },
+    )).toBeNull();
+  });
+
+  test("requireKnownVersion still returns version_too_old when reported version is too low", () => {
+    expect(checkNodeCompatibility(
+      makeNode({ driverVersions: { vllm: "0.18.0" } }),
+      makeReq({ minVersion: "0.19.1" }),
+      { requireKnownVersion: true },
+    )).toBe("version_too_old");
+  });
+
+  test("requireKnownVersion is ignored when the model has no minVersion", () => {
+    expect(checkNodeCompatibility(
+      makeNode({ driverVersions: {} }),
+      makeReq(),
+      { requireKnownVersion: true },
     )).toBeNull();
   });
 

--- a/packages/xinity-infoserver/node-compat.ts
+++ b/packages/xinity-infoserver/node-compat.ts
@@ -49,9 +49,10 @@ export type IncompatibilityReason =
 export function checkNodeCompatibility(
   node: NodeCapability,
   req: ModelNodeRequirements,
+  options: { requireKnownVersion?: boolean } = {},
 ): IncompatibilityReason | null {
-  // TODO v1.0.0 This setting will be switched to true
-  const requireKnownVersion = false;
+  // TODO v1.0.0 default this to true
+  const requireKnownVersion = options.requireKnownVersion ?? false;
 
   if (!node.drivers.includes(req.driver)) return "missing_driver";
 

--- a/packages/xinity-infoserver/node-compat.ts
+++ b/packages/xinity-infoserver/node-compat.ts
@@ -31,6 +31,7 @@ export type ModelNodeRequirements = {
 export type IncompatibilityReason =
   | "missing_driver"
   | "version_too_old"
+  | "version_unknown"
   | "wrong_platform"
   | "insufficient_capacity";
 
@@ -42,8 +43,6 @@ export type IncompatibilityReason =
  * This lets callers separate "structurally incompatible" from "just no capacity"
  * for greedy allocation loops.
  *
- * Fail-open for driverVersions: nodes that haven't reported a version
- * are not excluded (may be mid-upgrade).
  * Fail-closed for gpus: if a model requires specific GPU platforms,
  * nodes with no GPUs or wrong vendors are excluded.
  */
@@ -51,11 +50,16 @@ export function checkNodeCompatibility(
   node: NodeCapability,
   req: ModelNodeRequirements,
 ): IncompatibilityReason | null {
+  // TODO v1.0.0 This setting will be switched to true
+  const requireKnownVersion = false;
+
   if (!node.drivers.includes(req.driver)) return "missing_driver";
 
   if (req.minVersion) {
     const nodeVersion = node.driverVersions[req.driver];
-    if (nodeVersion && !satisfiesMinVersion(nodeVersion, req.minVersion)) {
+    if (!nodeVersion) {
+      if (requireKnownVersion) return "version_unknown";
+    } else if (!satisfiesMinVersion(nodeVersion, req.minVersion)) {
       return "version_too_old";
     }
   }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -70,7 +70,8 @@ case "$ARCH" in
   *)        fail "Unsupported architecture: $ARCH" ;;
 esac
 
-ASSET_NAME="xinity-cli-${SUFFIX}.zip"
+ASSET_PREFIX="xinity-cli-${SUFFIX}"
+ASSET_NAME=""
 
 # ── Auth (for private repos) ────────────────────────────────────────────────
 
@@ -111,6 +112,14 @@ RELEASE_JSON="$(curl_auth -H "Accept: application/vnd.github+json" "$RELEASE_URL
 
 TAG="$(printf '%s' "$RELEASE_JSON" | grep '"tag_name"' | head -1 | sed 's/.*: *"\([^"]*\)".*/\1/')"
 [[ -n "$TAG" ]] || fail "Could not parse release tag"
+
+if printf '%s' "$RELEASE_JSON" | grep -q "\"name\": *\"${ASSET_PREFIX}.tar.gz\""; then
+  ASSET_NAME="${ASSET_PREFIX}.tar.gz"
+elif printf '%s' "$RELEASE_JSON" | grep -q "\"name\": *\"${ASSET_PREFIX}.zip\""; then
+  ASSET_NAME="${ASSET_PREFIX}.zip"
+else
+  fail "Neither ${ASSET_PREFIX}.tar.gz nor ${ASSET_PREFIX}.zip found in release ${TAG}"
+fi
 
 info "Installing xinity CLI ${TAG} (${SUFFIX})"
 
@@ -167,10 +176,22 @@ fi
 
 # ── Extract and install ─────────────────────────────────────────────────────
 
-command -v unzip &>/dev/null || fail "'unzip' is required but not found"
+mkdir -p "${TMP_DIR}/extracted"
+case "$ASSET_NAME" in
+  *.tar.gz)
+    command -v tar &>/dev/null || fail "'tar' is required but not found"
+    tar -xzf "${TMP_DIR}/${ASSET_NAME}" -C "${TMP_DIR}/extracted"
+    ;;
+  *.zip)
+    command -v unzip &>/dev/null || fail "'unzip' is required but not found"
+    unzip -o "${TMP_DIR}/${ASSET_NAME}" -d "${TMP_DIR}/extracted" >/dev/null
+    ;;
+  *)
+    fail "Unknown archive format: ${ASSET_NAME}"
+    ;;
+esac
 
 mkdir -p "$INSTALL_DIR"
-unzip -o "${TMP_DIR}/${ASSET_NAME}" -d "${TMP_DIR}/extracted" >/dev/null
 mv "${TMP_DIR}/extracted/xinity" "${INSTALL_DIR}/xinity"
 chmod +x "${INSTALL_DIR}/xinity"
 


### PR DESCRIPTION
## Description

Security hardening pass + assorted correctness fixes across the stack.

- **Gateway**: inflight auth dedup for API key validation, tighter error handling on chat/responses + MCP tools, request-body size cap
- **Dashboard**: cross-org access checks, invite/membership validation, license-mismatch handling, data page Svelte fix, external trace-id schema
- **Daemon / Infoserver**: vLLM version detection, node-compat arg + version check fixes
- **CLI**: secure config file permissions, HTTP_OVERRIDE_ORIGIN now mirrors ORIGIN, env-config step moved into `configure`, TLS flags moved into expert settings, dispatcher prepared for tar.gz packaging at v1.0.0 (zip still active)

## Type of change

Bug fix

## Testing

- `bun test` (unit + e2e) green locally
- New e2e: cross-org access, data-page regression, between-org edits
- Expanded license + node-compat unit coverage

## Checklist

- [x] Tests pass locally (`bun test`), or no testable code was changed
- [x] New or changed behavior is covered by tests, or this change does not require tests
- [x] Documentation is updated, or no user-facing behavior or configuration was changed
- [x] There are no breaking changes, or they are marked with `!` in the commit type and described above
- [x] No security-sensitive changes (authentication, credentials, input handling), or they have been reviewed
- [x] No new dependencies were added, or they have been reviewed for license and maintenance status