### PR TITLE
docs: extended gateway documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Point any OpenAI SDK or tool at your gateway:
 from openai import OpenAI
 
 client = OpenAI(
-    base_url="https://your-xinity-instance/v1",
+    base_url="https://your-dashboard/v1",
     api_key="sk_..."
 )
 
@@ -253,6 +253,8 @@ response = client.chat.completions.create(
     messages=[{"role": "user", "content": "Summarize this contract."}]
 )
 ```
+
+The gateway serves a live, schema-derived API reference at `https://your-xinity-gateway/docs` (rendered with Scalar) and the raw OpenAPI document at `https://your-xinity-gateway-instance/openapi.json`. The dashboard's Documentation page links to it as **Live OpenAPI Spec**.
 
 ### Dashboard UI
 

--- a/packages/common-db/src/index.ts
+++ b/packages/common-db/src/index.ts
@@ -13,3 +13,4 @@ export * from "./migrations";
 export * from "./connection";
 export { drizzle } from "drizzle-orm/postgres-js";
 export * from "drizzle-orm";
+export type { PgColumn, PgTable } from "drizzle-orm/pg-core";

--- a/packages/common-env/src/index.ts
+++ b/packages/common-env/src/index.ts
@@ -120,3 +120,16 @@ export function getTlsConfig(env: { XINITY_TLS_CERT?: string; XINITY_TLS_KEY?: s
   if (!hasCert) return undefined;
   return { cert: env.XINITY_TLS_CERT!, key: env.XINITY_TLS_KEY! };
 }
+
+/** POSIX-safe single-quote shell escape. Strings made of only `[A-Za-z0-9@%+=:,./_-]` are returned as-is. */
+export function quoteShellArg(s: string): string {
+  if (/^[A-Za-z0-9@%+=:,./_-]+$/.test(s)) {
+    return s;
+  }
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+/** Join an argv array into a single shell-safe command string. */
+export function quoteShellArgv(argv: string[]): string {
+  return argv.map(quoteShellArg).join(" ");
+}

--- a/packages/xinity-ai-daemon/README.md
+++ b/packages/xinity-ai-daemon/README.md
@@ -21,7 +21,7 @@ The installation can be started like this:
 curl -fsSL https://ollama.com/install.sh | sh
 systemctl edit ollama
 ```
-Enter the following in the service override that opened due to `syst4emctl edit ollama`
+Enter the following in the service override that opened due to `systemctl edit ollama`
 ```ini
 [Service]
 Environment="OLLAMA_HOST=0.0.0.0"

--- a/packages/xinity-ai-daemon/src/scripts/print-vllm-command.ts
+++ b/packages/xinity-ai-daemon/src/scripts/print-vllm-command.ts
@@ -9,6 +9,7 @@
 
 import { parseArgs } from "node:util";
 import { z } from "zod";
+import { quoteShellArgv } from "common-env";
 import {
   ModelFileDefinitionSchema,
   resolveDriverForProviderModel,
@@ -129,15 +130,6 @@ function findModel(
   }
   const known = Object.keys(parsed.models).join(", ");
   die(`model "${name}" not found in model file (looked at public specifiers and providers.vllm). Known: ${known}`);
-}
-
-function quoteShellArg(s: string): string {
-  if (/^[A-Za-z0-9@%+=:,./_-]+$/.test(s)) return s;
-  return `'${s.replace(/'/g, `'\\''`)}'`;
-}
-
-function quoteShellArgv(argv: string[]): string {
-  return argv.map(quoteShellArg).join(" ");
 }
 
 function buildVllmInstanceConfig(

--- a/packages/xinity-ai-daemon/tsconfig.json
+++ b/packages/xinity-ai-daemon/tsconfig.json
@@ -9,6 +9,7 @@
     "types": ["bun"],
     "paths": {
       "common-db": ["../common-db/src/"],
+      "common-env": ["../common-env/src/"],
       "common-log": ["../common-log/src/"]
     }
   }

--- a/packages/xinity-ai-dashboard/README.md
+++ b/packages/xinity-ai-dashboard/README.md
@@ -111,4 +111,4 @@ This package is licensed under the **Elastic License 2.0 (ELv2)**, which differs
 ## Notes
 
 - Mailhog UI runs at `http://localhost:8025` when the dev Docker stack is up.
-- `MODEL_CONFIG_URL` points at `http://localhost:8090/models/v1.yaml` in the dev Docker stack.
+- `INFOSERVER_URL` points at `http://localhost:8393` for a locally-run infoserver (default in `example.env`).

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/docs/+page.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/docs/+page.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-  import { Rocket, BookOpen, Code, Layers, ShieldCheck, Cpu, Users, Tag, Plug, Wrench } from "@lucide/svelte";
+  import { Rocket, BookOpen, Code, Layers, ShieldCheck, Cpu, Users, Tag, Plug, Wrench, Globe } from "@lucide/svelte";
+  import { getClientEnv } from "$lib/clientEnv";
+
+  const { GATEWAY_URL } = getClientEnv();
+  const gatewayDocsUrl = `${GATEWAY_URL.replace(/\/$/, "")}/docs`;
 </script>
 
 <svelte:head>
@@ -55,6 +59,23 @@
       </div>
       <p class="text-sm text-gray-600">
         Complete reference for all endpoints, parameters, headers, and error codes.
+      </p>
+    </a>
+
+    <a
+      href={gatewayDocsUrl}
+      target="_blank"
+      rel="noopener"
+      class="group block p-6 bg-white border rounded-lg shadow-sm hover:shadow-md transition"
+    >
+      <div class="flex items-center gap-3 mb-3">
+        <div class="p-2 rounded-lg bg-xinity-purple/10 text-xinity-purple group-hover:bg-xinity-purple/15 transition-colors">
+          <Globe class="w-5 h-5" />
+        </div>
+        <h2 class="text-lg font-semibold group-hover:text-xinity-purple transition-colors">Live OpenAPI Spec</h2>
+      </div>
+      <p class="text-sm text-gray-600">
+        Interactive, always-up-to-date reference served directly by the gateway at <code>/docs</code>. Spec available at <code>/openapi.json</code>.
       </p>
     </a>
 

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/TestChatModal.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/TestChatModal.svelte
@@ -1,17 +1,16 @@
 <script lang="ts">
-  import Modal from "$lib/components/Modal.svelte";
   import { Button } from "$lib/components/ui/button";
   import { Label } from "$lib/components/ui/label";
   import { Badge } from "$lib/components/ui/badge";
   import { Checkbox } from "$lib/components/ui/checkbox";
   import * as Select from "$lib/components/ui/select";
-  import * as Alert from "$lib/components/ui/alert";
-  import { X, Send, RotateCcw } from "@lucide/svelte";
+  import { Send, RotateCcw } from "@lucide/svelte";
 
   import type { ApplicationDto } from "$lib/orpc/dtos/application.dto";
   import type { DeploymentDefinition } from "./+page.server";
   import { browserLogger } from "$lib/browserLogging";
-  import TestApiKeySection from "./TestApiKeySection.svelte";
+  import TestModal from "./TestModal.svelte";
+  import { formatErrorBody } from "./testHelpers";
 
   type ChatMessage = { role: "user" | "assistant"; content: string; reasoning?: string };
 
@@ -32,11 +31,9 @@
 
   let apiKey = $state("");
 
-  // Call settings
   let storeCall = $state(false);
   let selectedApplicationId = $state<string>(NO_APPLICATION);
 
-  // Chat state
   let messages = $state<ChatMessage[]>([]);
   let inputValue = $state(DEFAULT_PROMPT);
   let sending = $state(false);
@@ -54,26 +51,14 @@
     !sending && apiKey.trim().length > 0 && inputValue.trim().length > 0,
   );
 
-  // Re-scroll on every streamed chunk; depending on total content length
-  // (rather than messages.length) so chunks that don't change message count
-  // also fire the effect.
+  // Re-scroll on every streamed chunk; track total content length so chunks
+  // that don't change message count still fire the effect.
   const totalContentLen = $derived(messages.reduce((n, m) => n + m.content.length + (m.reasoning?.length ?? 0), 0));
   $effect(() => {
     void totalContentLen;
     if (chatScroll && messages.length > 0) {
       chatScroll.scrollTop = chatScroll.scrollHeight;
     }
-  });
-
-  // Fresh-open reset. Triggers on every false->true transition so reopening
-  // after an error always starts clean.
-  let wasOpen = $state(false);
-  $effect(() => {
-    if (open && !wasOpen) {
-      resetState();
-      focusInput();
-    }
-    wasOpen = open;
   });
 
   function focusInput() {
@@ -100,11 +85,22 @@
     selectedApplicationId = NO_APPLICATION;
   }
 
+  function handleOpen() {
+    resetState();
+    focusInput();
+  }
+
+  function handleClose() {
+    inflight?.abort();
+    close();
+  }
+
   async function handleSend() {
-    if (!canSend || !deployment) return;
+    if (!canSend || !deployment) {
+      return;
+    }
     const userText = inputValue.trim();
     inputValue = "";
-    // Append the user message + an empty assistant placeholder we stream into.
     messages = [
       ...messages,
       { role: "user", content: userText },
@@ -117,8 +113,6 @@
     const ctrl = new AbortController();
     inflight = ctrl;
 
-    // X-Application only matters when the call is being stored; skip it
-    // otherwise so behavior matches the disabled selector.
     const applicationName = storeCall ? selectedApplication?.name ?? null : null;
 
     try {
@@ -148,17 +142,20 @@
 
       await consumeSseStream(res.body, assistantIdx);
     } catch (err) {
-      // The abort path (close/reset/new send) is intentional, not a real error.
-      if (ctrl.signal.aborted) return;
+      if (ctrl.signal.aborted) {
+        return;
+      }
       browserLogger.warn({ err }, "Test chat request failed");
       const detail = err instanceof Error ? err.message : "Network error";
       appendToAssistant(assistantIdx, `Error: ${detail}`);
     } finally {
-      if (inflight === ctrl) inflight = null;
+      if (inflight === ctrl) {
+        inflight = null;
+      }
       sending = false;
-      // Skip refocus on abort: the modal is closing or the chat was reset, and
-      // grabbing focus mid-teardown would steal it from whatever is replacing us.
-      if (!ctrl.signal.aborted) focusInput();
+      if (!ctrl.signal.aborted) {
+        focusInput();
+      }
     }
   }
 
@@ -168,20 +165,25 @@
     let buffer = "";
     for (;;) {
       const { value, done } = await reader.read();
-      if (done) return;
+      if (done) {
+        return;
+      }
       buffer += decoder.decode(value, { stream: true });
 
       let nlIdx: number;
       while ((nlIdx = buffer.indexOf("\n")) >= 0) {
         const line = buffer.slice(0, nlIdx).replace(/\r$/, "").trim();
         buffer = buffer.slice(nlIdx + 1);
-        if (!line.startsWith("data:")) continue;
+        if (!line.startsWith("data:")) {
+          continue;
+        }
         const payload = line.slice(5).trim();
-        if (payload === "[DONE]") return;
+        if (payload === "[DONE]") {
+          return;
+        }
         try {
+          // reasoning_content (DeepSeek/QwQ/vLLM) and reasoning (OpenRouter) both used in the wild.
           const delta = JSON.parse(payload)?.choices?.[0]?.delta;
-          // Different backends emit thinking under different field names;
-          // accept both reasoning_content (DeepSeek/QwQ/vLLM) and reasoning (OpenRouter, etc.).
           const reasoning = delta?.reasoning_content ?? delta?.reasoning;
           if (typeof reasoning === "string" && reasoning.length > 0) {
             appendToAssistant(assistantIdx, reasoning, "reasoning");
@@ -197,163 +199,134 @@
     }
   }
 
-  async function formatErrorBody(res: Response): Promise<string> {
-    const text = await res.text().catch(() => "");
-    try {
-      const parsed = JSON.parse(text);
-      if (parsed?.error?.message) return String(parsed.error.message);
-    } catch {
-      /* fall through to raw text */
-    }
-    return text || `Request failed (${res.status})`;
-  }
-
   function appendToAssistant(idx: number, text: string, channel: "content" | "reasoning" = "content") {
     messages = messages.map((m, i) => {
-      if (i !== idx) return m;
+      if (i !== idx) {
+        return m;
+      }
       if (channel === "reasoning") {
         return { ...m, reasoning: (m.reasoning ?? "") + text };
       }
       return { ...m, content: m.content + text };
     });
   }
-
-  function handleClose() {
-    inflight?.abort();
-    close();
-  }
 </script>
 
-<Modal {open} onClose={handleClose} class="z-40">
-  {#if open && deployment}
-    <div class="bg-card rounded-xl shadow-2xl w-full max-w-3xl min-w-[min(48rem,90vw)] max-h-[90vh] flex flex-col">
-      <header class="p-6 border-b flex justify-between items-center">
-        <div>
-          <h2 class="text-2xl font-semibold">Test Chat Model</h2>
-          <p class="text-sm text-muted-foreground mt-1">
-            <span class="font-mono">{deployment.publicSpecifier}</span>
-          </p>
-        </div>
-        <Button variant="ghost" size="icon" onclick={handleClose} aria-label="Close test modal">
-          <X class="w-5 h-5" />
-        </Button>
-      </header>
+<TestModal
+  bind:open
+  {deployment}
+  title="Test Chat Model"
+  bind:apiKey
+  apiKeyHint={'Paste an API key or click "Generate temporary key" to start chatting.'}
+  onClose={handleClose}
+  onOpen={handleOpen}
+>
+  {#snippet body()}
+    <section class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      <div class="space-y-2">
+        <Label class="text-sm font-semibold">Logging</Label>
+        <label class="flex items-center gap-2 h-9 cursor-pointer select-none">
+          <Checkbox
+            checked={storeCall}
+            onCheckedChange={(checked) => (storeCall = checked === true)}
+          />
+          <span class="text-sm">Store calls</span>
+        </label>
+      </div>
+      <div class="space-y-2">
+        <Label for="testApplication" class="text-sm font-semibold {storeCall ? '' : 'text-muted-foreground'}">
+          Application
+        </Label>
+        <Select.Root type="single" bind:value={selectedApplicationId} disabled={!storeCall}>
+          <Select.Trigger id="testApplication" class="w-full">
+            {selectedApplication?.name ?? "None (default for key)"}
+          </Select.Trigger>
+          <Select.Content portalProps={{ disabled: true }}>
+            <Select.Item value={NO_APPLICATION} label="None (default for key)" />
+            {#each applications as app (app.id)}
+              <Select.Item value={app.id} label={app.name} />
+            {/each}
+          </Select.Content>
+        </Select.Root>
+      </div>
+    </section>
 
-      <main class="p-6 flex-1 overflow-y-auto space-y-5">
-        <TestApiKeySection bind:apiKey deploymentName={deployment.name} />
-
-        <section class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <div class="space-y-2">
-            <Label class="text-sm font-semibold">Logging</Label>
-            <label class="flex items-center gap-2 h-9 cursor-pointer select-none">
-              <Checkbox
-                checked={storeCall}
-                onCheckedChange={(checked) => (storeCall = checked === true)}
-              />
-              <span class="text-sm">Store calls</span>
-            </label>
-          </div>
-          <div class="space-y-2">
-            <Label for="testApplication" class="text-sm font-semibold {storeCall ? '' : 'text-muted-foreground'}">
-              Application
-            </Label>
-            <Select.Root type="single" bind:value={selectedApplicationId} disabled={!storeCall}>
-              <Select.Trigger id="testApplication" class="w-full">
-                {selectedApplication?.name ?? "None (default for key)"}
-              </Select.Trigger>
-              <Select.Content portalProps={{ disabled: true }}>
-                <Select.Item value={NO_APPLICATION} label="None (default for key)" />
-                {#each applications as app (app.id)}
-                  <Select.Item value={app.id} label={app.name} />
-                {/each}
-              </Select.Content>
-            </Select.Root>
-          </div>
-        </section>
-
-        <section class="space-y-3">
-          <div class="flex items-center justify-between">
-            <Label class="text-sm font-semibold">Conversation</Label>
-            <Button
-              variant="ghost"
-              size="sm"
-              onclick={resetChat}
-              disabled={messages.length === 0 && !sending}
-              title="Clear conversation and abort any in-flight request"
-            >
-              <RotateCcw class="w-4 h-4" />
-              Reset chat
-            </Button>
-          </div>
-          <div
-            bind:this={chatScroll}
-            class="h-72 overflow-y-auto rounded-md border bg-background p-3 space-y-3"
-          >
-            {#if messages.length === 0}
-              <p class="text-sm text-muted-foreground text-center py-12">
-                Send a message to start chatting with the model.
-              </p>
-            {:else}
-              {#each messages as msg, i (i)}
-                <div class="flex {msg.role === 'user' ? 'justify-end' : 'justify-start'}">
-                  <div
-                    class="max-w-[80%] rounded-lg px-3 py-2 text-sm whitespace-pre-wrap {msg.role === 'user' ? 'bg-primary text-primary-foreground' : 'bg-muted'}"
-                  >
-                    <div class="text-[10px] uppercase tracking-wider opacity-70 mb-1">
-                      {msg.role}
-                    </div>
-                    {#if msg.reasoning}
-                      <div class="opacity-60 italic border-l-2 border-current/30 pl-2 mb-2 text-xs">
-                        <div class="text-[9px] uppercase tracking-wider not-italic mb-1 opacity-80">Reasoning</div>
-                        {msg.reasoning}
-                      </div>
-                    {/if}
-                    {#if msg.content}
-                      {msg.content}
-                    {:else if sending && i === messages.length - 1 && !msg.reasoning}
-                      <Badge variant="secondary">thinking...</Badge>
-                    {/if}
-                  </div>
-                </div>
-              {/each}
-            {/if}
-          </div>
-        </section>
-
-        {#if !apiKey.trim()}
-          <Alert.Root>
-            <Alert.Description class="text-xs">
-              Paste an API key or click "Generate temporary key" to start chatting.
-            </Alert.Description>
-          </Alert.Root>
-        {/if}
-      </main>
-
-      <footer class="p-4 border-t bg-muted/40 rounded-b-xl">
-        <form
-          onsubmit={(e) => { e.preventDefault(); void handleSend(); }}
-          class="flex items-end gap-2"
+    <section class="space-y-3">
+      <div class="flex items-center justify-between">
+        <Label class="text-sm font-semibold">Conversation</Label>
+        <Button
+          variant="ghost"
+          size="sm"
+          onclick={resetChat}
+          disabled={messages.length === 0 && !sending}
+          title="Clear conversation and abort any in-flight request"
         >
-          <textarea
-            bind:value={inputValue}
-            bind:this={inputEl}
-            placeholder="Type a message..."
-            rows="2"
-            disabled={sending}
-            onkeydown={(e) => {
-              if (e.key === "Enter" && !e.shiftKey) {
-                e.preventDefault();
-                void handleSend();
-              }
-            }}
-            class="flex-1 min-h-15 max-h-40 rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring resize-y"
-          ></textarea>
-          <Button type="submit" disabled={!canSend}>
-            <Send class="w-4 h-4" />
-            Send
-          </Button>
-        </form>
-      </footer>
-    </div>
-  {/if}
-</Modal>
+          <RotateCcw class="w-4 h-4" />
+          Reset chat
+        </Button>
+      </div>
+      <div
+        bind:this={chatScroll}
+        class="h-72 overflow-y-auto rounded-md border bg-background p-3 space-y-3"
+      >
+        {#if messages.length === 0}
+          <p class="text-sm text-muted-foreground text-center py-12">
+            Send a message to start chatting with the model.
+          </p>
+        {:else}
+          {#each messages as msg, i (i)}
+            <div class="flex {msg.role === 'user' ? 'justify-end' : 'justify-start'}">
+              <div
+                class="max-w-[80%] rounded-lg px-3 py-2 text-sm whitespace-pre-wrap {msg.role === 'user' ? 'bg-primary text-primary-foreground' : 'bg-muted'}"
+              >
+                <div class="text-[10px] uppercase tracking-wider opacity-70 mb-1">
+                  {msg.role}
+                </div>
+                {#if msg.reasoning}
+                  <div class="opacity-60 italic border-l-2 border-current/30 pl-2 mb-2 text-xs">
+                    <div class="text-[9px] uppercase tracking-wider not-italic mb-1 opacity-80">Reasoning</div>
+                    {msg.reasoning}
+                  </div>
+                {/if}
+                {#if msg.content}
+                  {msg.content}
+                {:else if sending && i === messages.length - 1 && !msg.reasoning}
+                  <Badge variant="secondary">thinking...</Badge>
+                {/if}
+              </div>
+            </div>
+          {/each}
+        {/if}
+      </div>
+    </section>
+  {/snippet}
+
+  {#snippet footer()}
+    <form
+      onsubmit={(e) => {
+        e.preventDefault();
+        void handleSend();
+      }}
+      class="flex items-end gap-2"
+    >
+      <textarea
+        bind:value={inputValue}
+        bind:this={inputEl}
+        placeholder="Type a message..."
+        rows="2"
+        disabled={sending}
+        onkeydown={(e) => {
+          if (e.key === "Enter" && !e.shiftKey) {
+            e.preventDefault();
+            void handleSend();
+          }
+        }}
+        class="flex-1 min-h-15 max-h-40 rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring resize-y"
+      ></textarea>
+      <Button type="submit" disabled={!canSend}>
+        <Send class="w-4 h-4" />
+        Send
+      </Button>
+    </form>
+  {/snippet}
+</TestModal>

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/TestEmbeddingModal.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/TestEmbeddingModal.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
-  import Modal from "$lib/components/Modal.svelte";
   import { Button } from "$lib/components/ui/button";
   import { Label } from "$lib/components/ui/label";
   import * as Alert from "$lib/components/ui/alert";
-  import { X, Send, Copy, RotateCcw } from "@lucide/svelte";
+  import { Send, Copy, RotateCcw } from "@lucide/svelte";
 
   import type { DeploymentDefinition } from "./+page.server";
   import { browserLogger } from "$lib/browserLogging";
   import { copyToClipboard } from "$lib/copy";
-  import TestApiKeySection from "./TestApiKeySection.svelte";
+  import TestModal from "./TestModal.svelte";
+  import { formatErrorBody } from "./testHelpers";
 
   const DEFAULT_INPUT = "The quick brown fox jumps over the lazy dog.";
   const PREVIEW_HEAD = 6;
@@ -46,38 +46,39 @@
     sending || result !== null || errorMessage !== null || inputText !== DEFAULT_INPUT,
   );
 
-  // Fresh-open reset. Triggers on every false->true transition.
-  let wasOpen = $state(false);
-  $effect(() => {
-    if (open && !wasOpen) {
-      resetState();
-      queueMicrotask(() => inputEl?.focus());
-    }
-    wasOpen = open;
-  });
-
-  function resetState() {
+  function clearOutputs() {
     inflight?.abort();
     inflight = null;
     sending = false;
     inputText = DEFAULT_INPUT;
     result = null;
     errorMessage = null;
+  }
+
+  function resetState() {
+    clearOutputs();
     apiKey = "";
   }
 
   function resetInput() {
-    inflight?.abort();
-    inflight = null;
-    sending = false;
-    inputText = DEFAULT_INPUT;
-    result = null;
-    errorMessage = null;
+    clearOutputs();
     queueMicrotask(() => inputEl?.focus());
   }
 
+  function handleOpen() {
+    resetState();
+    queueMicrotask(() => inputEl?.focus());
+  }
+
+  function handleClose() {
+    inflight?.abort();
+    close();
+  }
+
   async function handleSend() {
-    if (!canSend || !deployment) return;
+    if (!canSend || !deployment) {
+      return;
+    }
     sending = true;
     errorMessage = null;
     result = null;
@@ -117,145 +118,121 @@
         durationMs: Math.round(performance.now() - start),
       };
     } catch (err) {
-      if (ctrl.signal.aborted) return;
+      if (ctrl.signal.aborted) {
+        return;
+      }
       browserLogger.warn({ err }, "Test embedding request failed");
       errorMessage = err instanceof Error ? err.message : "Network error";
     } finally {
-      if (inflight === ctrl) inflight = null;
+      if (inflight === ctrl) {
+        inflight = null;
+      }
       sending = false;
     }
   }
 
-  async function formatErrorBody(res: Response): Promise<string> {
-    const text = await res.text().catch(() => "");
-    try {
-      const parsed = JSON.parse(text);
-      if (parsed?.error?.message) return String(parsed.error.message);
-    } catch {
-      /* fall through to raw text */
-    }
-    return text || `Request failed (${res.status})`;
-  }
-
-  function handleClose() {
-    inflight?.abort();
-    close();
-  }
-
   function copyVector() {
-    if (!result) return;
+    if (!result) {
+      return;
+    }
     copyToClipboard(JSON.stringify(result.embedding));
   }
 
   function previewVector(v: number[]): string {
     const fmt = (n: number) => n.toFixed(4);
-    if (v.length <= PREVIEW_HEAD + PREVIEW_TAIL + 1) return v.map(fmt).join(", ");
+    if (v.length <= PREVIEW_HEAD + PREVIEW_TAIL + 1) {
+      return v.map(fmt).join(", ");
+    }
     const head = v.slice(0, PREVIEW_HEAD).map(fmt).join(", ");
     const tail = v.slice(-PREVIEW_TAIL).map(fmt).join(", ");
     return `${head}, ..., ${tail}`;
   }
 </script>
 
-<Modal {open} onClose={handleClose} class="z-40">
-  {#if open && deployment}
-    <div class="bg-card rounded-xl shadow-2xl w-full max-w-3xl min-w-[min(48rem,90vw)] max-h-[90vh] flex flex-col">
-      <header class="p-6 border-b flex justify-between items-center">
-        <div>
-          <h2 class="text-2xl font-semibold">Test Embedding Model</h2>
-          <p class="text-sm text-muted-foreground mt-1">
-            <span class="font-mono">{deployment.publicSpecifier}</span>
-          </p>
-        </div>
-        <Button variant="ghost" size="icon" onclick={handleClose} aria-label="Close test modal">
-          <X class="w-5 h-5" />
+<TestModal
+  bind:open
+  {deployment}
+  title="Test Embedding Model"
+  bind:apiKey
+  apiKeyHint={'Paste an API key or click "Generate temporary key" to compute an embedding.'}
+  onClose={handleClose}
+  onOpen={handleOpen}
+>
+  {#snippet body()}
+    <section class="space-y-2">
+      <div class="flex items-center justify-between">
+        <Label for="testEmbedInput" class="text-sm font-semibold">Input</Label>
+        <Button
+          variant="ghost"
+          size="sm"
+          onclick={resetInput}
+          disabled={!canReset}
+          title="Clear input and result"
+        >
+          <RotateCcw class="w-4 h-4" />
+          Reset
         </Button>
-      </header>
+      </div>
+      <textarea
+        id="testEmbedInput"
+        bind:value={inputText}
+        bind:this={inputEl}
+        placeholder="Text to embed..."
+        rows="4"
+        disabled={sending}
+        class="w-full min-h-24 rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring resize-y"
+      ></textarea>
+    </section>
 
-      <main class="p-6 flex-1 overflow-y-auto space-y-5">
-        <TestApiKeySection bind:apiKey deploymentName={deployment.name} />
+    {#if errorMessage}
+      <Alert.Root variant="destructive">
+        <Alert.Description>{errorMessage}</Alert.Description>
+      </Alert.Root>
+    {/if}
 
-        <section class="space-y-2">
+    {#if result}
+      <section class="space-y-3">
+        <Label class="text-sm font-semibold">Result</Label>
+        <div class="grid grid-cols-2 sm:grid-cols-4 gap-2">
+          <div class="rounded-md border bg-muted/40 p-3">
+            <div class="text-xs text-muted-foreground">Dimensions</div>
+            <div class="font-mono text-sm">{result.embedding.length}</div>
+          </div>
+          <div class="rounded-md border bg-muted/40 p-3">
+            <div class="text-xs text-muted-foreground">Prompt tokens</div>
+            <div class="font-mono text-sm">{result.promptTokens}</div>
+          </div>
+          <div class="rounded-md border bg-muted/40 p-3">
+            <div class="text-xs text-muted-foreground">Total tokens</div>
+            <div class="font-mono text-sm">{result.totalTokens}</div>
+          </div>
+          <div class="rounded-md border bg-muted/40 p-3">
+            <div class="text-xs text-muted-foreground">Duration</div>
+            <div class="font-mono text-sm">{result.durationMs} ms</div>
+          </div>
+        </div>
+        <div class="space-y-2">
           <div class="flex items-center justify-between">
-            <Label for="testEmbedInput" class="text-sm font-semibold">Input</Label>
-            <Button
-              variant="ghost"
-              size="sm"
-              onclick={resetInput}
-              disabled={!canReset}
-              title="Clear input and result"
-            >
-              <RotateCcw class="w-4 h-4" />
-              Reset
+            <Label class="text-sm font-semibold">Vector preview</Label>
+            <Button variant="outline" size="sm" onclick={copyVector}>
+              <Copy class="w-4 h-4" />
+              Copy full vector
             </Button>
           </div>
-          <textarea
-            id="testEmbedInput"
-            bind:value={inputText}
-            bind:this={inputEl}
-            placeholder="Text to embed..."
-            rows="4"
-            disabled={sending}
-            class="w-full min-h-24 rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring resize-y"
-          ></textarea>
-        </section>
+          <div class="rounded-md border bg-background px-3 py-2 font-mono text-xs break-all">
+            [{previewVector(result.embedding)}]
+          </div>
+        </div>
+      </section>
+    {/if}
+  {/snippet}
 
-        {#if errorMessage}
-          <Alert.Root variant="destructive">
-            <Alert.Description>{errorMessage}</Alert.Description>
-          </Alert.Root>
-        {/if}
-
-        {#if result}
-          <section class="space-y-3">
-            <Label class="text-sm font-semibold">Result</Label>
-            <div class="grid grid-cols-2 sm:grid-cols-4 gap-2">
-              <div class="rounded-md border bg-muted/40 p-3">
-                <div class="text-xs text-muted-foreground">Dimensions</div>
-                <div class="font-mono text-sm">{result.embedding.length}</div>
-              </div>
-              <div class="rounded-md border bg-muted/40 p-3">
-                <div class="text-xs text-muted-foreground">Prompt tokens</div>
-                <div class="font-mono text-sm">{result.promptTokens}</div>
-              </div>
-              <div class="rounded-md border bg-muted/40 p-3">
-                <div class="text-xs text-muted-foreground">Total tokens</div>
-                <div class="font-mono text-sm">{result.totalTokens}</div>
-              </div>
-              <div class="rounded-md border bg-muted/40 p-3">
-                <div class="text-xs text-muted-foreground">Duration</div>
-                <div class="font-mono text-sm">{result.durationMs} ms</div>
-              </div>
-            </div>
-            <div class="space-y-2">
-              <div class="flex items-center justify-between">
-                <Label class="text-sm font-semibold">Vector preview</Label>
-                <Button variant="outline" size="sm" onclick={copyVector}>
-                  <Copy class="w-4 h-4" />
-                  Copy full vector
-                </Button>
-              </div>
-              <div class="rounded-md border bg-background px-3 py-2 font-mono text-xs break-all">
-                [{previewVector(result.embedding)}]
-              </div>
-            </div>
-          </section>
-        {/if}
-
-        {#if !apiKey.trim()}
-          <Alert.Root>
-            <Alert.Description class="text-xs">
-              Paste an API key or click "Generate temporary key" to compute an embedding.
-            </Alert.Description>
-          </Alert.Root>
-        {/if}
-      </main>
-
-      <footer class="p-4 border-t bg-muted/40 rounded-b-xl flex justify-end gap-2">
-        <Button onclick={handleSend} disabled={!canSend}>
-          <Send class="w-4 h-4" />
-          {sending ? "Computing..." : "Compute embedding"}
-        </Button>
-      </footer>
+  {#snippet footer()}
+    <div class="flex justify-end gap-2">
+      <Button onclick={handleSend} disabled={!canSend}>
+        <Send class="w-4 h-4" />
+        {sending ? "Computing..." : "Compute embedding"}
+      </Button>
     </div>
-  {/if}
-</Modal>
+  {/snippet}
+</TestModal>

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/TestModal.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/TestModal.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+  import Modal from "$lib/components/Modal.svelte";
+  import { Button } from "$lib/components/ui/button";
+  import * as Alert from "$lib/components/ui/alert";
+  import { X } from "@lucide/svelte";
+
+  import type { DeploymentDefinition } from "./+page.server";
+  import TestApiKeySection from "./TestApiKeySection.svelte";
+
+  let {
+    open = $bindable(false),
+    deployment,
+    title,
+    apiKey = $bindable(""),
+    apiKeyHint,
+    onClose,
+    onOpen,
+    body,
+    footer,
+    extraHeader,
+  }: {
+    open: boolean;
+    deployment: DeploymentDefinition | null;
+    title: string;
+    apiKey: string;
+    apiKeyHint: string;
+    onClose: () => void;
+    onOpen?: () => void;
+    body: Snippet;
+    footer: Snippet;
+    extraHeader?: Snippet;
+  } = $props();
+
+  let wasOpen = $state(false);
+  $effect(() => {
+    if (open && !wasOpen) {
+      onOpen?.();
+    }
+    wasOpen = open;
+  });
+</script>
+
+<Modal {open} onClose={onClose} class="z-40">
+  {#if open && deployment}
+    <div class="bg-card rounded-xl shadow-2xl w-full max-w-3xl min-w-[min(48rem,90vw)] max-h-[90vh] flex flex-col">
+      <header class="p-6 border-b flex justify-between items-center">
+        <div>
+          <h2 class="text-2xl font-semibold">{title}</h2>
+          <p class="text-sm text-muted-foreground mt-1">
+            <span class="font-mono">{deployment.publicSpecifier}</span>
+          </p>
+          {#if extraHeader}
+            {@render extraHeader()}
+          {/if}
+        </div>
+        <Button variant="ghost" size="icon" onclick={onClose} aria-label="Close test modal">
+          <X class="w-5 h-5" />
+        </Button>
+      </header>
+
+      <main class="p-6 flex-1 overflow-y-auto space-y-5">
+        <TestApiKeySection bind:apiKey deploymentName={deployment.name} />
+        {@render body()}
+        {#if !apiKey.trim()}
+          <Alert.Root>
+            <Alert.Description class="text-xs">{apiKeyHint}</Alert.Description>
+          </Alert.Root>
+        {/if}
+      </main>
+
+      <footer class="p-4 border-t bg-muted/40 rounded-b-xl">
+        {@render footer()}
+      </footer>
+    </div>
+  {/if}
+</Modal>

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/TestRerankModal.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/TestRerankModal.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
-  import Modal from "$lib/components/Modal.svelte";
   import { Button } from "$lib/components/ui/button";
   import { Label } from "$lib/components/ui/label";
   import * as Alert from "$lib/components/ui/alert";
-  import { X, Send, Plus, Trash2, RotateCcw } from "@lucide/svelte";
+  import { Send, Plus, Trash2, RotateCcw } from "@lucide/svelte";
 
   import type { DeploymentDefinition } from "./+page.server";
   import { browserLogger } from "$lib/browserLogging";
-  import TestApiKeySection from "./TestApiKeySection.svelte";
+  import TestModal from "./TestModal.svelte";
+  import { formatErrorBody } from "./testHelpers";
 
   const DEFAULT_QUERY = "What is the capital of France?";
   const DEFAULT_DOCUMENTS = [
@@ -62,29 +62,25 @@
       !arraysEqual(documents, DEFAULT_DOCUMENTS),
   );
 
-  // Bar width is relative to the largest score in the response so models that
-  // emit small or negative scores still produce a readable chart.
+  // Bar width is relative to the largest score so models that emit small or
+  // negative scores still produce a readable chart.
   const maxAbsScore = $derived(
     result ? result.ranks.reduce((m, r) => Math.max(m, Math.abs(r.score)), 0) || 1 : 1,
   );
 
-  // Fresh-open reset. Triggers on every false->true transition.
-  let wasOpen = $state(false);
-  $effect(() => {
-    if (open && !wasOpen) {
-      resetState();
-      queueMicrotask(() => queryEl?.focus());
-    }
-    wasOpen = open;
-  });
-
   function arraysEqual(a: string[], b: string[]) {
-    if (a.length !== b.length) return false;
-    for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+    if (a.length !== b.length) {
+      return false;
+    }
+    for (let i = 0; i < a.length; i++) {
+      if (a[i] !== b[i]) {
+        return false;
+      }
+    }
     return true;
   }
 
-  function resetState() {
+  function clearInputs() {
     inflight?.abort();
     inflight = null;
     sending = false;
@@ -92,18 +88,26 @@
     documents = [...DEFAULT_DOCUMENTS];
     result = null;
     errorMessage = null;
+  }
+
+  function resetState() {
+    clearInputs();
     apiKey = "";
   }
 
   function resetInputs() {
-    inflight?.abort();
-    inflight = null;
-    sending = false;
-    query = DEFAULT_QUERY;
-    documents = [...DEFAULT_DOCUMENTS];
-    result = null;
-    errorMessage = null;
+    clearInputs();
     queueMicrotask(() => queryEl?.focus());
+  }
+
+  function handleOpen() {
+    resetState();
+    queueMicrotask(() => queryEl?.focus());
+  }
+
+  function handleClose() {
+    inflight?.abort();
+    close();
   }
 
   function setDocument(idx: number, value: string) {
@@ -115,12 +119,16 @@
   }
 
   function removeDocument(idx: number) {
-    if (documents.length <= 1) return;
+    if (documents.length <= 1) {
+      return;
+    }
     documents = documents.filter((_, i) => i !== idx);
   }
 
   async function handleSend() {
-    if (!canSend || !deployment) return;
+    if (!canSend || !deployment) {
+      return;
+    }
     sending = true;
     errorMessage = null;
     result = null;
@@ -161,18 +169,21 @@
         durationMs: Math.round(performance.now() - start),
       };
     } catch (err) {
-      if (ctrl.signal.aborted) return;
+      if (ctrl.signal.aborted) {
+        return;
+      }
       browserLogger.warn({ err }, "Test rerank request failed");
       errorMessage = err instanceof Error ? err.message : "Network error";
     } finally {
-      if (inflight === ctrl) inflight = null;
+      if (inflight === ctrl) {
+        inflight = null;
+      }
       sending = false;
     }
   }
 
   // The `document` field can be a raw string, an object with a `text` field, or
-  // omitted entirely; fall back to the input we sent so the user always sees
-  // which document the rank refers to.
+  // omitted entirely; fall back to the input we sent so the rank always shows text.
   function normalizeRankRow(
     row: unknown,
     rankIdx: number,
@@ -186,155 +197,127 @@
       text = r.document;
     } else if (r?.document && typeof r.document === "object" && "text" in r.document) {
       const t = (r.document as { text?: unknown }).text;
-      if (typeof t === "string") text = t;
+      if (typeof t === "string") {
+        text = t;
+      }
     }
-    if (!text) text = sentDocs[inputIndex] ?? "";
+    if (!text) {
+      text = sentDocs[inputIndex] ?? "";
+    }
     return { rank: rankIdx + 1, inputIndex, score, text };
-  }
-
-  async function formatErrorBody(res: Response): Promise<string> {
-    const text = await res.text().catch(() => "");
-    try {
-      const parsed = JSON.parse(text);
-      if (parsed?.error?.message) return String(parsed.error.message);
-    } catch {
-      /* fall through to raw text */
-    }
-    return text || `Request failed (${res.status})`;
-  }
-
-  function handleClose() {
-    inflight?.abort();
-    close();
   }
 </script>
 
-<Modal {open} onClose={handleClose} class="z-40">
-  {#if open && deployment}
-    <div class="bg-card rounded-xl shadow-2xl w-full max-w-3xl min-w-[min(48rem,90vw)] max-h-[90vh] flex flex-col">
-      <header class="p-6 border-b flex justify-between items-center">
-        <div>
-          <h2 class="text-2xl font-semibold">Test Rerank Model</h2>
-          <p class="text-sm text-muted-foreground mt-1">
-            <span class="font-mono">{deployment.publicSpecifier}</span>
-          </p>
-        </div>
-        <Button variant="ghost" size="icon" onclick={handleClose} aria-label="Close test modal">
-          <X class="w-5 h-5" />
+<TestModal
+  bind:open
+  {deployment}
+  title="Test Rerank Model"
+  bind:apiKey
+  apiKeyHint={'Paste an API key or click "Generate temporary key" to rank documents.'}
+  onClose={handleClose}
+  onOpen={handleOpen}
+>
+  {#snippet body()}
+    <section class="space-y-2">
+      <div class="flex items-center justify-between">
+        <Label for="testRerankQuery" class="text-sm font-semibold">Query</Label>
+        <Button
+          variant="ghost"
+          size="sm"
+          onclick={resetInputs}
+          disabled={!canReset}
+          title="Restore defaults and clear results"
+        >
+          <RotateCcw class="w-4 h-4" />
+          Reset
         </Button>
-      </header>
+      </div>
+      <textarea
+        id="testRerankQuery"
+        bind:value={query}
+        bind:this={queryEl}
+        placeholder="The query to rank documents against..."
+        rows="2"
+        disabled={sending}
+        class="w-full min-h-15 rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring resize-y"
+      ></textarea>
+    </section>
 
-      <main class="p-6 flex-1 overflow-y-auto space-y-5">
-        <TestApiKeySection bind:apiKey deploymentName={deployment.name} />
-
-        <section class="space-y-2">
-          <div class="flex items-center justify-between">
-            <Label for="testRerankQuery" class="text-sm font-semibold">Query</Label>
+    <section class="space-y-2">
+      <div class="flex items-center justify-between">
+        <Label class="text-sm font-semibold">Documents</Label>
+        <Button variant="ghost" size="sm" onclick={addDocument} disabled={sending}>
+          <Plus class="w-4 h-4" />
+          Add document
+        </Button>
+      </div>
+      <div class="space-y-2">
+        {#each documents as doc, i (i)}
+          <div class="flex items-start gap-2">
+            <textarea
+              value={doc}
+              oninput={(e) => setDocument(i, e.currentTarget.value)}
+              placeholder="Document {i + 1}"
+              rows="5"
+              disabled={sending}
+              class="flex-1 min-h-28 rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring resize-y"
+            ></textarea>
             <Button
-              variant="ghost"
-              size="sm"
-              onclick={resetInputs}
-              disabled={!canReset}
-              title="Restore defaults and clear results"
+              variant="outline"
+              size="icon"
+              onclick={() => removeDocument(i)}
+              disabled={sending || documents.length <= 1}
+              title="Remove document"
             >
-              <RotateCcw class="w-4 h-4" />
-              Reset
+              <Trash2 class="w-4 h-4" />
             </Button>
           </div>
-          <textarea
-            id="testRerankQuery"
-            bind:value={query}
-            bind:this={queryEl}
-            placeholder="The query to rank documents against..."
-            rows="2"
-            disabled={sending}
-            class="w-full min-h-15 rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring resize-y"
-          ></textarea>
-        </section>
+        {/each}
+      </div>
+    </section>
 
-        <section class="space-y-2">
-          <div class="flex items-center justify-between">
-            <Label class="text-sm font-semibold">Documents</Label>
-            <Button variant="ghost" size="sm" onclick={addDocument} disabled={sending}>
-              <Plus class="w-4 h-4" />
-              Add document
-            </Button>
-          </div>
-          <div class="space-y-2">
-            {#each documents as doc, i (i)}
-              <div class="flex items-start gap-2">
-                <textarea
-                  value={doc}
-                  oninput={(e) => setDocument(i, e.currentTarget.value)}
-                  placeholder="Document {i + 1}"
-                  rows="5"
-                  disabled={sending}
-                  class="flex-1 min-h-28 rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring resize-y"
-                ></textarea>
-                <Button
-                  variant="outline"
-                  size="icon"
-                  onclick={() => removeDocument(i)}
-                  disabled={sending || documents.length <= 1}
-                  title="Remove document"
-                >
-                  <Trash2 class="w-4 h-4" />
-                </Button>
-              </div>
-            {/each}
-          </div>
-        </section>
+    {#if errorMessage}
+      <Alert.Root variant="destructive">
+        <Alert.Description>{errorMessage}</Alert.Description>
+      </Alert.Root>
+    {/if}
 
-        {#if errorMessage}
-          <Alert.Root variant="destructive">
-            <Alert.Description>{errorMessage}</Alert.Description>
-          </Alert.Root>
-        {/if}
-
-        {#if result}
-          <section class="space-y-3">
-            <div class="flex items-center justify-between">
-              <Label class="text-sm font-semibold">Ranked results</Label>
-              <span class="text-xs text-muted-foreground">{result.durationMs} ms</span>
-            </div>
-            <div class="space-y-2">
-              {#each result.ranks as r (r.rank)}
-                <div class="rounded-md border bg-muted/40 p-3">
-                  <div class="flex items-baseline justify-between gap-2 mb-2">
-                    <div class="flex items-baseline gap-2">
-                      <span class="font-mono text-sm font-semibold">#{r.rank}</span>
-                      <span class="text-xs text-muted-foreground">input {r.inputIndex + 1}</span>
-                    </div>
-                    <span class="font-mono text-sm">{r.score.toFixed(4)}</span>
-                  </div>
-                  <div class="w-full bg-muted rounded-full h-1.5 mb-2">
-                    <div
-                      class="bg-primary h-1.5 rounded-full transition-all"
-                      style="width: {Math.max(0, Math.min(100, (Math.abs(r.score) / maxAbsScore) * 100))}%"
-                    ></div>
-                  </div>
-                  <p class="text-sm whitespace-pre-wrap wrap-break-words">{r.text}</p>
+    {#if result}
+      <section class="space-y-3">
+        <div class="flex items-center justify-between">
+          <Label class="text-sm font-semibold">Ranked results</Label>
+          <span class="text-xs text-muted-foreground">{result.durationMs} ms</span>
+        </div>
+        <div class="space-y-2">
+          {#each result.ranks as r (r.rank)}
+            <div class="rounded-md border bg-muted/40 p-3">
+              <div class="flex items-baseline justify-between gap-2 mb-2">
+                <div class="flex items-baseline gap-2">
+                  <span class="font-mono text-sm font-semibold">#{r.rank}</span>
+                  <span class="text-xs text-muted-foreground">input {r.inputIndex + 1}</span>
                 </div>
-              {/each}
+                <span class="font-mono text-sm">{r.score.toFixed(4)}</span>
+              </div>
+              <div class="w-full bg-muted rounded-full h-1.5 mb-2">
+                <div
+                  class="bg-primary h-1.5 rounded-full transition-all"
+                  style="width: {Math.max(0, Math.min(100, (Math.abs(r.score) / maxAbsScore) * 100))}%"
+                ></div>
+              </div>
+              <p class="text-sm whitespace-pre-wrap wrap-break-words">{r.text}</p>
             </div>
-          </section>
-        {/if}
+          {/each}
+        </div>
+      </section>
+    {/if}
+  {/snippet}
 
-        {#if !apiKey.trim()}
-          <Alert.Root>
-            <Alert.Description class="text-xs">
-              Paste an API key or click "Generate temporary key" to rank documents.
-            </Alert.Description>
-          </Alert.Root>
-        {/if}
-      </main>
-
-      <footer class="p-4 border-t bg-muted/40 rounded-b-xl flex justify-end gap-2">
-        <Button onclick={handleSend} disabled={!canSend}>
-          <Send class="w-4 h-4" />
-          {sending ? "Ranking..." : "Rank documents"}
-        </Button>
-      </footer>
+  {#snippet footer()}
+    <div class="flex justify-end gap-2">
+      <Button onclick={handleSend} disabled={!canSend}>
+        <Send class="w-4 h-4" />
+        {sending ? "Ranking..." : "Rank documents"}
+      </Button>
     </div>
-  {/if}
-</Modal>
+  {/snippet}
+</TestModal>

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/testHelpers.ts
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/testHelpers.ts
@@ -1,0 +1,12 @@
+export async function formatErrorBody(res: Response): Promise<string> {
+  const text = await res.text().catch(() => "");
+  try {
+    const parsed = JSON.parse(text);
+    if (parsed?.error?.message) {
+      return String(parsed.error.message);
+    }
+  } catch {
+    // raw text fallback below
+  }
+  return text || `Request failed (${res.status})`;
+}

--- a/packages/xinity-ai-gateway/README.md
+++ b/packages/xinity-ai-gateway/README.md
@@ -23,6 +23,15 @@ bun run dev
 - Call logging writes usage and call metadata directly to the database via
   functions in `src/callLogger.ts`.
 
+## Live API documentation
+
+The gateway serves its own OpenAPI documentation:
+
+- `GET /openapi.json` — the OpenAPI 3.1 spec, generated from the oRPC router plus hand-authored fragments for the `/v1/*` OpenAI-compatible routes (`src/openai-compat-openapi.ts`).
+- `GET /docs` — Scalar UI rendering of the same spec.
+
+When extending or modifying the OpenAI-compatible routes, update the hand-authored fragments in `src/openai-compat-openapi.ts` so the documentation stays in sync.
+
 ## Build
 
 ```bash

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoint-guards.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoint-guards.ts
@@ -1,0 +1,70 @@
+import { z } from "zod";
+import { resolveModel, type ResolvedModel } from "./ai-sdk";
+import { errorResponse, handleEndpointError, validateModelType, validationError } from "./util";
+import type { AuthResult } from "./auth";
+
+type EndpointLogger = {
+  info: (obj: Record<string, unknown>, msg: string) => void;
+  warn: (obj: Record<string, unknown>, msg: string) => void;
+  error: (obj: Record<string, unknown>, msg: string) => void;
+};
+
+export type EndpointHandlerContext<TBody> = {
+  auth: AuthResult;
+  body: TBody;
+  rawBody: Record<string, unknown>;
+  modelInfo: ResolvedModel["modelInfo"];
+  originalModel: string;
+  req: Request;
+};
+
+export type EndpointGuardOptions<TBody> = {
+  modelTypes: string[];
+  bodySchema: z.ZodType<TBody>;
+  log: EndpointLogger;
+  method?: "POST" | "GET";
+  handler: (ctx: EndpointHandlerContext<TBody>) => Promise<Response>;
+};
+
+/**
+ * Wraps an endpoint handler with the shared auth + model resolution + body
+ * validation preamble and the standard error-catch tail. The wrapped handler
+ * only sees a fully-parsed body and a resolved model.
+ */
+export function withEndpointGuards<TBody>(
+  opts: EndpointGuardOptions<TBody>,
+): (req: Request) => Promise<Response> {
+  return async (req) => {
+    try {
+      if (opts.method && req.method !== opts.method) {
+        return errorResponse("Method not allowed", 405);
+      }
+
+      const resolved = await resolveModel(req);
+      if (resolved instanceof Response) {
+        return resolved;
+      }
+
+      const typeError = validateModelType(resolved.modelInfo, opts.modelTypes);
+      if (typeError) {
+        return typeError;
+      }
+
+      const parseResult = opts.bodySchema.safeParse(resolved.body);
+      if (!parseResult.success) {
+        return validationError(parseResult.error);
+      }
+
+      return await opts.handler({
+        auth: resolved.auth,
+        body: parseResult.data,
+        rawBody: resolved.body,
+        modelInfo: resolved.modelInfo,
+        originalModel: resolved.originalModel,
+        req,
+      });
+    } catch (error) {
+      return handleEndpointError(error, opts.log);
+    }
+  };
+}

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-chatCompletion.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-chatCompletion.ts
@@ -10,14 +10,14 @@ import { backendFetch, backendUrl } from "../backend-fetch";
 
 const log = rootLogger.child({ name: "handle-chatCompletion" });
 
-const ChatCompletionBodySchema = z.looseObject({
+export const ChatCompletionBodySchema = z.looseObject({
   model: z.string(),
   messages: z.array(z.looseObject({
     role: z.string(),
     content: z.unknown(),
   })),
   stream: z.boolean().optional().default(false),
-  store: z.boolean().optional().default(true),
+  store: z.boolean().optional(),
   temperature: z.number().optional(),
   max_tokens: z.number().optional(),
   top_p: z.number().optional(),

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-chatCompletion.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-chatCompletion.ts
@@ -2,12 +2,9 @@ import { z } from "zod";
 import {
   errorResponse,
   forwardBackendError,
-  validateModelType,
   extractAllowedRequestParams,
-  handleEndpointError,
-  validationError,
 } from "../util";
-import { resolveModel } from "../ai-sdk";
+import { withEndpointGuards } from "../endpoint-guards";
 import { BackendChatChunkSchema } from "../backend-schemas";
 import type { ApiCallInputMessage } from "common-db";
 import { rootLogger } from "../../logger";
@@ -121,26 +118,11 @@ const chatNonStreamSpec: NonStreamSpec<z.infer<typeof ChatSyncChoiceSchema>> = {
   toLogOutput: (choices, model) => ({ model, choices }),
 };
 
-export async function handleChatCompletion(req: Request) {
-  try {
-    const resolved = await resolveModel(req);
-    if (resolved instanceof Response) {
-      return resolved;
-    }
-
-    const { auth, body: rawBody, originalModel, modelInfo } = resolved;
-
-    const typeError = validateModelType(modelInfo, ["chat"]);
-    if (typeError) {
-      return typeError;
-    }
-
-    const parseResult = ChatCompletionBodySchema.safeParse(rawBody);
-    if (!parseResult.success) {
-      return validationError(parseResult.error);
-    }
-    const body = parseResult.data;
-
+export const handleChatCompletion = withEndpointGuards({
+  modelTypes: ["chat"],
+  bodySchema: ChatCompletionBodySchema,
+  log,
+  handler: async ({ auth, body, rawBody, modelInfo, originalModel, req }) => {
     if (body.structured_outputs && modelInfo.driver !== "vllm") {
       return errorResponse("structured_outputs is only supported with the vLLM driver", 400);
     }
@@ -222,7 +204,5 @@ export async function handleChatCompletion(req: Request) {
       logFields,
       log,
     });
-  } catch (error) {
-    return handleEndpointError(error, log);
-  }
-}
+  },
+});

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-chatCompletion.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-chatCompletion.ts
@@ -1,12 +1,25 @@
 import { z } from "zod";
-import { errorResponse, forwardBackendError, logChatUsage, validateModelType, extractAllowedRequestParams, readSSEStream, handleEndpointError, SSE_RESPONSE_HEADERS, sseEncoder, handleStreamError, validationError } from "../util";
+import {
+  errorResponse,
+  forwardBackendError,
+  validateModelType,
+  extractAllowedRequestParams,
+  handleEndpointError,
+  validationError,
+} from "../util";
 import { resolveModel } from "../ai-sdk";
-import { BackendChatChunkSchema, BackendUsageSchema } from "../backend-schemas";
+import { BackendChatChunkSchema } from "../backend-schemas";
 import type { ApiCallInputMessage } from "common-db";
 import { rootLogger } from "../../logger";
 import { processMessageImages, imageStore } from "../../image-store";
 import { env } from "../../env";
 import { backendFetch, backendUrl } from "../backend-fetch";
+import {
+  forwardOpenAINonStream,
+  forwardOpenAIStream,
+  type NonStreamSpec,
+  type StreamSpec,
+} from "../openai-forward";
 
 const log = rootLogger.child({ name: "handle-chatCompletion" });
 
@@ -51,7 +64,45 @@ export const ChatCompletionBodySchema = z.looseObject({
   ]).optional(),
 });
 
-const NonStreamingChoicesSchema = z.array(z.looseObject({
+type ChatAcc = {
+  content: string;
+  role: string;
+  tool_calls?: unknown[];
+  finish_reason?: string | null;
+};
+
+const chatStreamSpec: StreamSpec<z.infer<typeof BackendChatChunkSchema>, ChatAcc> = {
+  chunkSchema: BackendChatChunkSchema,
+  initAcc: () => ({ content: "", role: "assistant" }),
+  applyChoice: (acc, choice) => {
+    if (typeof choice.delta.content === "string") {
+      acc.content += choice.delta.content;
+    }
+    if (choice.delta.role) {
+      acc.role = choice.delta.role;
+    }
+    if (Array.isArray(choice.delta.tool_calls) && choice.delta.tool_calls.length > 0) {
+      acc.tool_calls = choice.delta.tool_calls;
+    }
+    if (choice.finish_reason) {
+      acc.finish_reason = choice.finish_reason;
+    }
+  },
+  toLogEntry: (acc, index, model) => ({
+    model,
+    choices: [{
+      index,
+      delta: {
+        role: acc.role,
+        content: acc.content,
+        ...(acc.tool_calls ? { tool_calls: acc.tool_calls } : {}),
+      },
+      finish_reason: acc.finish_reason ?? null,
+    }],
+  }),
+};
+
+const ChatSyncChoiceSchema = z.looseObject({
   index: z.number(),
   message: z.looseObject({
     role: z.string(),
@@ -63,36 +114,26 @@ const NonStreamingChoicesSchema = z.array(z.looseObject({
     })).optional(),
   }),
   finish_reason: z.string().nullable().optional(),
-}));
+});
 
-function logNonStreamingChatResponse(
-  raw: Record<string, unknown>,
-  originalModel: string,
-  logFields: Omit<Parameters<typeof logChatUsage>[0], "usage" | "outputData" | "stream">,
-): void {
-  const choicesResult = NonStreamingChoicesSchema.safeParse(raw.choices);
-  const usageResult = BackendUsageSchema.safeParse(raw.usage);
-  if (!choicesResult.success) {
-    log.warn({ issues: choicesResult.error.issues }, "Could not extract choices for logging");
-    return;
-  }
-  logChatUsage({
-    ...logFields,
-    usage: usageResult.success ? usageResult.data : undefined,
-    outputData: { model: originalModel, choices: choicesResult.data },
-    stream: false,
-  });
-}
+const chatNonStreamSpec: NonStreamSpec<z.infer<typeof ChatSyncChoiceSchema>> = {
+  choicesSchema: z.array(ChatSyncChoiceSchema),
+  toLogOutput: (choices, model) => ({ model, choices }),
+};
 
 export async function handleChatCompletion(req: Request) {
   try {
     const resolved = await resolveModel(req);
-    if (resolved instanceof Response) return resolved;
+    if (resolved instanceof Response) {
+      return resolved;
+    }
 
     const { auth, body: rawBody, originalModel, modelInfo } = resolved;
 
     const typeError = validateModelType(modelInfo, ["chat"]);
-    if (typeError) return typeError;
+    if (typeError) {
+      return typeError;
+    }
 
     const parseResult = ChatCompletionBodySchema.safeParse(rawBody);
     if (!parseResult.success) {
@@ -100,7 +141,6 @@ export async function handleChatCompletion(req: Request) {
     }
     const body = parseResult.data;
 
-    // Reject structured_outputs for non-vLLM drivers
     if (body.structured_outputs && modelInfo.driver !== "vllm") {
       return errorResponse("structured_outputs is only supported with the vLLM driver", 400);
     }
@@ -117,9 +157,7 @@ export async function handleChatCompletion(req: Request) {
       auth.orgId,
       imageStore,
     );
-    const inputMessages = messagesForDB;
 
-    // Build fetch body. everything passes through in OpenAI format
     const fetchBody: Record<string, unknown> = {
       model: modelInfo.model,
       messages: messagesForLLM,
@@ -134,21 +172,26 @@ export async function handleChatCompletion(req: Request) {
       tools: body.tools,
       tool_choice: body.tool_choice,
     };
-    if (body.stream) fetchBody.stream_options = { include_usage: true };
-    if (body.structured_outputs) fetchBody.structured_outputs = body.structured_outputs;
-    // Merge allowed extra request params directly into body
+    if (body.stream) {
+      fetchBody.stream_options = { include_usage: true };
+    }
+    if (body.structured_outputs) {
+      fetchBody.structured_outputs = body.structured_outputs;
+    }
     const extraParams = extractAllowedRequestParams(rawBody, modelInfo.requestParams);
-    if (extraParams) Object.assign(fetchBody, extraParams);
+    if (extraParams) {
+      Object.assign(fetchBody, extraParams);
+    }
 
     const logFields = {
       auth,
       modelInfo,
       modelSpecifier: originalModel,
-      inputMessages,
+      inputMessages: messagesForDB,
       callStartTime,
       logCalls: body.store,
       metadata: body.metadata ?? undefined,
-    } as const;
+    };
 
     const backendResponse = await backendFetch(backendUrl(modelInfo.host, modelInfo.model, "/v1/chat/completions", modelInfo.tls), {
       method: "POST",
@@ -163,89 +206,22 @@ export async function handleChatCompletion(req: Request) {
     }
 
     if (body.stream) {
-      let collectedUsage: z.infer<typeof BackendUsageSchema> | undefined;
-      let deltaModel = originalModel;
-      const accumByChoice = new Map<number, {
-        content: string; role: string;
-        tool_calls?: unknown[]; finish_reason?: string | null;
-      }>();
-
-      const stream = new ReadableStream({
-        async start(controller) {
-          try {
-            for await (const event of readSSEStream(backendResponse)) {
-              if (event.data === "[DONE]") {
-                controller.enqueue(sseEncoder.encode("data: [DONE]\n\n"));
-                break;
-              }
-
-              let json: unknown;
-              try { json = JSON.parse(event.data); } catch {
-                log.warn({ data: event.data }, "Non-JSON SSE chunk from backend, skipping");
-                continue;
-              }
-              const parsed = BackendChatChunkSchema.safeParse(json);
-              if (!parsed.success) {
-                log.warn({ issues: parsed.error.issues }, "Malformed backend SSE chunk, skipping");
-                continue;
-              }
-              const chunk = { ...parsed.data, model: originalModel };
-
-              if (chunk.usage) collectedUsage = chunk.usage;
-              if (chunk.choices.length) {
-                deltaModel = chunk.model;
-                for (const choice of chunk.choices) {
-                  const acc = accumByChoice.get(choice.index) ?? { content: "", role: "assistant" };
-                  acc.content += typeof choice.delta.content === "string" ? choice.delta.content : "";
-                  if (choice.delta.role) acc.role = choice.delta.role as string;
-                  if (Array.isArray(choice.delta.tool_calls) && choice.delta.tool_calls.length > 0)
-                    acc.tool_calls = choice.delta.tool_calls as unknown[];
-                  if (choice.finish_reason) acc.finish_reason = choice.finish_reason;
-                  accumByChoice.set(choice.index, acc);
-                }
-              }
-
-              controller.enqueue(sseEncoder.encode(`data: ${JSON.stringify(chunk)}\n\n`));
-            }
-            controller.close();
-
-            logChatUsage({
-              ...logFields,
-              usage: collectedUsage,
-              outputData: [...accumByChoice.entries()]
-                .sort(([a], [b]) => a - b)
-                .map(([idx, acc]) => ({
-                  model: deltaModel,
-                  choices: [{
-                    index: idx,
-                    delta: { role: acc.role, content: acc.content, ...(acc.tool_calls ? { tool_calls: acc.tool_calls } : {}) },
-                    finish_reason: acc.finish_reason ?? null,
-                  }],
-                })),
-              stream: true,
-            });
-          } catch (e) {
-            handleStreamError(e, controller, log);
-          }
-        },
+      return forwardOpenAIStream({
+        backendResponse,
+        originalModel,
+        spec: chatStreamSpec,
+        logFields,
+        log,
       });
-
-      return new Response(stream, { headers: SSE_RESPONSE_HEADERS });
-
-    } else {
-      // Non-streaming: always forward, extract logging data field-by-field
-      let raw: Record<string, unknown>;
-      try {
-        raw = await backendResponse.json() as Record<string, unknown>;
-      } catch {
-        return errorResponse("Backend returned an invalid response", 502);
-      }
-
-      raw.model = originalModel;
-      logNonStreamingChatResponse(raw, originalModel, logFields);
-      return Response.json(raw);
     }
 
+    return forwardOpenAINonStream({
+      backendResponse,
+      originalModel,
+      spec: chatNonStreamSpec,
+      logFields,
+      log,
+    });
   } catch (error) {
     return handleEndpointError(error, log);
   }

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-completions.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-completions.ts
@@ -9,7 +9,7 @@ import { backendFetch, backendUrl } from "../backend-fetch";
 
 const log = rootLogger.child({ name: "handle-completions" });
 
-const CompletionBodySchema = z.looseObject({
+export const CompletionBodySchema = z.looseObject({
   model: z.string(),
   prompt: z.union([z.string(), z.array(z.string())]).optional(),
   max_tokens: z.number().optional(),
@@ -20,7 +20,7 @@ const CompletionBodySchema = z.looseObject({
   stream: z.boolean().optional().default(false),
   seed: z.number().optional(),
   stop: z.union([z.string(), z.array(z.string())]).optional(),
-  store: z.boolean().optional().default(true),
+  store: z.boolean().optional(),
   metadata: z.record(z.string(), z.unknown()).nullable().optional(),
 });
 

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-completions.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-completions.ts
@@ -1,12 +1,6 @@
 import { z } from "zod";
-import { resolveModel } from "../ai-sdk";
-import {
-  errorResponse,
-  forwardBackendError,
-  validateModelType,
-  handleEndpointError,
-  validationError,
-} from "../util";
+import { errorResponse, forwardBackendError } from "../util";
+import { withEndpointGuards } from "../endpoint-guards";
 import { BackendCompletionChunkSchema } from "../backend-schemas";
 import type { ApiCallInputMessage } from "common-db";
 import { rootLogger } from "../../logger";
@@ -87,30 +81,12 @@ const completionNonStreamSpec: NonStreamSpec<z.infer<typeof CompletionSyncChoice
   }),
 };
 
-export async function handleCompletion(req: Request): Promise<Response> {
-  try {
-    if (req.method !== "POST") {
-      return errorResponse("Method not allowed", 405);
-    }
-
-    const resolved = await resolveModel(req);
-    if (resolved instanceof Response) {
-      return resolved;
-    }
-
-    const { auth, body: rawBody, originalModel, modelInfo } = resolved;
-
-    const typeError = validateModelType(modelInfo, ["chat"]);
-    if (typeError) {
-      return typeError;
-    }
-
-    const parseResult = CompletionBodySchema.safeParse(rawBody);
-    if (!parseResult.success) {
-      return validationError(parseResult.error);
-    }
-    const body = parseResult.data;
-
+export const handleCompletion = withEndpointGuards({
+  modelTypes: ["chat"],
+  bodySchema: CompletionBodySchema,
+  log,
+  method: "POST",
+  handler: async ({ auth, body, modelInfo, originalModel, req }) => {
     const promptText = normalizePrompt(body.prompt);
     if (!promptText) {
       return errorResponse("Unsupported data type", 422);
@@ -174,7 +150,5 @@ export async function handleCompletion(req: Request): Promise<Response> {
       logFields,
       log,
     });
-  } catch (error) {
-    return handleEndpointError(error, log);
-  }
-}
+  },
+});

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-completions.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-completions.ts
@@ -1,11 +1,23 @@
 import { z } from "zod";
 import { resolveModel } from "../ai-sdk";
-import { errorResponse, forwardBackendError, logChatUsage, readSSEStream, validateModelType, handleEndpointError, SSE_RESPONSE_HEADERS, sseEncoder, handleStreamError, validationError } from "../util";
-import { BackendCompletionChunkSchema, BackendUsageSchema } from "../backend-schemas";
+import {
+  errorResponse,
+  forwardBackendError,
+  validateModelType,
+  handleEndpointError,
+  validationError,
+} from "../util";
+import { BackendCompletionChunkSchema } from "../backend-schemas";
 import type { ApiCallInputMessage } from "common-db";
 import { rootLogger } from "../../logger";
 import { env } from "../../env";
 import { backendFetch, backendUrl } from "../backend-fetch";
+import {
+  forwardOpenAINonStream,
+  forwardOpenAIStream,
+  type NonStreamSpec,
+  type StreamSpec,
+} from "../openai-forward";
 
 const log = rootLogger.child({ name: "handle-completions" });
 
@@ -24,15 +36,56 @@ export const CompletionBodySchema = z.looseObject({
   metadata: z.record(z.string(), z.unknown()).nullable().optional(),
 });
 
-const normalizePrompt = (prompt: string | string[] | undefined): string | null => {
-  if (typeof prompt === "string") return prompt;
-  if (Array.isArray(prompt)) return prompt.join("\n");
+function normalizePrompt(prompt: string | string[] | undefined): string | null {
+  if (typeof prompt === "string") {
+    return prompt;
+  }
+  if (Array.isArray(prompt)) {
+    return prompt.join("\n");
+  }
   return null;
+}
+
+type CompletionAcc = {
+  content: string;
+  finish_reason?: string | null;
 };
 
-// ---------------------------------------------------------------------------
-// Handler
-// ---------------------------------------------------------------------------
+const completionStreamSpec: StreamSpec<z.infer<typeof BackendCompletionChunkSchema>, CompletionAcc> = {
+  chunkSchema: BackendCompletionChunkSchema,
+  initAcc: () => ({ content: "" }),
+  applyChoice: (acc, choice) => {
+    acc.content += choice.text ?? "";
+    if (choice.finish_reason) {
+      acc.finish_reason = choice.finish_reason;
+    }
+  },
+  toLogEntry: (acc, index, model) => ({
+    model,
+    choices: [{
+      index,
+      delta: { role: "assistant", content: acc.content },
+      finish_reason: acc.finish_reason ?? null,
+    }],
+  }),
+};
+
+const CompletionSyncChoiceSchema = z.looseObject({
+  index: z.number(),
+  text: z.string(),
+  finish_reason: z.string().nullable().optional(),
+});
+
+const completionNonStreamSpec: NonStreamSpec<z.infer<typeof CompletionSyncChoiceSchema>> = {
+  choicesSchema: z.array(CompletionSyncChoiceSchema),
+  toLogOutput: (choices, model) => ({
+    model,
+    choices: choices.map((ch) => ({
+      index: ch.index,
+      message: { role: "assistant", content: ch.text },
+    })),
+  }),
+};
 
 export async function handleCompletion(req: Request): Promise<Response> {
   try {
@@ -41,12 +94,16 @@ export async function handleCompletion(req: Request): Promise<Response> {
     }
 
     const resolved = await resolveModel(req);
-    if (resolved instanceof Response) return resolved;
+    if (resolved instanceof Response) {
+      return resolved;
+    }
 
     const { auth, body: rawBody, originalModel, modelInfo } = resolved;
 
     const typeError = validateModelType(modelInfo, ["chat"]);
-    if (typeError) return typeError;
+    if (typeError) {
+      return typeError;
+    }
 
     const parseResult = CompletionBodySchema.safeParse(rawBody);
     if (!parseResult.success) {
@@ -70,7 +127,7 @@ export async function handleCompletion(req: Request): Promise<Response> {
       callStartTime,
       logCalls: body.store,
       metadata: body.metadata ?? undefined,
-    } as const;
+    };
 
     const fetchBody: Record<string, unknown> = {
       model: modelInfo.model,
@@ -84,7 +141,9 @@ export async function handleCompletion(req: Request): Promise<Response> {
       stop: body.stop,
       stream: body.stream,
     };
-    if (body.stream) fetchBody.stream_options = { include_usage: true };
+    if (body.stream) {
+      fetchBody.stream_options = { include_usage: true };
+    }
 
     const backendResponse = await backendFetch(backendUrl(modelInfo.host, modelInfo.model, "/v1/completions", modelInfo.tls), {
       method: "POST",
@@ -99,107 +158,22 @@ export async function handleCompletion(req: Request): Promise<Response> {
     }
 
     if (body.stream) {
-      let collectedUsage: z.infer<typeof BackendUsageSchema> | undefined = undefined;
-      let deltaModel = originalModel;
-      const accumByChoice = new Map<number, { content: string; finish_reason?: string | null }>();
-
-      const stream = new ReadableStream({
-        async start(controller) {
-          try {
-            for await (const event of readSSEStream(backendResponse)) {
-              if (event.data === "[DONE]") {
-                controller.enqueue(sseEncoder.encode("data: [DONE]\n\n"));
-                break;
-              }
-
-              let json: unknown;
-              try { json = JSON.parse(event.data); } catch {
-                log.warn({ data: event.data }, "Non-JSON SSE chunk from backend, skipping");
-                continue;
-              }
-              const parsed = BackendCompletionChunkSchema.safeParse(json);
-              if (!parsed.success) {
-                log.warn({ issues: parsed.error.issues }, "Malformed backend SSE chunk, skipping");
-                continue;
-              }
-              const chunk = { ...parsed.data, model: originalModel };
-
-              if (chunk.usage) collectedUsage = chunk.usage;
-              if (chunk.choices.length) {
-                deltaModel = chunk.model;
-                for (const choice of chunk.choices) {
-                  const acc = accumByChoice.get(choice.index) ?? { content: "" };
-                  acc.content += choice.text ?? "";
-                  if (choice.finish_reason) acc.finish_reason = choice.finish_reason;
-                  accumByChoice.set(choice.index, acc);
-                }
-              }
-
-              controller.enqueue(sseEncoder.encode(`data: ${JSON.stringify(chunk)}\n\n`));
-            }
-            controller.close();
-
-            // Translate completions format (choices[].text) to chat delta format for logging
-            logChatUsage({
-              ...logFields,
-              usage: collectedUsage,
-              outputData: [...accumByChoice.entries()]
-                .sort(([a], [b]) => a - b)
-                .map(([idx, acc]) => ({
-                  model: deltaModel,
-                  choices: [{
-                    index: idx,
-                    delta: { role: "assistant" as const, content: acc.content },
-                    finish_reason: acc.finish_reason ?? null,
-                  }],
-                })),
-              stream: true,
-            });
-          } catch (e) {
-            handleStreamError(e, controller, log);
-          }
-        },
+      return forwardOpenAIStream({
+        backendResponse,
+        originalModel,
+        spec: completionStreamSpec,
+        logFields,
+        log,
       });
-
-      return new Response(stream, { headers: SSE_RESPONSE_HEADERS });
     }
 
-    // Non-streaming: always forward, extract logging data field-by-field
-    let raw: Record<string, unknown>;
-    try {
-      raw = await backendResponse.json() as Record<string, unknown>;
-    } catch {
-      return errorResponse("Backend returned an invalid response", 502);
-    }
-
-    raw.model = originalModel;
-
-    const choicesResult = z.array(z.looseObject({
-      index: z.number(),
-      text: z.string(),
-      finish_reason: z.string().nullable().optional(),
-    })).safeParse(raw.choices);
-
-    const usageResult = BackendUsageSchema.safeParse(raw.usage);
-
-    if (choicesResult.success) {
-      logChatUsage({
-        ...logFields,
-        usage: usageResult.success ? usageResult.data : undefined,
-        outputData: {
-          model: originalModel,
-          choices: choicesResult.data.map((ch) => ({
-            index: ch.index,
-            message: { role: "assistant", content: ch.text },
-          })),
-        },
-        stream: false,
-      });
-    } else {
-      log.warn({ issues: choicesResult.error.issues }, "Could not extract choices for logging");
-    }
-
-    return Response.json(raw);
+    return forwardOpenAINonStream({
+      backendResponse,
+      originalModel,
+      spec: completionNonStreamSpec,
+      logFields,
+      log,
+    });
   } catch (error) {
     return handleEndpointError(error, log);
   }

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-embeddings.test.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-embeddings.test.ts
@@ -225,6 +225,8 @@ describe("handleEmbeddingGeneration", () => {
       host: `localhost:${mockPort}`,
       model: "test-chat-model",
       driver: "vllm",
+      authToken: null,
+      tls: false,
       type: "chat",
       tags: [],
       requestParams: {},

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-embeddings.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-embeddings.ts
@@ -7,7 +7,7 @@ import { backendFetch, backendUrl } from "../backend-fetch";
 
 const log = rootLogger.child({ name: "handle-embeddings" });
 
-const EmbeddingBodySchema = z.looseObject({
+export const EmbeddingBodySchema = z.looseObject({
   model: z.string(),
   input: z.union([z.string(), z.array(z.string())]),
   encoding_format: z.enum(["float", "base64"]).optional().default("float"),

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-embeddings.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-embeddings.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
-import { resolveModel } from "../ai-sdk";
-import { errorResponse, forwardBackendError, recordUsage, validateModelType, handleEndpointError, validationError } from "../util";
+import { errorResponse, forwardBackendError, recordUsage } from "../util";
+import { withEndpointGuards } from "../endpoint-guards";
 import { rootLogger } from "../../logger";
 import { env } from "../../env";
 import { backendFetch, backendUrl } from "../backend-fetch";
@@ -15,22 +15,11 @@ export const EmbeddingBodySchema = z.looseObject({
   user: z.string().optional(),
 });
 
-export async function handleEmbeddingGeneration(req: Request): Promise<Response> {
-  try {
-    const resolved = await resolveModel(req);
-    if (resolved instanceof Response) return resolved;
-
-    const { auth, body: rawBody, modelInfo, originalModel } = resolved;
-
-    const typeError = validateModelType(modelInfo, ["embedding"]);
-    if (typeError) return typeError;
-
-    const parseResult = EmbeddingBodySchema.safeParse(rawBody);
-    if (!parseResult.success) {
-      return validationError(parseResult.error);
-    }
-    const body = parseResult.data;
-
+export const handleEmbeddingGeneration = withEndpointGuards({
+  modelTypes: ["embedding"],
+  bodySchema: EmbeddingBodySchema,
+  log,
+  handler: async ({ auth, body, modelInfo, originalModel, req }) => {
     const callStartTime = Date.now();
 
     const fetchBody: Record<string, unknown> = {
@@ -38,8 +27,12 @@ export async function handleEmbeddingGeneration(req: Request): Promise<Response>
       input: body.input,
       encoding_format: body.encoding_format,
     };
-    if (body.dimensions != null) fetchBody.dimensions = body.dimensions;
-    if (body.user != null) fetchBody.user = body.user;
+    if (body.dimensions != null) {
+      fetchBody.dimensions = body.dimensions;
+    }
+    if (body.user != null) {
+      fetchBody.user = body.user;
+    }
 
     const backendResponse = await backendFetch(backendUrl(modelInfo.host, modelInfo.model, "/v1/embeddings", modelInfo.tls), {
       method: "POST",
@@ -53,7 +46,6 @@ export async function handleEmbeddingGeneration(req: Request): Promise<Response>
       return forwardBackendError(backendResponse, log);
     }
 
-    // Always forward, extract usage best-effort
     let raw: Record<string, unknown>;
     try {
       raw = await backendResponse.json() as Record<string, unknown>;
@@ -81,7 +73,5 @@ export async function handleEmbeddingGeneration(req: Request): Promise<Response>
     }
 
     return Response.json(raw);
-  } catch (error) {
-    return handleEndpointError(error, log);
-  }
-}
+  },
+});

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-models.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-models.ts
@@ -1,6 +1,28 @@
-import { modelDeploymentT, modelInstallationT, organizationT, sql, deploymentMatchesInstallation, type ModelDeployment, type ModelInstallation } from "common-db";
+import { modelDeploymentT, modelInstallationT, modelInstallationStateT, organizationT, sql, deploymentMatchesInstallation, type ModelDeployment, lifecycleStateEnum } from "common-db";
 import { getDB } from "../../db";
 import { checkAuth } from "../auth";
+
+const TRUTHY_QUERY_VALUES = new Set(["true", "1"]);
+
+type LifecycleState = typeof lifecycleStateEnum.enumValues[number];
+type InstallationLifecycle = LifecycleState | null;
+
+const LIFECYCLE_PRIORITY: Record<LifecycleState, number> = {
+  ready: 4,
+  installing: 3,
+  downloading: 2,
+  failed: 1,
+};
+
+function deriveStatus(lifecycles: InstallationLifecycle[]): LifecycleState | null {
+  if (lifecycles.length === 0) {
+    return null;
+  }
+  const concrete: LifecycleState[] = lifecycles.map(l => l ?? "downloading");
+  return concrete.reduce((best, current) => {
+    return LIFECYCLE_PRIORITY[current] > LIFECYCLE_PRIORITY[best] ? current : best;
+  });
+}
 
 export async function handleModelsRequest(req: Request): Promise<Response> {
   const authHeader = req.headers.get("authorization") || "";
@@ -10,44 +32,52 @@ export async function handleModelsRequest(req: Request): Promise<Response> {
   }
   const { orgId } = authCheckResponse;
 
+  const includeUnavailable = TRUTHY_QUERY_VALUES.has(
+    (new URL(req.url).searchParams.get("include_unavailable") ?? "").toLowerCase(),
+  );
+
   const [organization] = await getDB().select().from(organizationT).where(sql`${organizationT.id} = ${orgId}`).limit(1);
   const models = await getDB()
     .select()
     .from(modelDeploymentT)
     .leftJoin(modelInstallationT, sql`${deploymentMatchesInstallation} AND ${modelInstallationT.deletedAt} IS NULL`)
+    .leftJoin(modelInstallationStateT, sql`${modelInstallationStateT.id} = ${modelInstallationT.id}`)
     .where(sql`${modelDeploymentT.organizationId} = ${orgId} AND ${modelDeploymentT.deletedAt} IS NULL`);
 
-  const modelMap = new Map<string, { modelDeployment: ModelDeployment, modelInstallations: ModelInstallation[] }>();
-  models.forEach(model => {
-    if (modelMap.has(model.model_deployment.publicSpecifier)) {
-      if (model.model_installation) {
-        modelMap.get(model.model_deployment.publicSpecifier)?.modelInstallations.push(model.model_installation);
+  const modelMap = new Map<string, { modelDeployment: ModelDeployment; lifecycles: InstallationLifecycle[] }>();
+  models.forEach(row => {
+    const key = row.model_deployment.publicSpecifier;
+    const lifecycle: InstallationLifecycle = row.model_installation
+      ? (row.model_installation_state?.lifecycleState ?? null)
+      : null;
+    const entry = modelMap.get(key);
+    if (entry) {
+      if (row.model_installation) {
+        entry.lifecycles.push(lifecycle);
       }
     } else {
-      modelMap.set(model.model_deployment.publicSpecifier, {
-        modelDeployment: model.model_deployment,
-        modelInstallations: model.model_installation ? [model.model_installation] : [],
+      modelMap.set(key, {
+        modelDeployment: row.model_deployment,
+        lifecycles: row.model_installation ? [lifecycle] : [],
       });
     }
   });
 
-  const modelOutput = Array.from(modelMap.values()).map(model => {
-    const isCanary = model.modelDeployment.progress !== 100;
-    // Status is ready if there is at least one installation older then 5 min, loading if there is at least one, not_ready otherwise
-    const status = model.modelInstallations.some(installation => installation.createdAt < new Date(Date.now() - 5 * 60 * 1000)) ? "ready" :
-      model.modelInstallations.length > 0 ? "loading" : "not_ready";
-    return {
-      id: model.modelDeployment.publicSpecifier,
-      object: "model",
-      created: Math.floor(model.modelDeployment.createdAt.valueOf() / 1000),
-      owned_by: organization?.slug || "organization",
-      status,
-      canary: isCanary,
-    }
-  })
+  const modelOutput = Array.from(modelMap.values()).map(model => ({
+    id: model.modelDeployment.publicSpecifier,
+    object: "model",
+    created: Math.floor(model.modelDeployment.createdAt.valueOf() / 1000),
+    owned_by: organization?.slug || "organization",
+    status: deriveStatus(model.lifecycles),
+    canary: model.modelDeployment.progress !== 100,
+  }));
+  const visibleModels = includeUnavailable
+    ? modelOutput
+    : modelOutput.filter(model => model.status === "ready");
+
   return new Response(JSON.stringify({
     object: "list",
-    data: modelOutput,
+    data: visibleModels,
   }), {
     headers: {
       "Content-Type": "application/json",

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-rerank.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-rerank.ts
@@ -11,7 +11,7 @@ const log = rootLogger.child({ name: "handle-rerank" });
 // Request body schema
 // ---------------------------------------------------------------------------
 
-const RerankBodySchema = z.looseObject({
+export const RerankBodySchema = z.looseObject({
   model: z.string(),
   query: z.string(),
   documents: z.array(z.union([z.string(), z.record(z.string(), z.unknown())])),

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-rerank.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-rerank.ts
@@ -1,15 +1,11 @@
 import { z } from "zod";
-import { resolveModel } from "../ai-sdk";
-import { forwardBackendError, validateModelType, handleEndpointError, validationError } from "../util";
+import { forwardBackendError } from "../util";
+import { withEndpointGuards } from "../endpoint-guards";
 import { rootLogger } from "../../logger";
 import { env } from "../../env";
 import { backendFetch, backendUrl } from "../backend-fetch";
 
 const log = rootLogger.child({ name: "handle-rerank" });
-
-// ---------------------------------------------------------------------------
-// Request body schema
-// ---------------------------------------------------------------------------
 
 export const RerankBodySchema = z.looseObject({
   model: z.string(),
@@ -19,28 +15,11 @@ export const RerankBodySchema = z.looseObject({
   return_documents: z.boolean().optional().default(true),
 });
 
-// ---------------------------------------------------------------------------
-// Handler
-// ---------------------------------------------------------------------------
-
-export async function handleRerank(req: Request): Promise<Response> {
-  try {
-    const resolved = await resolveModel(req);
-    if (resolved instanceof Response) {
-      return resolved;
-    }
-
-    const { body: rawBody, modelInfo, originalModel } = resolved;
-
-    const typeError = validateModelType(modelInfo, ["rerank"]);
-    if (typeError) return typeError;
-
-    const parseResult = RerankBodySchema.safeParse(rawBody);
-    if (!parseResult.success) {
-      return validationError(parseResult.error);
-    }
-    const body = parseResult.data;
-
+export const handleRerank = withEndpointGuards({
+  modelTypes: ["rerank"],
+  bodySchema: RerankBodySchema,
+  log,
+  handler: async ({ body, modelInfo, originalModel, req }) => {
     const backendResponse = await backendFetch(backendUrl(modelInfo.host, modelInfo.model, "/v1/rerank", modelInfo.tls), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -65,7 +44,5 @@ export async function handleRerank(req: Request): Promise<Response> {
       ...result,
       model: originalModel,
     });
-  } catch (error) {
-    return handleEndpointError(error, log);
-  }
-}
+  },
+});

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-responses.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-responses.ts
@@ -230,7 +230,7 @@ export async function handleCreateResponseRequest(req: Request): Promise<Respons
       modelSpecifier: originalModel,
       inputMessages: messagesForDB,
       callStartTime,
-      logCalls: body.store ?? true,
+      logCalls: body.store,
       metadata: body.metadata as Record<string, unknown> | undefined,
     } as const;
 
@@ -340,7 +340,7 @@ type LogFields = {
   readonly modelSpecifier: string;
   readonly inputMessages: ApiCallInputMessage[];
   readonly callStartTime: number;
-  readonly logCalls: boolean;
+  readonly logCalls: boolean | undefined;
   readonly metadata: Record<string, unknown> | undefined;
 };
 

--- a/packages/xinity-ai-gateway/src/llm-forward/openai-forward.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/openai-forward.ts
@@ -1,0 +1,159 @@
+import { z } from "zod";
+import {
+  errorResponse,
+  handleStreamError,
+  logChatUsage,
+  readSSEStream,
+  SSE_RESPONSE_HEADERS,
+  sseEncoder,
+} from "./util";
+import { BackendUsageSchema } from "./backend-schemas";
+import type { AuthResult } from "./auth";
+import type { ApiCallInputMessage } from "common-db";
+import type { ChatStreamData, ChatSyncData } from "../callLogger";
+
+type Logger = {
+  info: (obj: Record<string, unknown>, msg: string) => void;
+  warn: (obj: Record<string, unknown>, msg: string) => void;
+  error: (obj: Record<string, unknown>, msg: string) => void;
+};
+
+export type OpenAIForwardLogFields = {
+  auth: AuthResult;
+  modelInfo: { model: string };
+  modelSpecifier: string;
+  inputMessages: ApiCallInputMessage[];
+  callStartTime: number;
+  logCalls?: boolean;
+  metadata?: Record<string, unknown>;
+};
+
+type StreamChunkLike = {
+  choices: Array<{ index: number }>;
+  model: string;
+  usage?: z.infer<typeof BackendUsageSchema>;
+};
+
+export type StreamSpec<Chunk extends StreamChunkLike, Acc> = {
+  chunkSchema: z.ZodType<Chunk>;
+  initAcc: () => Acc;
+  applyChoice: (acc: Acc, choice: Chunk["choices"][number]) => void;
+  toLogEntry: (acc: Acc, index: number, model: string) => ChatStreamData[number];
+};
+
+export function forwardOpenAIStream<Chunk extends StreamChunkLike, Acc>({
+  backendResponse,
+  originalModel,
+  spec,
+  logFields,
+  log,
+}: {
+  backendResponse: Response;
+  originalModel: string;
+  spec: StreamSpec<Chunk, Acc>;
+  logFields: OpenAIForwardLogFields;
+  log: Logger;
+}): Response {
+  let collectedUsage: z.infer<typeof BackendUsageSchema> | undefined;
+  const accumByChoice = new Map<number, Acc>();
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      try {
+        for await (const event of readSSEStream(backendResponse)) {
+          if (event.data === "[DONE]") {
+            controller.enqueue(sseEncoder.encode("data: [DONE]\n\n"));
+            break;
+          }
+
+          let json: unknown;
+          try {
+            json = JSON.parse(event.data);
+          } catch {
+            log.warn({ data: event.data }, "Non-JSON SSE chunk from backend, skipping");
+            continue;
+          }
+          const parsed = spec.chunkSchema.safeParse(json);
+          if (!parsed.success) {
+            log.warn({ issues: parsed.error.issues }, "Malformed backend SSE chunk, skipping");
+            continue;
+          }
+          const chunk = { ...parsed.data, model: originalModel };
+
+          if (chunk.usage) {
+            collectedUsage = chunk.usage;
+          }
+          if (chunk.choices.length) {
+            for (const choice of chunk.choices) {
+              let acc = accumByChoice.get(choice.index);
+              if (!acc) {
+                acc = spec.initAcc();
+                accumByChoice.set(choice.index, acc);
+              }
+              spec.applyChoice(acc, choice);
+            }
+          }
+
+          controller.enqueue(sseEncoder.encode(`data: ${JSON.stringify(chunk)}\n\n`));
+        }
+        controller.close();
+
+        const outputData: ChatStreamData = [...accumByChoice.entries()]
+          .sort(([a], [b]) => a - b)
+          .map(([idx, acc]) => spec.toLogEntry(acc, idx, originalModel));
+
+        logChatUsage({
+          ...logFields,
+          usage: collectedUsage,
+          outputData,
+          stream: true,
+        });
+      } catch (e) {
+        handleStreamError(e, controller, log);
+      }
+    },
+  });
+
+  return new Response(stream, { headers: SSE_RESPONSE_HEADERS });
+}
+
+export type NonStreamSpec<Choice> = {
+  choicesSchema: z.ZodType<Choice[]>;
+  toLogOutput: (choices: Choice[], model: string) => ChatSyncData;
+};
+
+export async function forwardOpenAINonStream<Choice>({
+  backendResponse,
+  originalModel,
+  spec,
+  logFields,
+  log,
+}: {
+  backendResponse: Response;
+  originalModel: string;
+  spec: NonStreamSpec<Choice>;
+  logFields: OpenAIForwardLogFields;
+  log: Logger;
+}): Promise<Response> {
+  let raw: Record<string, unknown>;
+  try {
+    raw = await backendResponse.json() as Record<string, unknown>;
+  } catch {
+    return errorResponse("Backend returned an invalid response", 502);
+  }
+  raw.model = originalModel;
+
+  const choicesResult = spec.choicesSchema.safeParse(raw.choices);
+  const usageResult = BackendUsageSchema.safeParse(raw.usage);
+  if (choicesResult.success) {
+    logChatUsage({
+      ...logFields,
+      usage: usageResult.success ? usageResult.data : undefined,
+      outputData: spec.toLogOutput(choicesResult.data, originalModel),
+      stream: false,
+    });
+  } else {
+    log.warn({ issues: choicesResult.error.issues }, "Could not extract choices for logging");
+  }
+  return Response.json(raw);
+}

--- a/packages/xinity-ai-gateway/src/llm-forward/responses/schemas.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/responses/schemas.ts
@@ -42,7 +42,7 @@ export const CreateResponseBodySchema = z.object({
   input: z.unknown(),
   stream: z.boolean().optional().default(false),
   background: z.boolean().optional().default(false),
-  store: z.boolean().optional().default(true),
+  store: z.boolean().optional(),
   temperature: z.number().optional(),
   top_p: z.number().optional(),
   max_output_tokens: z.number().nullable().optional(),

--- a/packages/xinity-ai-gateway/src/llm-forward/util.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/util.ts
@@ -109,6 +109,11 @@ export type RecordUsageContext = {
   auth: AuthResult;
   modelInfo: { model: string };
   callStartTime: number;
+  /**
+   * Per-request override for whether the call body is stored:
+   *   `undefined` defers to the API key's `collectData` policy,
+   *   `true`/`false` ignore the policy and force the outcome.
+   */
   logCalls?: boolean;
   /** The deployment's public specifier, used for per-deployment metrics. */
   deployment?: string;
@@ -120,14 +125,16 @@ export const recordUsage = ({
   auth,
   modelInfo,
   callStartTime,
-  logCalls = true,
+  logCalls,
   deployment,
 }: RecordUsageContext): boolean => {
   const durationMs = Date.now() - callStartTime;
   recordTokenUsage(modelInfo.model, auth.keyId, usage, { deployment, durationMs });
-  if (!usage) return false;
+  if (!usage) {
+    return false;
+  }
 
-  const shouldLog = auth.collectData && logCalls;
+  const shouldLog = logCalls ?? auth.collectData;
 
   recordUsageEvent({
     organizationId: auth.orgId,
@@ -168,11 +175,13 @@ export const logChatUsage = ({
   modelSpecifier,
   inputMessages,
   callStartTime,
-  logCalls = true,
+  logCalls,
   metadata,
 }: UsageLogContext) => {
   const shouldLog = recordUsage({ usage, auth, modelInfo, callStartTime, logCalls, deployment: modelSpecifier });
-  if (!shouldLog) return;
+  if (!shouldLog) {
+    return;
+  }
 
   const commonFields = {
     keyId: auth.keyId,

--- a/packages/xinity-ai-gateway/src/openai-compat-openapi.ts
+++ b/packages/xinity-ai-gateway/src/openai-compat-openapi.ts
@@ -1,0 +1,347 @@
+import { z } from "zod";
+import type { OpenAPI } from "@orpc/openapi";
+import { ChatCompletionBodySchema } from "./llm-forward/endpoints/handle-chatCompletion";
+import { CompletionBodySchema } from "./llm-forward/endpoints/handle-completions";
+import { EmbeddingBodySchema } from "./llm-forward/endpoints/handle-embeddings";
+import { RerankBodySchema } from "./llm-forward/endpoints/handle-rerank";
+import { CreateResponseBodySchema } from "./llm-forward/responses/schemas";
+
+const TAG = "OpenAI Compatible";
+const SECURITY = [{ bearerAuth: [] }];
+
+const STORE_NOTE =
+  "`store` (Xinity semantics): omit to defer to the API key's data-collection policy. `true`/`false` are explicit overrides that ignore the per-key policy.";
+const APP_HEADER_NOTE =
+  "`X-Application` request header (optional, Xinity extension): routes the call to a named application for organizing usage in the dashboard.";
+const METADATA_NOTE =
+  "`metadata` is surfaced in the Xinity dashboard as filterable tags on each call.";
+
+function toSchema(schema: z.ZodTypeAny): OpenAPI.SchemaObject {
+  const json = z.toJSONSchema(schema, { unrepresentable: "any" }) as Record<string, unknown>;
+  delete json.$schema;
+  return json as OpenAPI.SchemaObject;
+}
+
+const errorResponseSchema = {
+  type: "object",
+  required: ["error"],
+  properties: {
+    error: {
+      type: "object",
+      required: ["message", "type"],
+      properties: {
+        message: { type: "string" },
+        type: { type: "string" },
+        code: { type: ["string", "null"] },
+      },
+    },
+  },
+};
+
+const usageSchema = {
+  type: "object",
+  additionalProperties: true,
+  properties: {
+    prompt_tokens: { type: "integer" },
+    completion_tokens: { type: "integer" },
+    total_tokens: { type: "integer" },
+  },
+};
+
+const modelObjectSchema = {
+  type: "object",
+  additionalProperties: true,
+  required: ["id", "object", "created", "owned_by", "status", "canary"],
+  properties: {
+    id: { type: "string" },
+    object: { type: "string", enum: ["model"] },
+    created: { type: "integer" },
+    owned_by: { type: "string" },
+    status: {
+      type: "string",
+      enum: ["ready", "loading", "not_ready"],
+      description: "Xinity extension. Readiness of the deployment. Default `/v1/models` only returns `ready`; pass `?include_unavailable=true` to see the rest.",
+    },
+    canary: {
+      type: "boolean",
+      description: "Xinity extension. True while a canary rollout's progress is below 100%.",
+    },
+  },
+};
+
+const modelsListResponseSchema = {
+  type: "object",
+  required: ["object", "data"],
+  properties: {
+    object: { type: "string", enum: ["list"] },
+    data: { type: "array", items: { $ref: "#/components/schemas/ModelObject" } },
+  },
+};
+
+const passthroughObject = { type: "object", additionalProperties: true };
+
+const errorJsonContent = { "application/json": { schema: { $ref: "#/components/schemas/Error" } } };
+const errorResponses = {
+  "400": { description: "Bad request", content: errorJsonContent },
+  "401": { description: "Missing or invalid API key", content: errorJsonContent },
+  "403": { description: "Forbidden", content: errorJsonContent },
+  "404": { description: "Not found", content: errorJsonContent },
+  "429": { description: "Backend queue is full; retry with backoff", content: errorJsonContent },
+  "500": { description: "Internal server error", content: errorJsonContent },
+  "502": { description: "Bad gateway from inference backend", content: errorJsonContent },
+  "503": { description: "Backend unavailable", content: errorJsonContent },
+  "504": { description: "Backend timed out", content: errorJsonContent },
+};
+
+const sseContent = {
+  "text/event-stream": { schema: { type: "string" } },
+};
+
+function jsonRequest(schemaRef: string) {
+  return {
+    required: true,
+    content: { "application/json": { schema: { $ref: schemaRef } } },
+  };
+}
+
+export const openaiCompatSchemas = {
+  Error: errorResponseSchema,
+  Usage: usageSchema,
+  ModelObject: modelObjectSchema,
+  ModelsListResponse: modelsListResponseSchema,
+  ChatCompletionRequest: toSchema(ChatCompletionBodySchema),
+  ChatCompletionResponse: passthroughObject,
+  CompletionRequest: toSchema(CompletionBodySchema),
+  CompletionResponse: passthroughObject,
+  EmbeddingRequest: toSchema(EmbeddingBodySchema),
+  EmbeddingResponse: passthroughObject,
+  RerankRequest: toSchema(RerankBodySchema),
+  RerankResponse: passthroughObject,
+  CreateResponseRequest: toSchema(CreateResponseBodySchema),
+  ResponseObject: passthroughObject,
+} as Record<string, OpenAPI.SchemaObject>;
+
+export const openaiCompatPaths = {
+  "/v1/models": {
+    get: {
+      tags: [TAG],
+      summary: "List models",
+      description: [
+        "OpenAI: https://platform.openai.com/docs/api-reference/models/list",
+        "",
+        "Xinity differences:",
+        "- Defaults to filtering for `status: ready` deployments. Pass `?include_unavailable=true` to also receive `loading` and `not_ready` deployments.",
+        "- Each item carries Xinity extension fields `status` and `canary` (see ModelObject).",
+      ].join("\n"),
+      security: SECURITY,
+      parameters: [
+        {
+          name: "include_unavailable",
+          in: "query",
+          required: false,
+          description: "Include deployments whose lifecycle state is not `ready`. Accepts `true` or `1`.",
+          schema: { type: "boolean", default: false },
+        },
+      ],
+      responses: {
+        "200": {
+          description: "List of models",
+          content: { "application/json": { schema: { $ref: "#/components/schemas/ModelsListResponse" } } },
+        },
+        ...errorResponses,
+      },
+    },
+  },
+  "/v1/chat/completions": {
+    post: {
+      tags: [TAG],
+      summary: "Create a chat completion",
+      description: [
+        "OpenAI: https://platform.openai.com/docs/api-reference/chat/create",
+        "",
+        "Xinity differences:",
+        `- ${STORE_NOTE}`,
+        `- ${METADATA_NOTE}`,
+        "- `structured_outputs` is only honored for vLLM-driven models; rejected with 400 otherwise.",
+        `- ${APP_HEADER_NOTE}`,
+      ].join("\n"),
+      security: SECURITY,
+      requestBody: jsonRequest("#/components/schemas/ChatCompletionRequest"),
+      responses: {
+        "200": {
+          description: "Chat completion, or SSE stream when `stream: true`",
+          content: {
+            "application/json": { schema: { $ref: "#/components/schemas/ChatCompletionResponse" } },
+            ...sseContent,
+          },
+        },
+        ...errorResponses,
+      },
+    },
+  },
+  "/v1/completions": {
+    post: {
+      tags: [TAG],
+      summary: "Create a text completion (legacy)",
+      description: [
+        "OpenAI: https://platform.openai.com/docs/api-reference/completions/create",
+        "",
+        "Xinity differences:",
+        `- ${STORE_NOTE}`,
+        `- ${METADATA_NOTE}`,
+        `- ${APP_HEADER_NOTE}`,
+      ].join("\n"),
+      security: SECURITY,
+      requestBody: jsonRequest("#/components/schemas/CompletionRequest"),
+      responses: {
+        "200": {
+          description: "Text completion, or SSE stream when `stream: true`",
+          content: {
+            "application/json": { schema: { $ref: "#/components/schemas/CompletionResponse" } },
+            ...sseContent,
+          },
+        },
+        ...errorResponses,
+      },
+    },
+  },
+  "/v1/embeddings": {
+    post: {
+      tags: [TAG],
+      summary: "Create embeddings",
+      description: [
+        "OpenAI: https://platform.openai.com/docs/api-reference/embeddings/create",
+        "",
+        "Xinity differences:",
+        `- ${APP_HEADER_NOTE}`,
+        "- Embedding call payloads are never persisted regardless of API key policy.",
+      ].join("\n"),
+      security: SECURITY,
+      requestBody: jsonRequest("#/components/schemas/EmbeddingRequest"),
+      responses: {
+        "200": {
+          description: "Embedding vectors",
+          content: { "application/json": { schema: { $ref: "#/components/schemas/EmbeddingResponse" } } },
+        },
+        ...errorResponses,
+      },
+    },
+  },
+  "/v1/rerank": {
+    post: {
+      tags: [TAG],
+      summary: "Rerank documents by relevance to a query",
+      description: [
+        "Cohere v1 rerank: https://docs.cohere.com/v1/reference/rerank",
+        "",
+        "Xinity notes:",
+        "- Only available for deployments whose model type is `rerank`.",
+        `- ${APP_HEADER_NOTE}`,
+      ].join("\n"),
+      security: SECURITY,
+      requestBody: jsonRequest("#/components/schemas/RerankRequest"),
+      responses: {
+        "200": {
+          description: "Reranked documents",
+          content: { "application/json": { schema: { $ref: "#/components/schemas/RerankResponse" } } },
+        },
+        ...errorResponses,
+      },
+    },
+  },
+  "/v1/responses": {
+    post: {
+      tags: [TAG],
+      summary: "Create a response",
+      description: [
+        "OpenAI: https://platform.openai.com/docs/api-reference/responses/create",
+        "",
+        "Xinity differences:",
+        `- ${STORE_NOTE}`,
+        `- ${METADATA_NOTE}`,
+        "- Supported tool types: `function`, plus `web_search` (and the `web_search_preview*` aliases). Other built-in tools are not implemented.",
+        `- ${APP_HEADER_NOTE}`,
+      ].join("\n"),
+      security: SECURITY,
+      requestBody: jsonRequest("#/components/schemas/CreateResponseRequest"),
+      responses: {
+        "200": {
+          description: "Completed response, or SSE stream when `stream: true`",
+          content: {
+            "application/json": { schema: { $ref: "#/components/schemas/ResponseObject" } },
+            ...sseContent,
+          },
+        },
+        "202": {
+          description: "Accepted; response is being generated in the background (`background: true`)",
+          content: { "application/json": { schema: { $ref: "#/components/schemas/ResponseObject" } } },
+        },
+        ...errorResponses,
+      },
+    },
+  },
+  "/v1/responses/{responseId}": {
+    parameters: [
+      {
+        name: "responseId",
+        in: "path",
+        required: true,
+        schema: { type: "string" },
+      },
+    ],
+    get: {
+      tags: [TAG],
+      summary: "Retrieve a stored response",
+      description: "OpenAI: https://platform.openai.com/docs/api-reference/responses/get",
+      security: SECURITY,
+      responses: {
+        "200": {
+          description: "The stored response object",
+          content: { "application/json": { schema: { $ref: "#/components/schemas/ResponseObject" } } },
+        },
+        ...errorResponses,
+      },
+    },
+    delete: {
+      tags: [TAG],
+      summary: "Delete a stored response",
+      description: "OpenAI: https://platform.openai.com/docs/api-reference/responses/delete",
+      security: SECURITY,
+      responses: {
+        "200": {
+          description: "Deletion confirmation",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["id", "object", "deleted"],
+                properties: {
+                  id: { type: "string" },
+                  object: { type: "string", enum: ["response"] },
+                  deleted: { type: "boolean" },
+                },
+              },
+            },
+          },
+        },
+        ...errorResponses,
+      },
+    },
+  },
+} as unknown as OpenAPI.PathsObject;
+
+export const openaiCompatTags: OpenAPI.TagObject[] = [
+  {
+    name: TAG,
+    description:
+      "Endpoints under `/v1/*` that mirror the OpenAI (and, for `/v1/rerank`, Cohere v1) APIs. Point an OpenAI client's `baseURL` at this gateway's `/v1`. Each operation links to the upstream reference; only Xinity-specific differences are documented inline.",
+  },
+];
+
+export const openaiCompatSecuritySchemes: Record<string, OpenAPI.SecuritySchemeObject> = {
+  bearerAuth: {
+    type: "http",
+    scheme: "bearer",
+    description: "Xinity API key, sent as `Authorization: Bearer <key>`.",
+  },
+};

--- a/packages/xinity-ai-gateway/src/openai-compat-openapi.ts
+++ b/packages/xinity-ai-gateway/src/openai-compat-openapi.ts
@@ -58,9 +58,9 @@ const modelObjectSchema = {
     created: { type: "integer" },
     owned_by: { type: "string" },
     status: {
-      type: "string",
-      enum: ["ready", "loading", "not_ready"],
-      description: "Xinity extension. Readiness of the deployment. Default `/v1/models` only returns `ready`; pass `?include_unavailable=true` to see the rest.",
+      type: ["string", "null"],
+      enum: ["downloading", "installing", "ready", "failed", null],
+      description: "Xinity extension. Aggregated installation lifecycle state across the deployment's replicas (best-state wins). `null` when no installation exists. Default `/v1/models` only returns deployments with `status: ready`; pass `?include_unavailable=true` to see the rest.",
     },
     canary: {
       type: "boolean",

--- a/packages/xinity-ai-gateway/src/openapi.ts
+++ b/packages/xinity-ai-gateway/src/openapi.ts
@@ -1,6 +1,12 @@
 import { version } from "../../../package.json";
 import scalar from "./assets/scalar.html" with { type: "text" };
 import { serverRouter } from "./rpc/gatewayRouter";
+import {
+  openaiCompatPaths,
+  openaiCompatSchemas,
+  openaiCompatSecuritySchemes,
+  openaiCompatTags,
+} from "./openai-compat-openapi";
 
 export async function createOpenapiSpec() {
   const { OpenAPIGenerator } = await import("@orpc/openapi");
@@ -12,25 +18,20 @@ export async function createOpenapiSpec() {
     info: {
       title: "Xinity AI Gateway",
       version,
-      description: `The gateway represents one of the central pieces of xinity infrastructure. It    
+      description: `The gateway represents one of the central pieces of xinity infrastructure. It
       - forwards calls to the respective target nodes running models
       - records usage and api call contents / messages
       - provides metrics about model usage, for observability
 
-      All capabilities are presented via an OpenAI-compatible API focusing on embeddings and chat completion, which is not individually documented here.
-      Simply point the baseUrl of an OpenAI client toward /v1
+      OpenAI-compatible endpoints are listed below under the "OpenAI Compatible" tag.
+      Point the baseUrl of an OpenAI client toward /v1 to use them.
       `,
     },
-    tags: [],
-    commonSchemas: {},
+    tags: openaiCompatTags,
+    paths: openaiCompatPaths,
     components: {
-      // securitySchemes: {
-      //   apiKeyAuth: {
-      //     type: "apiKey",
-      //     in: "header",
-      //     name: "x-apikey",
-      //   },
-      // },
+      schemas: openaiCompatSchemas,
+      securitySchemes: openaiCompatSecuritySchemes,
     },
   });
   return new Response(JSON.stringify(spec), {

--- a/packages/xinity-cli/src/lib/env-prompt.ts
+++ b/packages/xinity-cli/src/lib/env-prompt.ts
@@ -4,7 +4,7 @@ import pc from "picocolors";
 import { cancelAndExit } from "./output.ts";
 import { parseEnvString } from "./env-file.ts";
 import { type Component, ENV_SCHEMAS, ENV_DIR, SECRETS_DIR, getAutoDefaults } from "./component-meta.ts";
-import { writeEnvConfig, restartService } from "./service.ts";
+import { writeEnvConfig, writeSystemdUnit, restartService } from "./service.ts";
 import { createLocalHost, readSecrets, type Host } from "./host.ts";
 
 export interface EnvField {
@@ -373,6 +373,7 @@ export async function menuConfigureEnv(
 
   const wrote = await writeEnvConfig(component, result.config, result.secrets, h);
   if (wrote) {
+    await writeSystemdUnit(component, Object.keys(result.secrets), h);
     await restartService(component, h);
   }
   p.outro("Done");

--- a/packages/xinity-cli/src/lib/installer.ts
+++ b/packages/xinity-cli/src/lib/installer.ts
@@ -19,7 +19,7 @@ import { analyzeEnvSchema, categorizeFields, menuEditEnv, promptForEnv } from ".
 import { parseEnvString } from "./env-file.ts";
 import { pass, fail, warn, info, cancelAndExit } from "./output.ts";
 import { type Host, createLocalHost, commandExistsOn, isUnitActiveOn, readSecrets } from "./host.ts";
-import { writeEnvConfig, stopService, startService } from "./service.ts";
+import { writeEnvConfig, writeSystemdUnit, stopService, startService } from "./service.ts";
 import {
   type Component, type InstallResult, type RemoveResult,
   ENV_SCHEMAS, ENV_DIR, SECRETS_DIR, BIN_DIR, DASHBOARD_DIR, UNIT_DIR,
@@ -621,30 +621,6 @@ async function configureEnv(
   return promptForEnv(component, schema, existing);
 }
 
-// ─── Systemd unit ──────────────────────────────────────────────────────────
-
-async function installUnit(component: Component, secretKeys: string[], host: Host): Promise<boolean> {
-  const baseConfig = getComponentConfig(component);
-  const config: UnitConfig = { ...baseConfig, secretKeys };
-
-  const unitContent = generateUnit(config);
-  const unitPath = `${UNIT_DIR}/${unitName(component)}`;
-
-  const result = await host.withElevation(
-    `cat > ${unitPath} << 'UNITEOF'\n${unitContent}UNITEOF\nsystemctl daemon-reload`,
-    `Install ${component} systemd unit`,
-  );
-
-  if (!result.success && !result.skipped) {
-    fail("Systemd", result.output);
-    return false;
-  }
-  if (result.skipped) return false;
-
-  pass("Systemd", `Unit installed at ${unitPath}`);
-  return true;
-}
-
 // ─── Main orchestrator ─────────────────────────────────────────────────────
 
 type ArtifactResult =
@@ -761,8 +737,10 @@ async function configureAndStart(
     }
 
     const secretKeys = Object.keys(envResult.secrets);
-    const unitInstalled = await installUnit(component, secretKeys, host);
-    if (!unitInstalled) errors.push("Systemd unit not installed (may need manual setup)");
+    const unitInstalled = await writeSystemdUnit(component, secretKeys, host);
+    if (!unitInstalled) {
+      errors.push("Systemd unit not installed (may need manual setup)");
+    }
 
     const started = await startService(component, host);
     if (started) return errors;

--- a/packages/xinity-cli/src/lib/postgres-setup.ts
+++ b/packages/xinity-cli/src/lib/postgres-setup.ts
@@ -8,6 +8,7 @@
  * identically for local and remote (--target-host) execution.
  */
 import { randomBytes } from "crypto";
+import { quoteShellArg } from "common-env";
 import * as p from "./clack.ts";
 import pc from "picocolors";
 import { type Host, commandExistsOn } from "./host.ts";
@@ -217,7 +218,7 @@ async function createDatabase(
     p.log.step("Creating user and database requires access to the postgres system user.");
 
     const result = await host.withElevation(
-      `su - postgres -c "psql -c ${shellQuote(createUserSql)}" && su - postgres -c "psql -c ${shellQuote(createDbSql)}"`,
+      `su - postgres -c "psql -c ${quoteShellArg(createUserSql)}" && su - postgres -c "psql -c ${quoteShellArg(createDbSql)}"`,
       "Create PostgreSQL user and database",
     );
     if (!result.success) {
@@ -238,10 +239,6 @@ async function createDatabase(
   p.note(connectionUrl, "Connection URL");
 
   return connectionUrl;
-}
-
-function shellQuote(s: string): string {
-  return `'${s.replace(/'/g, "'\\''")}'`;
 }
 
 // ─── Install flow ───────────────────────────────────────────────────────────

--- a/packages/xinity-cli/src/lib/service.ts
+++ b/packages/xinity-cli/src/lib/service.ts
@@ -8,9 +8,9 @@
 import * as p from "./clack.ts";
 import pc from "picocolors";
 
-import { type Component, ENV_DIR, SECRETS_DIR } from "./component-meta.ts";
+import { type Component, ENV_DIR, SECRETS_DIR, UNIT_DIR } from "./component-meta.ts";
 import { serializeEnvFile } from "./env-file.ts";
-import { unitName } from "./systemd.ts";
+import { generateUnit, getComponentConfig, unitName, type UnitConfig } from "./systemd.ts";
 import { pass, fail, info } from "./output.ts";
 import { type Host, createLocalHost, isUnitActiveOn, getUnitStatusOn } from "./host.ts";
 
@@ -56,6 +56,38 @@ export async function writeEnvConfig(
   }
 
   pass("Config", "Environment configured");
+  return true;
+}
+
+/**
+ * Generate the systemd unit for a component and write it to /etc/systemd/system,
+ * then daemon-reload. 
+ */
+export async function writeSystemdUnit(
+  component: Component,
+  secretKeys: string[],
+  host: Host = createLocalHost(),
+): Promise<boolean> {
+  const baseConfig = getComponentConfig(component);
+  const config: UnitConfig = { ...baseConfig, secretKeys };
+
+  const unitContent = generateUnit(config);
+  const unitPath = `${UNIT_DIR}/${unitName(component)}`;
+
+  const result = await host.withElevation(
+    `cat > ${unitPath} << 'UNITEOF'\n${unitContent}UNITEOF\nsystemctl daemon-reload`,
+    `Install ${component} systemd unit`,
+  );
+
+  if (!result.success && !result.skipped) {
+    fail("Systemd", result.output);
+    return false;
+  }
+  if (result.skipped) {
+    return false;
+  }
+
+  pass("Systemd", `Unit installed at ${unitPath}`);
   return true;
 }
 

--- a/tests/system/gateway/gateway-test-helpers.ts
+++ b/tests/system/gateway/gateway-test-helpers.ts
@@ -1,6 +1,6 @@
 import { randomBytes, randomUUID } from "crypto";
 import { createServer } from "net";
-import { aiApiKeyT, aiApplicationT, aiNodeT, modelDeploymentT, modelInstallationT, organizationT, preconfigureDB, sql } from "common-db";
+import { aiApiKeyT, aiApplicationT, aiNodeT, modelDeploymentT, modelInstallationStateT, modelInstallationT, organizationT, preconfigureDB, sql } from "common-db";
 import { readProcessOutput, waitForHttp } from "../test-helpers";
 import { ensureInfoServerRunning, infoServerUrl } from "../infoserver/infoserver-test-helpers";
 import { ensureSystemReady } from "../guard";
@@ -229,6 +229,7 @@ export async function createModelInstallation(input: {
   estCapacity?: number;
   driver?: "ollama" | "vllm";
   deletedAt?: Date;
+  lifecycleState?: "downloading" | "installing" | "ready" | "failed";
 }): Promise<{ id: string }> {
   const [installation] = await getDB().insert(modelInstallationT).values({
     nodeId: input.nodeId,
@@ -239,8 +240,25 @@ export async function createModelInstallation(input: {
     deletedAt: input.deletedAt,
   }).returning();
 
+  if (input.lifecycleState) {
+    await getDB().insert(modelInstallationStateT).values({
+      id: installation!.id,
+      lifecycleState: input.lifecycleState,
+    });
+  }
+
   createdInstallationIds.push(installation!.id);
   return { id: installation!.id };
+}
+
+export async function createReadyInstallationFor(deployment: { publicSpecifier: string }): Promise<{ id: string }> {
+  const node = await createAiNode();
+  return createModelInstallation({
+    nodeId: node.id,
+    model: deployment.publicSpecifier,
+    port: await getAvailablePort(),
+    lifecycleState: "ready",
+  });
 }
 
 export function makeUnknownKey(): string {

--- a/tests/system/gateway/gateway.models.test.ts
+++ b/tests/system/gateway/gateway.models.test.ts
@@ -1,9 +1,12 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import {
   cleanupTestData,
+  createAiNode,
   createApiKey,
   createModelDeployment,
+  createModelInstallation,
   createOrganizationAndApp,
+  createReadyInstallationFor,
   ensureGatewayRunning,
   gatewayUrl,
 } from "./gateway-test-helpers";
@@ -33,6 +36,7 @@ describe("xinity-ai-gateway models", () => {
     const { orgId, appId } = await createOrganizationAndApp();
     const { fullKey } = await createApiKey({ orgId, appId });
     const deployment = await createModelDeployment({ orgId });
+    await createReadyInstallationFor(deployment);
 
     const res = await fetch(gatewayUrl("/v1/models"), {
       headers: { authorization: `Bearer ${fullKey}` },
@@ -45,6 +49,7 @@ describe("xinity-ai-gateway models", () => {
         {
           id: deployment.publicSpecifier,
           object: "model",
+          status: "ready",
         },
       ],
     });
@@ -77,6 +82,8 @@ describe("xinity-ai-gateway models", () => {
       orgId: orgB.orgId,
       publicSpecifier: `org-b-${orgB.orgId}`,
     });
+    await createReadyInstallationFor(deploymentA);
+    await createReadyInstallationFor(deploymentB);
 
     const resA = await fetch(gatewayUrl("/v1/models"), {
       headers: { authorization: `Bearer ${keyA.fullKey}` },
@@ -107,5 +114,96 @@ describe("xinity-ai-gateway models", () => {
         },
       ],
     });
+  });
+
+  it("hides non-ready deployments by default", async () => {
+    const { orgId, appId } = await createOrganizationAndApp();
+    const { fullKey } = await createApiKey({ orgId, appId });
+
+    const readyDeployment = await createModelDeployment({ orgId, publicSpecifier: `ready-${orgId}` });
+    await createReadyInstallationFor(readyDeployment);
+
+    const downloadingDeployment = await createModelDeployment({ orgId, publicSpecifier: `downloading-${orgId}` });
+    const installingDeployment = await createModelDeployment({ orgId, publicSpecifier: `installing-${orgId}` });
+    const failedDeployment = await createModelDeployment({ orgId, publicSpecifier: `failed-${orgId}` });
+    const node = await createAiNode();
+    await createModelInstallation({
+      nodeId: node.id,
+      model: downloadingDeployment.publicSpecifier,
+      port: 19990,
+      lifecycleState: "downloading",
+    });
+    await createModelInstallation({
+      nodeId: node.id,
+      model: installingDeployment.publicSpecifier,
+      port: 19991,
+      lifecycleState: "installing",
+    });
+    await createModelInstallation({
+      nodeId: node.id,
+      model: failedDeployment.publicSpecifier,
+      port: 19992,
+      lifecycleState: "failed",
+    });
+
+    await createModelDeployment({ orgId, publicSpecifier: `noinstall-${orgId}` });
+
+    const res = await fetch(gatewayUrl("/v1/models"), {
+      headers: { authorization: `Bearer ${fullKey}` },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { data: Array<{ id: string; status: string }> };
+    const ids = body.data.map((m) => m.id);
+    expect(ids).toContain(readyDeployment.publicSpecifier);
+    expect(ids).not.toContain(downloadingDeployment.publicSpecifier);
+    expect(ids).not.toContain(installingDeployment.publicSpecifier);
+    expect(ids).not.toContain(failedDeployment.publicSpecifier);
+    expect(ids).not.toContain(`noinstall-${orgId}`);
+    for (const m of body.data) expect(m.status).toBe("ready");
+  });
+
+  it("surfaces raw lifecycle states when include_unavailable=true", async () => {
+    const { orgId, appId } = await createOrganizationAndApp();
+    const { fullKey } = await createApiKey({ orgId, appId });
+
+    const readyDeployment = await createModelDeployment({ orgId, publicSpecifier: `ready-${orgId}` });
+    await createReadyInstallationFor(readyDeployment);
+
+    const downloadingDeployment = await createModelDeployment({ orgId, publicSpecifier: `downloading-${orgId}` });
+    const installingDeployment = await createModelDeployment({ orgId, publicSpecifier: `installing-${orgId}` });
+    const failedDeployment = await createModelDeployment({ orgId, publicSpecifier: `failed-${orgId}` });
+    const node = await createAiNode();
+    await createModelInstallation({
+      nodeId: node.id,
+      model: downloadingDeployment.publicSpecifier,
+      port: 19980,
+      lifecycleState: "downloading",
+    });
+    await createModelInstallation({
+      nodeId: node.id,
+      model: installingDeployment.publicSpecifier,
+      port: 19981,
+      lifecycleState: "installing",
+    });
+    await createModelInstallation({
+      nodeId: node.id,
+      model: failedDeployment.publicSpecifier,
+      port: 19982,
+      lifecycleState: "failed",
+    });
+
+    const noInstallDeployment = await createModelDeployment({ orgId, publicSpecifier: `noinstall-${orgId}` });
+
+    const res = await fetch(gatewayUrl("/v1/models?include_unavailable=true"), {
+      headers: { authorization: `Bearer ${fullKey}` },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { data: Array<{ id: string; status: string | null }> };
+    const byId = new Map(body.data.map((m) => [m.id, m.status]));
+    expect(byId.get(readyDeployment.publicSpecifier)).toBe("ready");
+    expect(byId.get(downloadingDeployment.publicSpecifier)).toBe("downloading");
+    expect(byId.get(installingDeployment.publicSpecifier)).toBe("installing");
+    expect(byId.get(failedDeployment.publicSpecifier)).toBe("failed");
+    expect(byId.get(noInstallDeployment.publicSpecifier)).toBe(null);
   });
 });

--- a/tests/system/gateway/gateway.openapi.test.ts
+++ b/tests/system/gateway/gateway.openapi.test.ts
@@ -1,0 +1,58 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { ensureGatewayRunning, gatewayUrl } from "./gateway-test-helpers";
+
+type OpenApiSpec = {
+  paths: Record<string, Record<string, { tags?: string[]; parameters?: Array<{ name: string; in: string }> }>>;
+  components?: {
+    schemas?: Record<string, unknown>;
+    securitySchemes?: Record<string, unknown>;
+  };
+};
+
+beforeAll(async () => {
+  await ensureGatewayRunning();
+});
+
+async function fetchSpec(): Promise<OpenApiSpec> {
+  const res = await fetch(gatewayUrl("/openapi.json"));
+  expect(res.status).toBe(200);
+  return await res.json() as OpenApiSpec;
+}
+
+describe("xinity-ai-gateway openapi spec", () => {
+  it("documents every OpenAI-compatible /v1/* route alongside oRPC routes", async () => {
+    const spec = await fetchSpec();
+    const paths = Object.keys(spec.paths);
+    expect(paths).toEqual(expect.arrayContaining([
+      "/v1/models",
+      "/v1/chat/completions",
+      "/v1/completions",
+      "/v1/embeddings",
+      "/v1/rerank",
+      "/v1/responses",
+      "/v1/responses/{responseId}",
+      "/healthCheck",
+    ]));
+  });
+
+  it("documents the include_unavailable query parameter on /v1/models", async () => {
+    const spec = await fetchSpec();
+    const params = spec.paths["/v1/models"]?.get?.parameters ?? [];
+    const includeUnavailable = params.find(p => p.name === "include_unavailable");
+    expect(includeUnavailable).toBeDefined();
+    expect(includeUnavailable?.in).toBe("query");
+  });
+
+  it("registers component schemas and the bearer security scheme", async () => {
+    const spec = await fetchSpec();
+    const schemas = spec.components?.schemas ?? {};
+    expect(schemas.ModelObject).toBeDefined();
+    expect(schemas.ChatCompletionRequest).toBeDefined();
+    expect(schemas.EmbeddingRequest).toBeDefined();
+    expect(schemas.RerankRequest).toBeDefined();
+    expect(schemas.CreateResponseRequest).toBeDefined();
+
+    const security = spec.components?.securitySchemes ?? {};
+    expect(security.bearerAuth).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Description

Extends the gateway's existing OpenAPI document to cover the OpenAI-compatible endpoints (chat, completions, embeddings, rerank, models) with schemas. `/v1/models` now hides deployments that are not `ready` by default (`include_unavailable=true` restores the old behaviour). CLI handles optional secrets correctly during install/configure. Small refactors and README cleanups bundled in.

## Type of change

Documentation + Bug fix

## Testing

New system tests for the OpenAPI document and model listing under `tests/system/gateway/`.

## Checklist

- [x] Tests pass locally (`bun test`), or no testable code was changed
- [x] New or changed behavior is covered by tests, or this change does not require tests
- [x] Documentation is updated, or no user-facing behavior or configuration was changed
- [x] There are no breaking changes, or they are marked with `!` in the commit type and described above
- [x] No security-sensitive changes (authentication, credentials, input handling), or they have been reviewed
- [x] No new dependencies were added, or they have been reviewed for license and maintenance status