### PR TITLE
feat: deployment strategy

### DIFF
--- a/nix/modules/xinity-infoserver.mod.nix
+++ b/nix/modules/xinity-infoserver.mod.nix
@@ -102,13 +102,13 @@
             LOG_LEVEL = cfg.logLevel;
           }
           // lib.optionalAttrs (cfg.modelInfoFile != null) {
-            MODEL_INFO_FILE = toString cfg.modelInfoFile;
+            MODEL_INFO_FILE = cfg.modelInfoFile;
           }
           // lib.optionalAttrs (cfg.logDir != null) {
             LOG_DIR = cfg.logDir;
           }
           // lib.optionalAttrs (cfg.modelInfoDir != null) {
-            MODEL_INFO_DIR = toString cfg.modelInfoDir;
+            MODEL_INFO_DIR = cfg.modelInfoDir;
           }
           // cfg.extraEnvironment;
           serviceConfig = {

--- a/packages/common-db/src/schema/models.ts
+++ b/packages/common-db/src/schema/models.ts
@@ -75,7 +75,10 @@ export const aiNodeT = pgTable("ai_node", {
   /** estimated capacity available on the node, as GB of estimated usable model capacity */
   estCapacity: real("est_capacity").notNull(),
   available: boolean().notNull().default(true),
-  /** Represents drivers supported on this node */
+  /** @deprecated Use {@link driverVersions}. The presence of a key in driverVersions
+   * is the source of truth for driver availability. The daemon still writes this
+   * column for backward compatibility, but the dashboard no longer reads it.
+   * Will be removed in a future migration. */
   drivers: text().array().notNull().default(["ollama"]),
   /** Number of GPUs detected on this node. 0 means CPU-only. */
   gpuCount: integer("gpu_count").notNull().default(0),

--- a/packages/xinity-ai-dashboard/src/lib/components/RolesPermissionMatrix.svelte
+++ b/packages/xinity-ai-dashboard/src/lib/components/RolesPermissionMatrix.svelte
@@ -5,7 +5,7 @@
 
   type ResourcePermissions = {
     label: string;
-    actions: Record<RoleName, string[]>;
+    actions: Record<RoleName, readonly string[]>;
   };
 
   const permissionObjects = {
@@ -22,8 +22,8 @@
   const resources: ResourcePermissions[] = Object.entries(permissionObjects).map(([object, label]) => ({
     label,
     actions: Object.fromEntries(Object.entries(roles).map(([role, values]) =>
-      [role, values.statements[object as keyof typeof values.statements] as string[]] as [RoleName, string[]]
-    )) as Record<RoleName, string[]>,
+      [role, values.statements[object as keyof typeof values.statements] ?? []] as [RoleName, readonly string[]]
+    )) as Record<RoleName, readonly string[]>,
   }))
 
   const roleOrder: RoleName[] = Object.keys(roleLabels) as RoleName[];
@@ -37,8 +37,8 @@
     pending: "Can sign in and manage their own account. No access to organization resources.",
   };
 
-  function formatActions(actions: string[]): string {
-    if (actions.length === 0) return "\u2014";
+  function formatActions(actions: readonly string[]): string {
+    if (actions.length === 0) return "-";
     return actions.join(", ");
   }
 </script>

--- a/packages/xinity-ai-dashboard/src/lib/server/auth-server.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/auth-server.ts
@@ -5,6 +5,8 @@ import { apiKey } from "@better-auth/api-key";
 import { passkey } from "@better-auth/passkey";
 import { sso } from "@better-auth/sso";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
+import { sveltekitCookies } from "better-auth/svelte-kit";
+import { getRequestEvent } from "$app/server";
 import { twoFactorT, userT, accountT, verificationT, sessionT, passkeyT, dashboardApiKeyT, ssoProviderT } from "common-db";
 import { organizationT, memberT, invitationT, sql, eq, and } from "common-db";
 import { rootLogger } from "./logging";
@@ -282,6 +284,7 @@ export const auth = betterAuth({
         });
       },
     }),
+    sveltekitCookies(getRequestEvent),
   ],
 });
 

--- a/packages/xinity-ai-dashboard/src/lib/server/env-schema.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/env-schema.ts
@@ -31,4 +31,5 @@ export const dashboardEnvSchema = z.object({
   LICENSE_KEY: z.string().optional().describe("License key for unlocking paid features (Ed25519-signed token)").meta(secret()),
   TRUSTED_ORIGINS: z.string().optional().describe("Comma-separated additional trusted origins for CSRF validation behind reverse proxies").meta(expert()),
   GATEWAY_URL: z.url().default("http://localhost:4010").describe("Gateway base URL shown to users in docs and code examples (e.g. https://api.example.com). Must NOT include the /v1 path segment - that is appended where needed. The deprecated PUBLIC_LLM_API_URL did include /v1; double-check after migrating.").meta(clientPublic()),
+  DEPLOYMENT_STRATEGY: z.enum(["first-fit", "balanced", "bin-pack", "proportional"]).default("balanced").describe("Node selection strategy for new model installations. 'first-fit' picks the first node that fits (deterministic). 'balanced' picks the node with the most absolute free VRAM (spread for HA). 'bin-pack' picks the tightest fit (consolidate so idle nodes stay drainable). 'proportional' picks the node with the lowest percent utilization (fair spread across heterogeneous fleets).").meta(expert()),
 });

--- a/packages/xinity-ai-dashboard/src/lib/server/lib/orchestration.mod.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/lib/orchestration.mod.ts
@@ -5,6 +5,7 @@ import { resolveDefaultProvider, resolveMinVersionForDriver, resolveRequiredPlat
 import { rootLogger } from "../logging";
 import { building } from "$app/environment";
 import { maxVramGb } from "$lib/server/license";
+import { serverEnv } from "$lib/server/serverenv";
 
 const log = rootLogger.child({ name: "orchestration.mod" })
 
@@ -23,6 +24,28 @@ interface ClusterState {
 
 export type ModelRequirement = { lookup: ModelLookup; replicas: number; kvCacheSize: number | null; preferredDriver: Provider | null };
 export type ModelRequirementTable = Record<string, ModelRequirement>;
+
+export type DeploymentStrategy = "first-fit" | "balanced" | "bin-pack" | "proportional";
+
+/** Returns availableServers ordered by the given strategy's preference.
+ * Re-evaluated per placement so spread strategies see updated `used` after each replica. */
+export function rankServers(strategy: DeploymentStrategy, state: ClusterState): AiNode[] {
+  const free = (s: AiNode) => {
+    const cap = state.serverCapacity.get(s.id);
+    return cap ? cap.total - cap.used : 0;
+  };
+  const ratio = (s: AiNode) => {
+    const cap = state.serverCapacity.get(s.id);
+    return cap && cap.total > 0 ? cap.used / cap.total : 1;
+  };
+  const servers = [...state.availableServers];
+  switch (strategy) {
+    case "first-fit":    return servers;
+    case "balanced":     return servers.sort((a, b) => free(b) - free(a));
+    case "bin-pack":     return servers.sort((a, b) => free(a) - free(b));
+    case "proportional": return servers.sort((a, b) => ratio(a) - ratio(b));
+  }
+}
 
 function mergeRequirementsByLookupKey(entries: ModelRequirement[]): ModelRequirementTable {
   return entries.reduce((agg, entry) => {
@@ -129,13 +152,14 @@ export function collectExcessInstallations(requiredModels: ModelRequirementTable
   return toUninstall;
 }
 
-/** First-fit placement; skips nodes that already host the model. */
+/** Picks a node according to the configured strategy; skips nodes that already host the model. */
 export function findServerForModel(
   specifier: string,
   driver: string,
   weight: number,
   state: ClusterState,
   pending: NewInstallation[],
+  strategy: DeploymentStrategy,
   minVersion?: string,
   requiredPlatforms?: string[],
 ): string | null {
@@ -144,7 +168,7 @@ export function findServerForModel(
     minVersion, requiredPlatforms: requiredPlatforms ?? [],
   };
 
-  for (const server of state.availableServers) {
+  for (const server of rankServers(strategy, state)) {
     const cap = state.serverCapacity.get(server.id);
     if (!cap) continue;
 
@@ -195,6 +219,7 @@ async function planNewInstallations(
   requiredModels: ModelRequirementTable,
   state: ClusterState,
   licenseVramLimit: number,
+  strategy: DeploymentStrategy,
 ): Promise<NewInstallation[]> {
   const toInstall: NewInstallation[] = [];
   let usedVram = totalVramUsed(state);
@@ -244,7 +269,7 @@ async function planNewInstallations(
         break;
       }
 
-      const nodeId = findServerForModel(key, driver, totalCapacity, state, toInstall, minVersion, requiredPlatforms);
+      const nodeId = findServerForModel(key, driver, totalCapacity, state, toInstall, strategy, minVersion, requiredPlatforms);
       if (!nodeId) {
         log.warn({ lookup: requirement.lookup }, "No server with enough capacity for additional replica");
         break;
@@ -297,7 +322,7 @@ async function runSyncDeployedModels() {
     ...orphaned.map(i => i.id),
     ...collectExcessInstallations(requiredModels, state),
   ];
-  const toInstall = await planNewInstallations(requiredModels, state, maxVramGb());
+  const toInstall = await planNewInstallations(requiredModels, state, maxVramGb(), serverEnv.DEPLOYMENT_STRATEGY);
   await applyChanges(toUninstall, toInstall);
 }
 

--- a/packages/xinity-ai-dashboard/src/lib/server/lib/orchestration.mod.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/lib/orchestration.mod.ts
@@ -179,7 +179,6 @@ export function findServerForModel(
 
     const nodeCap: NodeCapability = {
       free: cap.total - cap.used,
-      drivers: server.drivers,
       driverVersions: (server.driverVersions ?? {}) as Record<string, string>,
       gpus: (server.gpus ?? []) as { vendor: string; name: string; vramMb: number }[],
     };

--- a/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/application.procedure.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/application.procedure.ts
@@ -59,7 +59,9 @@ const getApplication = rootOs
   .use(requirePermission({ aiApplication: ["read"] }))
   .route({ method: "GET", path: "/{id}", tags, summary: "Get Application" })
   .input(ApplicationDto.pick({ id: true }))
-  .handler(async ({ context, input }) => {
+  .output(ApplicationDto)
+  .errors({ NOT_FOUND: {} })
+  .handler(async ({ context, input, errors }) => {
     const [app] = await getDB()
       .select()
       .from(aiApplicationT)
@@ -72,6 +74,7 @@ const getApplication = rootOs
       )
       .limit(1);
 
+    if (!app) throw errors.NOT_FOUND();
     return app;
   });
 

--- a/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/cluster.procedure.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/cluster.procedure.ts
@@ -14,7 +14,6 @@ const GpuInfoSchema = z.object({
 
 const NodeCapabilitySchema = z.object({
   free: z.number(),
-  drivers: z.array(z.string()),
   driverVersions: z.record(z.string(), z.string()),
   gpus: z.array(GpuInfoSchema),
 });
@@ -36,7 +35,6 @@ export async function buildClusterCapacity(): Promise<ClusterCapacity> {
   const nodes = await getDB().select({
     id: aiNodeT.id,
     estCapacity: aiNodeT.estCapacity,
-    drivers: aiNodeT.drivers,
     driverVersions: aiNodeT.driverVersions,
     gpus: aiNodeT.gpus,
   }).from(aiNodeT)
@@ -51,14 +49,13 @@ export async function buildClusterCapacity(): Promise<ClusterCapacity> {
 
   const nodeCapabilities: NodeCapability[] = nodes.map(n => ({
     free: n.estCapacity - (nodeUsed.get(n.id) ?? 0),
-    drivers: n.drivers,
     driverVersions: (n.driverVersions ?? {}) as Record<string, string>,
     gpus: (n.gpus ?? []) as { vendor: string; name: string; vramMb: number }[],
   }));
 
   const maxNodeFreeCapacity = Math.max(0, ...nodeCapabilities.map(n => n.free));
   const availableDrivers = [...new Set(
-    nodeCapabilities.filter(n => n.free > 0).flatMap(n => n.drivers),
+    nodeCapabilities.filter(n => n.free > 0).flatMap(n => Object.keys(n.driverVersions)),
   )];
   const nodeFreeCapacities = nodeCapabilities
     .map(n => n.free).filter(c => c > 0).sort((a, b) => b - a);

--- a/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/deployment.procedure.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/deployment.procedure.ts
@@ -525,7 +525,7 @@ const checkCapacity = rootOs
   })
   .input(CapacityCheckInput)
   .output(CapacityCheckOutput)
-  .handler(async ({ input }) => {
+  .handler(async ({ input }): Promise<CapacityCheckResult> =>  {
     return checkDeploymentCapacity(input);
   });
 

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/data/[applicationId=uuid]/+page.server.ts
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/data/[applicationId=uuid]/+page.server.ts
@@ -1,7 +1,7 @@
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import { applicationRouter } from '$lib/server/orpc/procedures/application.procedure';
-import { call } from '@orpc/server';
+import { call, ORPCError } from '@orpc/server';
 import { auth } from '$lib/server/auth-server';
 
 export const load: PageServerLoad = async ({ params, locals }) => {
@@ -11,9 +11,13 @@ export const load: PageServerLoad = async ({ params, locals }) => {
   }
 
   const { applicationId } = params;
-  const application = await call(applicationRouter.get, { id: applicationId }, { context: locals });
-
-  return {
-    application
-  };
+  try {
+    const application = await call(applicationRouter.get, { id: applicationId }, { context: locals });
+    return { application };
+  } catch (err) {
+    if (err instanceof ORPCError && err.code === 'NOT_FOUND') {
+      error(404, 'Application not found');
+    }
+    throw err;
+  }
 };

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/data/[applicationId=uuid]/+page.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/data/[applicationId=uuid]/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { page } from "$app/stores";
   import type { PageData } from "./$types";
   import DataPageLayout from "./DataPageLayout.svelte";
   import NoOrganization from "$lib/components/NoOrganization.svelte";
@@ -7,7 +6,6 @@
   let { data }: { data: PageData } = $props();
 
   const application = $derived(data.application);
-  const applicationId = $page.params.applicationId!;
 </script>
 
 <svelte:head>
@@ -18,7 +16,7 @@
   <NoOrganization />
 {:else}
   <DataPageLayout
-    {applicationId}
+    applicationId={application.id}
     title="{application.name} Data"
     description="View, analyze, and improve your application data."
   />

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/DeploymentModal.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/DeploymentModal.svelte
@@ -182,8 +182,8 @@
     }
     const abort = new AbortController();
     orpc.deployment.checkCapacity({
-      modelSpecifier: selectedPrimarySpecifier!,
-      earlyModelSpecifier: isCanaryEnabled ? selectedCanarySpecifier : null,
+      specifier: selectedPrimarySpecifier!,
+      earlySpecifier: isCanaryEnabled ? selectedCanarySpecifier : null,
       replicas, progress: isCanaryEnabled ? canaryTraffic : 100, kvCacheSize,
       earlyKvCacheSize: isCanaryEnabled ? earlyKvCacheSize : null,
     }, { signal: abort.signal }).then(([error, data]) => {

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/ModelSelectorModal.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/ModelSelectorModal.svelte
@@ -129,7 +129,7 @@
     // (meaning it would work if not for the version/platform mismatch)
     const needed = model.weight + model.minKvCache;
     const drivers = Object.keys(model.providers).filter(d => model.providers[d as keyof typeof model.providers] !== undefined);
-    return nodeCapabilities.some(n => n.free >= needed && drivers.some(d => n.drivers.includes(d)));
+    return nodeCapabilities.some(n => n.free >= needed && drivers.some(d => d in n.driverVersions));
   }
 
   function handleSelect(model: ModelWithSpecifier) {

--- a/packages/xinity-ai-dashboard/tests/orchestration.test.ts
+++ b/packages/xinity-ai-dashboard/tests/orchestration.test.ts
@@ -12,7 +12,7 @@ function makeNode(overrides: Partial<AiNode> & { id: string }): AiNode {
     estCapacity: 24,
     available: true,
     drivers: ["ollama"],
-    driverVersions: {},
+    driverVersions: { ollama: "0.6.3" },
     gpus: [],
     gpuCount: 1,
     authToken: null,
@@ -102,29 +102,29 @@ describe("orchestration: node goes unavailable", () => {
     expect(findServerForModel("new-model", "vllm", 8, state, [], FF, "0.19.1")).toBe("node-f");
   });
 
-  test("findServerForModel allows nodes with unknown version (fail-open)", () => {
-    const unknownNode = makeNode({ id: "node-g", host: "10.0.0.7", drivers: ["vllm"], driverVersions: {} });
+  test("findServerForModel allows nodes whose driver version is recorded as empty (fail-open)", () => {
+    const unknownNode = makeNode({ id: "node-g", host: "10.0.0.7", drivers: ["vllm"], driverVersions: { vllm: "" } });
     const state = buildClusterState([], [unknownNode]);
 
     expect(findServerForModel("new-model", "vllm", 8, state, [], FF, "0.19.1")).toBe("node-g");
   });
 
   test("findServerForModel skips nodes with wrong GPU platform", () => {
-    const amdNode = makeNode({ id: "node-h", host: "10.0.0.8", drivers: ["vllm"], gpus: [{ vendor: "amd", name: "MI300X", vramMb: 196608 }] });
+    const amdNode = makeNode({ id: "node-h", host: "10.0.0.8", drivers: ["vllm"], driverVersions: { vllm: "0.20.0" }, gpus: [{ vendor: "amd", name: "MI300X", vramMb: 196608 }] });
     const state = buildClusterState([], [amdNode]);
 
     expect(findServerForModel("mxfp4-model", "vllm", 8, state, [], FF, undefined, ["nvidia"])).toBeNull();
   });
 
   test("findServerForModel accepts nodes with matching GPU platform", () => {
-    const nvidiaNode = makeNode({ id: "node-i", host: "10.0.0.9", drivers: ["vllm"], gpus: [{ vendor: "nvidia", name: "A100", vramMb: 81920 }] });
+    const nvidiaNode = makeNode({ id: "node-i", host: "10.0.0.9", drivers: ["vllm"], driverVersions: { vllm: "0.20.0" }, gpus: [{ vendor: "nvidia", name: "A100", vramMb: 81920 }] });
     const state = buildClusterState([], [nvidiaNode]);
 
     expect(findServerForModel("mxfp4-model", "vllm", 8, state, [], FF, undefined, ["nvidia"])).toBe("node-i");
   });
 
   test("findServerForModel rejects nodes with no GPUs when platform is required", () => {
-    const cpuNode = makeNode({ id: "node-j", host: "10.0.0.10", drivers: ["vllm"], gpus: [] });
+    const cpuNode = makeNode({ id: "node-j", host: "10.0.0.10", drivers: ["vllm"], driverVersions: { vllm: "0.20.0" }, gpus: [] });
     const state = buildClusterState([], [cpuNode]);
 
     expect(findServerForModel("mxfp4-model", "vllm", 8, state, [], FF, undefined, ["nvidia"])).toBeNull();

--- a/packages/xinity-ai-dashboard/tests/orchestration.test.ts
+++ b/packages/xinity-ai-dashboard/tests/orchestration.test.ts
@@ -1,7 +1,9 @@
 import { describe, test, expect } from "bun:test";
-import { buildClusterState, collectExcessInstallations, findServerForModel } from "../src/lib/server/lib/orchestration.mod";
+import { buildClusterState, collectExcessInstallations, findServerForModel, rankServers } from "../src/lib/server/lib/orchestration.mod";
 import type { AiNode, ModelInstallation } from "common-db";
-import type { ModelRequirementTable } from "../src/lib/server/lib/orchestration.mod";
+import type { ModelRequirementTable, DeploymentStrategy } from "../src/lib/server/lib/orchestration.mod";
+
+const FF: DeploymentStrategy = "first-fit";
 
 function makeNode(overrides: Partial<AiNode> & { id: string }): AiNode {
   return {
@@ -68,7 +70,7 @@ describe("orchestration: node goes unavailable", () => {
     expect(excess).toHaveLength(0);
 
     // Planner would place the replacement on node-a
-    const replacement = findServerForModel("llama2:7b", "ollama", 8, state, []);
+    const replacement = findServerForModel("llama2:7b", "ollama", 8, state, [], FF);
     expect(replacement).toBe("node-a");
   });
 
@@ -76,56 +78,56 @@ describe("orchestration: node goes unavailable", () => {
     const ollamaOnly = makeNode({ id: "node-c", host: "10.0.0.3", drivers: ["ollama"] });
     const state = buildClusterState([], [ollamaOnly]);
 
-    expect(findServerForModel("some-model", "vllm", 8, state, [])).toBeNull();
+    expect(findServerForModel("some-model", "vllm", 8, state, [], FF)).toBeNull();
   });
 
   test("findServerForModel skips nodes without enough capacity", () => {
     const tinyNode = makeNode({ id: "node-d", host: "10.0.0.4", estCapacity: 4 });
     const state = buildClusterState([], [tinyNode]);
 
-    expect(findServerForModel("big-model", "ollama", 16, state, [])).toBeNull();
+    expect(findServerForModel("big-model", "ollama", 16, state, [], FF)).toBeNull();
   });
 
   test("findServerForModel skips nodes with incompatible driver version", () => {
     const oldNode = makeNode({ id: "node-e", host: "10.0.0.5", drivers: ["vllm"], driverVersions: { vllm: "0.18.0" } });
     const state = buildClusterState([], [oldNode]);
 
-    expect(findServerForModel("new-model", "vllm", 8, state, [], "0.19.1")).toBeNull();
+    expect(findServerForModel("new-model", "vllm", 8, state, [], FF, "0.19.1")).toBeNull();
   });
 
   test("findServerForModel accepts nodes with sufficient driver version", () => {
     const newNode = makeNode({ id: "node-f", host: "10.0.0.6", drivers: ["vllm"], driverVersions: { vllm: "0.20.0" } });
     const state = buildClusterState([], [newNode]);
 
-    expect(findServerForModel("new-model", "vllm", 8, state, [], "0.19.1")).toBe("node-f");
+    expect(findServerForModel("new-model", "vllm", 8, state, [], FF, "0.19.1")).toBe("node-f");
   });
 
   test("findServerForModel allows nodes with unknown version (fail-open)", () => {
     const unknownNode = makeNode({ id: "node-g", host: "10.0.0.7", drivers: ["vllm"], driverVersions: {} });
     const state = buildClusterState([], [unknownNode]);
 
-    expect(findServerForModel("new-model", "vllm", 8, state, [], "0.19.1")).toBe("node-g");
+    expect(findServerForModel("new-model", "vllm", 8, state, [], FF, "0.19.1")).toBe("node-g");
   });
 
   test("findServerForModel skips nodes with wrong GPU platform", () => {
     const amdNode = makeNode({ id: "node-h", host: "10.0.0.8", drivers: ["vllm"], gpus: [{ vendor: "amd", name: "MI300X", vramMb: 196608 }] });
     const state = buildClusterState([], [amdNode]);
 
-    expect(findServerForModel("mxfp4-model", "vllm", 8, state, [], undefined, ["nvidia"])).toBeNull();
+    expect(findServerForModel("mxfp4-model", "vllm", 8, state, [], FF, undefined, ["nvidia"])).toBeNull();
   });
 
   test("findServerForModel accepts nodes with matching GPU platform", () => {
     const nvidiaNode = makeNode({ id: "node-i", host: "10.0.0.9", drivers: ["vllm"], gpus: [{ vendor: "nvidia", name: "A100", vramMb: 81920 }] });
     const state = buildClusterState([], [nvidiaNode]);
 
-    expect(findServerForModel("mxfp4-model", "vllm", 8, state, [], undefined, ["nvidia"])).toBe("node-i");
+    expect(findServerForModel("mxfp4-model", "vllm", 8, state, [], FF, undefined, ["nvidia"])).toBe("node-i");
   });
 
   test("findServerForModel rejects nodes with no GPUs when platform is required", () => {
     const cpuNode = makeNode({ id: "node-j", host: "10.0.0.10", drivers: ["vllm"], gpus: [] });
     const state = buildClusterState([], [cpuNode]);
 
-    expect(findServerForModel("mxfp4-model", "vllm", 8, state, [], undefined, ["nvidia"])).toBeNull();
+    expect(findServerForModel("mxfp4-model", "vllm", 8, state, [], FF, undefined, ["nvidia"])).toBeNull();
   });
 });
 
@@ -150,6 +152,85 @@ describe("orchestration: lookup-key correlation", () => {
   test("findServerForModel skips a node that already hosts the canonical specifier", () => {
     const inst = makeInstallation({ id: "i1", nodeId: "node-1", specifier: "llama-3.3-70b", model: "llama" });
     const state = buildClusterState([inst], [node]);
-    expect(findServerForModel("llama-3.3-70b", "ollama", 8, state, [])).toBeNull();
+    expect(findServerForModel("llama-3.3-70b", "ollama", 8, state, [], FF)).toBeNull();
+  });
+});
+
+describe("orchestration: deployment strategies", () => {
+  const nodeA = makeNode({ id: "node-a", host: "10.0.0.1", estCapacity: 24 });
+  const nodeB = makeNode({ id: "node-b", host: "10.0.0.2", estCapacity: 24 });
+  const nodeC = makeNode({ id: "node-c", host: "10.0.0.3", estCapacity: 48 });
+
+  // Pre-load A with 4GB used, B with 16GB used, C with 24GB used.
+  // Free: A=20, B=8, C=24. Ratio used: A=4/24≈0.167, B=16/24≈0.667, C=24/48=0.5.
+  const preinstalls = [
+    makeInstallation({ id: "p-a", nodeId: "node-a", model: "x", estCapacity: 4 }),
+    makeInstallation({ id: "p-b", nodeId: "node-b", model: "y", estCapacity: 16 }),
+    makeInstallation({ id: "p-c", nodeId: "node-c", model: "z", estCapacity: 24 }),
+  ];
+
+  test("rankServers first-fit preserves DB order", () => {
+    const state = buildClusterState(preinstalls, [nodeA, nodeB, nodeC]);
+    expect(rankServers("first-fit", state).map(s => s.id)).toEqual(["node-a", "node-b", "node-c"]);
+  });
+
+  test("rankServers balanced orders by most absolute free first", () => {
+    const state = buildClusterState(preinstalls, [nodeA, nodeB, nodeC]);
+    // Free: A=20, B=8, C=24 -> C, A, B
+    expect(rankServers("balanced", state).map(s => s.id)).toEqual(["node-c", "node-a", "node-b"]);
+  });
+
+  test("rankServers bin-pack orders by least free first", () => {
+    const state = buildClusterState(preinstalls, [nodeA, nodeB, nodeC]);
+    // Free: A=20, B=8, C=24 -> B, A, C
+    expect(rankServers("bin-pack", state).map(s => s.id)).toEqual(["node-b", "node-a", "node-c"]);
+  });
+
+  test("rankServers proportional orders by lowest percent used first", () => {
+    const state = buildClusterState(preinstalls, [nodeA, nodeB, nodeC]);
+    // Ratio: A=0.167, B=0.667, C=0.5 -> A, C, B
+    expect(rankServers("proportional", state).map(s => s.id)).toEqual(["node-a", "node-c", "node-b"]);
+  });
+
+  test("findServerForModel balanced picks node with most free capacity", () => {
+    const state = buildClusterState(preinstalls, [nodeA, nodeB, nodeC]);
+    expect(findServerForModel("new-model", "ollama", 4, state, [], "balanced")).toBe("node-c");
+  });
+
+  test("findServerForModel bin-pack picks tightest fit that still satisfies", () => {
+    const state = buildClusterState(preinstalls, [nodeA, nodeB, nodeC]);
+    // B has 8 free, the tightest that fits a 4GB model.
+    expect(findServerForModel("new-model", "ollama", 4, state, [], "bin-pack")).toBe("node-b");
+  });
+
+  test("findServerForModel bin-pack skips nodes too tight to fit", () => {
+    const state = buildClusterState(preinstalls, [nodeA, nodeB, nodeC]);
+    // 10GB doesn't fit on B (8 free), so falls through to A (20 free), not C (24 free).
+    expect(findServerForModel("big-model", "ollama", 10, state, [], "bin-pack")).toBe("node-a");
+  });
+
+  test("findServerForModel proportional picks lowest percent used", () => {
+    const state = buildClusterState(preinstalls, [nodeA, nodeB, nodeC]);
+    expect(findServerForModel("new-model", "ollama", 4, state, [], "proportional")).toBe("node-a");
+  });
+
+  test("balanced spreads replicas across nodes across consecutive placements", () => {
+    // No preinstalls. Three equal-size nodes. Placing 3 replicas of a 4GB model with
+    // balanced should land one on each, because the planner mutates serverCapacity
+    // between placements and rankServers re-sorts each call.
+    const empty = buildClusterState([], [nodeA, nodeB, nodeC]);
+    const pending: Parameters<typeof findServerForModel>[4] = [];
+
+    const first = findServerForModel("m", "ollama", 4, empty, pending, "balanced")!;
+    empty.serverCapacity.get(first)!.used += 4;
+    pending.push({ nodeId: first, specifier: null, model: "m", estCapacity: 4, kvCacheCapacity: 0, driver: "ollama", port: 11434 });
+
+    const second = findServerForModel("m", "ollama", 4, empty, pending, "balanced")!;
+    empty.serverCapacity.get(second)!.used += 4;
+    pending.push({ nodeId: second, specifier: null, model: "m", estCapacity: 4, kvCacheCapacity: 0, driver: "ollama", port: 11434 });
+
+    const third = findServerForModel("m", "ollama", 4, empty, pending, "balanced")!;
+
+    expect(new Set([first, second, third])).toEqual(new Set(["node-a", "node-b", "node-c"]));
   });
 });

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-chatCompletion.test.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-chatCompletion.test.ts
@@ -466,7 +466,7 @@ describe("handleChatCompletion, tool calling", () => {
     expect(lastUpstreamBody?.tool_choice).toEqual({ type: "function", function: { name: "get_weather" } });
   });
 
-  test("should reject tools when model does not support them", async () => {
+  test("should reject tools when catalog explicitly says model does not support them", async () => {
     getModelInfo.mockImplementationOnce(async () => ({
       host: `localhost:${mockPort}`,
       model: "test-model",
@@ -493,6 +493,33 @@ describe("handleChatCompletion, tool calling", () => {
 
     const body = await res.json() as any;
     expect(body.error.message).toContain("tool use");
+  });
+
+  test("should allow tools when catalog entry is missing (legacy fallback, tags undefined)", async () => {
+    getModelInfo.mockImplementationOnce(async () => ({
+      host: `localhost:${mockPort}`,
+      model: "test-model",
+      driver: "vllm",
+      authToken: null,
+      tls: false,
+      tags: undefined,
+      requestParams: undefined,
+      release: () => {},
+    }));
+
+    const req = new Request("http://localhost:4000/v1/chat/completions", {
+      method: "POST",
+      headers: { "Authorization": "Bearer test" },
+      body: JSON.stringify({
+        model: "test-model",
+        messages: [{ role: "user", content: "Hello" }],
+        tools: SAMPLE_TOOLS,
+      }),
+    });
+
+    const res = await handleChatCompletion(req);
+    expect(res.status).toBe(200);
+    expect(lastUpstreamBody?.tools).toEqual(SAMPLE_TOOLS);
   });
 
   test("should work without tools (backward compatibility)", async () => {

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-chatCompletion.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-chatCompletion.ts
@@ -128,7 +128,7 @@ export const handleChatCompletion = withEndpointGuards({
     }
 
     const hasTools = Array.isArray(body.tools) && body.tools.length > 0;
-    if (hasTools && !modelInfo.tags.includes("tools")) {
+    if (hasTools && modelInfo.tags !== undefined && !modelInfo.tags.includes("tools")) {
       return errorResponse("Model does not support tool use", 400);
     }
 

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-responses.test.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-responses.test.ts
@@ -29,14 +29,17 @@ mock.module("../auth", () => ({
   checkAuth,
 }));
 
+import type { getModelInfo as getModelInfoT } from "../model-data";
+
 let mockPort = 0;
-const getModelInfo = jest.fn(async () => ({
+const getModelInfo = jest.fn<typeof getModelInfoT>(async () => ({
   host: `localhost:${mockPort}`,
   model: "test-model",
   driver: "vllm",
   authToken: null,
   tls: false,
   tags: ["tools"],
+  requestParams: {},
   release: () => {},
 }));
 
@@ -493,6 +496,134 @@ describe("handleResponses", () => {
     expect(functionCallItem.status).toBe("completed");
     expect(functionCallItem.call_id).toBeDefined();
     expect(functionCallItem.arguments).toBe('{"city":"Berlin"}');
+  });
+
+  test("should reject function tools when catalog explicitly says model does not support them", async () => {
+    getModelInfo.mockImplementationOnce(async () => ({
+      host: `localhost:${mockPort}`,
+      model: "test-model",
+      driver: "vllm",
+      authToken: null,
+      tls: false,
+      tags: [],
+      release: () => {},
+    }));
+
+    const req = new Request("http://localhost:4000/v1/responses", {
+      method: "POST",
+      headers: { "Authorization": "Bearer test" },
+      body: JSON.stringify({
+        model: "test-model",
+        input: "Hi",
+        tools: [{
+          type: "function",
+          name: "get_weather",
+          parameters: { type: "object", properties: { city: { type: "string" } } },
+        }],
+      }),
+    });
+
+    const res = await handleCreateResponseRequest(req);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as any;
+    expect(body.error.message).toContain("tool use");
+  });
+
+  test("should allow function tools when catalog entry is missing (legacy fallback, tags undefined)", async () => {
+    getModelInfo.mockImplementationOnce(async () => ({
+      host: `localhost:${mockPort}`,
+      model: "test-model",
+      driver: "vllm",
+      authToken: null,
+      tls: false,
+      tags: undefined,
+      release: () => {},
+    }));
+
+    const req = new Request("http://localhost:4000/v1/responses", {
+      method: "POST",
+      headers: { "Authorization": "Bearer test" },
+      body: JSON.stringify({
+        model: "test-model",
+        input: "What is the weather in Berlin?",
+        tools: [{
+          type: "function",
+          name: "get_weather",
+          parameters: { type: "object", properties: { city: { type: "string" } } },
+        }],
+      }),
+    });
+
+    const res = await handleCreateResponseRequest(req);
+    expect(res.status).toBe(200);
+  });
+
+  test("should reject structured output when catalog explicitly says model does not support tools", async () => {
+    getModelInfo.mockImplementationOnce(async () => ({
+      host: `localhost:${mockPort}`,
+      model: "test-model",
+      driver: "vllm",
+      authToken: null,
+      tls: false,
+      tags: [],
+      release: () => {},
+    }));
+
+    const req = new Request("http://localhost:4000/v1/responses", {
+      method: "POST",
+      headers: { "Authorization": "Bearer test" },
+      body: JSON.stringify({
+        model: "test-model",
+        input: "Hi",
+        text: {
+          format: {
+            type: "json_schema",
+            json_schema: {
+              name: "TestSchema",
+              schema: { type: "object", properties: { greeting: { type: "string" } } },
+            },
+          },
+        },
+      }),
+    });
+
+    const res = await handleCreateResponseRequest(req);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as any;
+    expect(body.error.message).toContain("structured output");
+  });
+
+  test("should allow structured output when catalog entry is missing (legacy fallback, tags undefined)", async () => {
+    getModelInfo.mockImplementationOnce(async () => ({
+      host: `localhost:${mockPort}`,
+      model: "test-model",
+      driver: "vllm",
+      authToken: null,
+      tls: false,
+      tags: undefined,
+      release: () => {},
+    }));
+
+    const req = new Request("http://localhost:4000/v1/responses", {
+      method: "POST",
+      headers: { "Authorization": "Bearer test" },
+      body: JSON.stringify({
+        model: "test-model",
+        input: "Hi",
+        text: {
+          format: {
+            type: "json_schema",
+            json_schema: {
+              name: "TestSchema",
+              schema: { type: "object", properties: { greeting: { type: "string" } } },
+            },
+          },
+        },
+      }),
+    });
+
+    const res = await handleCreateResponseRequest(req);
+    expect(res.status).toBe(200);
   });
 
   test("should accept function_call_output in input for multi-turn tool use", async () => {

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-responses.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-responses.ts
@@ -234,11 +234,11 @@ export async function handleCreateResponseRequest(req: Request): Promise<Respons
       metadata: body.metadata as Record<string, unknown> | undefined,
     } as const;
 
-    if (hasTools && !modelInfo.tags.includes("tools")) {
+    if (hasTools && modelInfo.tags !== undefined && !modelInfo.tags.includes("tools")) {
       return errorResponse("Model does not support tool use", 400);
     }
 
-    if (outputConfig.usesStructuredOutput && !modelInfo.tags.includes("tools")) {
+    if (outputConfig.usesStructuredOutput && modelInfo.tags !== undefined && !modelInfo.tags.includes("tools")) {
       return errorResponse("Model does not support structured output", 400);
     }
 

--- a/packages/xinity-ai-gateway/src/llm-forward/model-data.test.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/model-data.test.ts
@@ -29,19 +29,30 @@ mock.module("../db", () => ({
   getDB: () => db,
 }));
 
-const mockResolveModelMeta = jest.fn(async () => ({ type: "chat" as string | undefined, tags: ["tools"] as string[] }));
-const mockResolveRequestParams = jest.fn(async () => ({} as Record<string, string>));
-const mockFetchModel = jest.fn(async (lookup: { kind: "canonical"; specifier: string } | { kind: "legacy"; providerModel: string }) => {
-  const value = lookup.kind === "canonical" ? lookup.specifier : lookup.providerModel;
-  return { providers: { ollama: value, vllm: value } as { ollama?: string; vllm?: string } };
-});
+type MockModel = {
+  type?: string;
+  tags?: string[];
+  providerTags?: { ollama?: string[]; vllm?: string[] };
+  requestParams?: { ollama?: Record<string, string>; vllm?: Record<string, string> };
+  providers: { ollama?: string; vllm?: string };
+};
+
+const mockFetchModel = jest.fn<(lookup: { kind: "canonical"; specifier: string } | { kind: "legacy"; providerModel: string }) => Promise<MockModel | undefined>>();
+
+function resolveTagsForDriver(model: MockModel, driver: "vllm" | "ollama"): string[] {
+  return model.providerTags?.[driver] ?? model.tags ?? [];
+}
+
+function resolveRequestParamsForDriver(model: MockModel, driver: "vllm" | "ollama"): Record<string, string> {
+  return model.requestParams?.[driver] ?? {};
+}
 
 mock.module("xinity-infoserver", () => ({
   createInfoserverClient: () => ({
-    resolveModelMeta: mockResolveModelMeta,
-    resolveRequestParams: mockResolveRequestParams,
     fetchModel: mockFetchModel,
   }),
+  resolveTagsForDriver,
+  resolveRequestParamsForDriver,
   BLOCKED_REQUEST_PARAM_PREFIXES: ["chat_template", "tokenize", "prompt", "api_key"],
   deploymentLookup,
   deploymentEarlyLookup,
@@ -89,14 +100,10 @@ const noop = () => {};
 beforeEach(() => {
   queryQueue.length = 0;
   mockSelectHost.mockReset();
-  mockResolveModelMeta.mockReset();
-  mockResolveModelMeta.mockResolvedValue({ type: "chat", tags: ["tools"] });
-  mockResolveRequestParams.mockReset();
-  mockResolveRequestParams.mockResolvedValue({});
   mockFetchModel.mockReset();
   mockFetchModel.mockImplementation(async (lookup) => {
     const value = lookup.kind === "canonical" ? lookup.specifier : lookup.providerModel;
-    return { providers: { ollama: value, vllm: value } };
+    return { type: "chat", tags: ["tools"], providers: { ollama: value, vllm: value } };
   });
 });
 
@@ -203,16 +210,51 @@ describe("getModelInfo", () => {
     queryQueue.push([deploymentResult({ modelSpecifier: "llama3:latest" })]);
     queryQueue.push([installationResult({ host: "node-a", nodePort: 11434, modelPort: 11434, driver: "ollama" })]);
     mockSelectHost.mockResolvedValue({ host: "node-a:11434", useFinalModel: true, release: noop });
-    mockResolveModelMeta.mockResolvedValue({ type: "embedding", tags: ["multilingual"] });
-    mockResolveRequestParams.mockResolvedValue({ "top_k": "number" });
+    mockFetchModel.mockResolvedValueOnce({
+      type: "embedding",
+      tags: ["multilingual"],
+      requestParams: { ollama: { "top_k": "number" } },
+      providers: { ollama: "llama3:latest", vllm: "llama3:latest" },
+    });
 
     const result = await getModelInfo("org-1", "my-model", "key-1");
 
     expect(result!.type).toBe("embedding");
     expect(result!.tags).toEqual(["multilingual"]);
     expect(result!.requestParams).toEqual({ "top_k": "number" });
-    expect(mockResolveModelMeta).toHaveBeenCalledWith({ kind: "legacy", providerModel: "llama3:latest" }, "ollama");
-    expect(mockResolveRequestParams).toHaveBeenCalledWith({ kind: "legacy", providerModel: "llama3:latest" }, "ollama");
+    expect(mockFetchModel).toHaveBeenCalledWith({ kind: "legacy", providerModel: "llama3:latest" });
+  });
+
+  test("returns tags and requestParams undefined when model is not in the infoserver catalog (legacy fallback)", async () => {
+    queryQueue.push([deploymentResult({ modelSpecifier: "llama3:latest" })]);
+    queryQueue.push([installationResult({ host: "node-a", nodePort: 11434, modelPort: 11434, driver: "ollama" })]);
+    mockSelectHost.mockResolvedValue({ host: "node-a:11434", useFinalModel: true, release: noop });
+    mockFetchModel.mockResolvedValueOnce(undefined);
+
+    const result = await getModelInfo("org-1", "my-model", "key-1");
+
+    expect(result).toBeDefined();
+    expect(result!.model).toBe("llama3:latest");
+    expect(result!.type).toBeUndefined();
+    expect(result!.tags).toBeUndefined();
+    expect(result!.requestParams).toBeUndefined();
+  });
+
+  test("uses providerTags for the resolved driver when present", async () => {
+    queryQueue.push([deploymentResult({ modelSpecifier: "mistral:latest" })]);
+    queryQueue.push([installationResult({ host: "gpu-node", nodePort: 8000, modelPort: 8000, driver: "vllm" })]);
+    mockSelectHost.mockResolvedValue({ host: "gpu-node:8000", useFinalModel: true, release: noop });
+    mockFetchModel.mockResolvedValueOnce({
+      type: "chat",
+      tags: ["tools"],
+      providerTags: { vllm: ["tools", "vision"], ollama: ["tools"] },
+      providers: { vllm: "mistral:latest", ollama: "mistral:latest" },
+    });
+
+    const result = await getModelInfo("org-1", "my-model", "key-1");
+
+    expect(result!.driver).toBe("vllm");
+    expect(result!.tags).toEqual(["tools", "vision"]);
   });
 
   test("skips early model lookup when earlyModelSpecifier is null", async () => {

--- a/packages/xinity-ai-gateway/src/llm-forward/model-data.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/model-data.ts
@@ -1,7 +1,7 @@
 import { calcCanaryProgress, sql, modelDeploymentT, aiNodeT, modelInstallationT, installationMatchesLookup } from "common-db";
 import { getDB } from "../db";
 import { env } from "../env";
-import { createInfoserverClient, deploymentLookup, deploymentEarlyLookup, lookupKey, type ModelLookup } from "xinity-infoserver";
+import { createInfoserverClient, deploymentLookup, deploymentEarlyLookup, lookupKey, resolveTagsForDriver, resolveRequestParamsForDriver, type ModelLookup } from "xinity-infoserver";
 import { selectHost as _selectHost, type LoadBalanceStrategy } from "./load-balancer";
 
 /** Indirection for testability. tests can swap this without mock.module. */
@@ -9,7 +9,6 @@ export const _deps = { selectHost: _selectHost };
 
 const infoClient = createInfoserverClient({ baseUrl: env.INFOSERVER_URL, cacheTtlMs: env.INFOSERVER_CACHE_TTL_MS });
 
-/** Retrieves the mapping from public model string to internal split model representation */
 async function publicModelSpecifierToModelSource(orgId: string, specifier: string) {
 
   const [deployment] = await getDB().select().from(modelDeploymentT).where(sql`
@@ -32,7 +31,6 @@ async function publicModelSpecifierToModelSource(orgId: string, specifier: strin
   }
 }
 
-/** Retrieves the servers under which the model identified by the given lookup is available. */
 async function getModelSources(lookup: ModelLookup) {
   const modelLocations = await getDB().select({
     host: aiNodeT.host,
@@ -68,21 +66,17 @@ type ModelInfo = {
   driver: string;
   /** Per-node auth token for authenticating requests to the daemon. */
   authToken: string | null;
-  /** Whether this daemon node serves over TLS. */
   tls: boolean;
-  /** Model type from the catalog (chat, embedding, rerank). Undefined if catalog is unavailable. */
+  /** Model type from the catalog (chat, embedding, rerank). Undefined if catalog entry is unavailable. */
   type?: string;
-  /** Model tags from the catalog (e.g. "tools", "custom_code", "vision"). */
-  tags: string[];
-  /** Allowed request-level passthrough params: dot-path to primitive type. */
-  requestParams: Record<string, string>;
+  /** Model tags from the catalog (e.g. "tools", "custom_code", "vision"). Undefined if catalog entry is unavailable. */
+  tags?: string[];
+  /** Allowed request-level passthrough params: dot-path to primitive type. Undefined if catalog entry is unavailable. */
+  requestParams?: Record<string, string>;
   /** Call when the request completes to release load-balancer resources. */
   release: () => void;
 }
 
-/** Retrieves the up to date model data for the specified api user id, and public deployment specifier.
- * If no deployment can be found, returns undefined.
- */
 export async function getModelInfo(orgId: string, publicSpecifier: string, keyId: string): Promise<ModelInfo | undefined> {
   const accessInfo = await publicModelSpecifierToModelSource(orgId, publicSpecifier);
   if (!accessInfo) {
@@ -137,10 +131,9 @@ export async function getModelInfo(orgId: string, publicSpecifier: string, keyId
     return;
   }
 
-  const [{ type, tags }, requestParams] = await Promise.all([
-    infoClient.resolveModelMeta(resolvedLookup, driver as "vllm" | "ollama"),
-    infoClient.resolveRequestParams(resolvedLookup, driver as "vllm" | "ollama"),
-  ]);
+  const type = model?.type;
+  const tags = model ? resolveTagsForDriver(model, driver as "vllm" | "ollama") : undefined;
+  const requestParams = model ? resolveRequestParamsForDriver(model, driver as "vllm" | "ollama") : undefined;
 
   return {
     host: result.host,

--- a/packages/xinity-ai-gateway/src/llm-forward/util.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/util.ts
@@ -323,7 +323,7 @@ const TYPE_VALIDATORS: Record<string, (v: unknown) => boolean> = {
  */
 export function extractAllowedRequestParams(
   rawBody: Record<string, unknown>,
-  allowedParams: Record<string, string>,
+  allowedParams: Record<string, string> | undefined,
 ): Record<string, unknown> | undefined {
   if (!allowedParams || Object.keys(allowedParams).length === 0) return undefined;
 

--- a/packages/xinity-infoserver/node-compat.test.ts
+++ b/packages/xinity-infoserver/node-compat.test.ts
@@ -7,7 +7,6 @@ const amdGpu: GpuInfo = { vendor: "amd", name: "MI300X", vramMb: 196608 };
 function makeNode(overrides?: Partial<NodeCapability>): NodeCapability {
   return {
     free: 24,
-    drivers: ["vllm", "ollama"],
     driverVersions: { vllm: "0.20.0", ollama: "0.6.3" },
     gpus: [nvidiaGpu],
     ...overrides,
@@ -30,7 +29,14 @@ describe("checkNodeCompatibility", () => {
 
   test("returns missing_driver when driver not available", () => {
     expect(checkNodeCompatibility(
-      makeNode({ drivers: ["ollama"] }),
+      makeNode({ driverVersions: { ollama: "0.6.3" } }),
+      makeReq({ driver: "vllm" }),
+    )).toBe("missing_driver");
+  });
+
+  test("returns missing_driver when driverVersions is empty (no successful probes)", () => {
+    expect(checkNodeCompatibility(
+      makeNode({ driverVersions: {} }),
       makeReq({ driver: "vllm" }),
     )).toBe("missing_driver");
   });
@@ -49,16 +55,16 @@ describe("checkNodeCompatibility", () => {
     )).toBeNull();
   });
 
-  test("skips version check when node has no version info (fail-open by default)", () => {
+  test("skips version check when driver is present but its version is empty (fail-open by default)", () => {
     expect(checkNodeCompatibility(
-      makeNode({ driverVersions: {} }),
+      makeNode({ driverVersions: { vllm: "" } }),
       makeReq({ minVersion: "0.19.1" }),
     )).toBeNull();
   });
 
-  test("returns version_unknown when requireKnownVersion is true and node has no version", () => {
+  test("returns version_unknown when requireKnownVersion is true and the driver's version is empty", () => {
     expect(checkNodeCompatibility(
-      makeNode({ driverVersions: {} }),
+      makeNode({ driverVersions: { vllm: "" } }),
       makeReq({ minVersion: "0.19.1" }),
       { requireKnownVersion: true },
     )).toBe("version_unknown");
@@ -82,7 +88,7 @@ describe("checkNodeCompatibility", () => {
 
   test("requireKnownVersion is ignored when the model has no minVersion", () => {
     expect(checkNodeCompatibility(
-      makeNode({ driverVersions: {} }),
+      makeNode({ driverVersions: { vllm: "" } }),
       makeReq(),
       { requireKnownVersion: true },
     )).toBeNull();
@@ -132,7 +138,7 @@ describe("checkNodeCompatibility", () => {
 
   test("checks constraints in order: driver before version before platform before capacity", () => {
     expect(checkNodeCompatibility(
-      makeNode({ drivers: [], driverVersions: {}, gpus: [amdGpu], free: 0 }),
+      makeNode({ driverVersions: {}, gpus: [amdGpu], free: 0 }),
       makeReq({ minVersion: "0.19.1", requiredPlatforms: ["nvidia"], capacityGb: 100 }),
     )).toBe("missing_driver");
   });
@@ -193,7 +199,7 @@ describe("isDeployableOnCluster", () => {
       providers: { vllm: "org/model" as string | undefined, ollama: "model" as string | undefined },
     };
     expect(isDeployableOnCluster(
-      [makeNode({ drivers: ["ollama"], driverVersions: {} })],
+      [makeNode({ driverVersions: { ollama: "0.6.3" } })],
       multiProviderModel,
     )).toBe(true);
   });
@@ -206,7 +212,7 @@ describe("isDeployableOnCluster", () => {
   test("model without providerMinVersions or providerPlatforms works on any node", () => {
     const simpleModel = { weight: 8, minKvCache: 2, providers: { ollama: "m" as string | undefined } };
     expect(isDeployableOnCluster(
-      [makeNode({ drivers: ["ollama"], gpus: [amdGpu], driverVersions: {} })],
+      [makeNode({ driverVersions: { ollama: "0.6.3" }, gpus: [amdGpu] })],
       simpleModel,
     )).toBe(true);
   });

--- a/packages/xinity-infoserver/node-compat.ts
+++ b/packages/xinity-infoserver/node-compat.ts
@@ -12,10 +12,11 @@ export type GpuInfo = {
   vramMb: number;
 };
 
-/** Minimal representation of a node's capabilities. */
+/** Minimal representation of a node's capabilities.
+ * Driver availability is determined by keys present in `driverVersions`:
+ * if the daemon couldn't probe a version for a driver, that driver is unusable. */
 export type NodeCapability = {
   free: number;
-  drivers: string[];
   driverVersions: Record<string, string>;
   gpus: GpuInfo[];
 };
@@ -54,7 +55,7 @@ export function checkNodeCompatibility(
   // TODO v1.0.0 default this to true
   const requireKnownVersion = options.requireKnownVersion ?? false;
 
-  if (!node.drivers.includes(req.driver)) return "missing_driver";
+  if (!(req.driver in node.driverVersions)) return "missing_driver";
 
   if (req.minVersion) {
     const nodeVersion = node.driverVersions[req.driver];


### PR DESCRIPTION
## Description

- Adds `DEPLOYMENT_STRATEGY` env var (`first-fit` | `balanced` | `bin-pack` | `proportional`, default `balanced`). Orchestrator ranks nodes per replica via the chosen strategy.
- Fixes gateway tool-calling rejection for models routable via the legacy provider-model fallback. `ModelInfo.tags` / `requestParams` are now optional; guards only fire when tags is known. Also collapses 3 infoserver fetches per request to 1.
- Bundled fixes: dashboard data page first load (`b4d5f13`), better-auth SvelteKit cookie plugin (`2d4daf7`), nix infoserver model folder type (`8abd3f6`), `driverVersions` presence check (`6754407`).

## Type of change

Bug fix | New feature

## Testing

- `bun test` in `xinity-ai-gateway` (242/242) and `xinity-ai-dashboard`, plus `tsc --noEmit` clean.
- Manual: deployed a model absent from the infoserver catalog, confirmed tool-call requests now return 200 instead of 400.

## Checklist

- [x] Tests pass locally (`bun test`), or no testable code was changed
- [x] New or changed behavior is covered by tests, or this change does not require tests
- [x] Documentation is updated, or no user-facing behavior or configuration was changed
- [x] There are no breaking changes, or they are marked with `!` in the commit type and described above
- [x] No security-sensitive changes (authentication, credentials, input handling), or they have been reviewed
- [x] No new dependencies were added, or they have been reviewed for license and maintenance status