### PR TITLE
fix(cli): backups during upgrade flow

### DIFF
--- a/packages/xinity-cli/build.ts
+++ b/packages/xinity-cli/build.ts
@@ -5,8 +5,8 @@
  *   2. Compile the bundle into a standalone binary with bun build --compile
  *
  * Usage:
- *   CLI_VERSION=v1.0.0 bun run build.ts --target bun-linux-x64
- *   bun run build.ts                           # defaults: target=bun-linux-x64, version=dev
+ *   bun run build.ts --target bun-linux-x64 --outfile dist/xinity
+ *   bun run build.ts                           # defaults: target=bun-linux-x64, outfile=dist/xinity
  */
 import { resolve } from "path";
 import { parseArgs } from "util";

--- a/packages/xinity-cli/src/commands/update.ts
+++ b/packages/xinity-cli/src/commands/update.ts
@@ -117,7 +117,7 @@ export async function runUpdateFlow(opts: { checkOnly: boolean; targetVersion: s
   spinner.stop(`Latest release: ${release.tagName}`);
 
   // Compare versions
-  const needsUpdate = CLI_VERSION !== release.tagName && CLI_VERSION !== "dev";
+  const needsUpdate = CLI_VERSION !== release.tagName;
   const status = needsUpdate
     ? pc.yellow(`${CLI_VERSION} → ${release.tagName}`)
     : pc.green(`${CLI_VERSION} (up to date)`);

--- a/packages/xinity-cli/src/lib/env-file.ts
+++ b/packages/xinity-cli/src/lib/env-file.ts
@@ -13,8 +13,8 @@ export function parseEnvString(content: string): Record<string, string> {
     if (!trimmed || trimmed.startsWith("#")) continue;
     const eq = trimmed.indexOf("=");
     if (eq === -1) continue;
-    const key = trimmed.slice(0, eq);
-    let value = trimmed.slice(eq + 1);
+    const key = trimmed.slice(0, eq).trim();
+    let value = trimmed.slice(eq + 1).trim();
     if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
       value = value.slice(1, -1);
     }

--- a/packages/xinity-cli/src/lib/env-prompt.ts
+++ b/packages/xinity-cli/src/lib/env-prompt.ts
@@ -232,7 +232,9 @@ async function promptField(
   if (field.isBoolean) {
     const value = await promptOrExit(p.confirm({
       message: `${field.key}${hint}`,
-      initialValue: existing === "true" || existing === "1" || (field.hasDefault && field.defaultValue === true),
+      initialValue: existingValue !== undefined
+        ? existingValue === "true" || existingValue === "1"
+        : field.hasDefault && field.defaultValue === true,
     }));
     return String(value);
   }

--- a/packages/xinity-cli/src/lib/host.ts
+++ b/packages/xinity-cli/src/lib/host.ts
@@ -319,7 +319,9 @@ export async function readSecrets(
     return { secrets, permissionDenied: true, skipped: false };
   }
 
-  const parts = result.output.split("\0").filter(Boolean);
+  // NUL-delimited key\0value pairs with a trailing NUL. Don't drop empty
+  // tokens, or an empty value would misalign every later pair.
+  const parts = result.output.split("\0");
   for (let i = 0; i + 1 < parts.length; i += 2) {
     const key = parts[i];
     const value = parts[i + 1];

--- a/packages/xinity-cli/src/lib/installer.ts
+++ b/packages/xinity-cli/src/lib/installer.ts
@@ -19,7 +19,7 @@ import { parseEnvString } from "./env-file.ts";
 import { pass, fail, warn, info, cancelAndExit, elevationHardFailed, promptOrExit } from "./output.ts";
 import { type Host, createLocalHost, commandExistsOn, isUnitActiveOn, readSecrets } from "./host.ts";
 import { isOllamaRunning, waitForOllamaRunning } from "./ollama-setup.ts";
-import { writeEnvConfig, writeSystemdUnit, stopService, startService } from "./service.ts";
+import { writeEnvConfig, writeSystemdUnit, stopService, startService, restartService } from "./service.ts";
 import {
   type Component, type InstallResult, type RemoveResult,
   ENV_SCHEMAS, ENV_DIR, SECRETS_DIR, BIN_DIR, DASHBOARD_DIR, UNIT_DIR,
@@ -692,17 +692,79 @@ function printServiceFailureDiagnostics(unit: string): void {
   p.log.info(`  ${pc.cyan(`journalctl -u ${unit} -e --no-pager`)}`);
 }
 
+/** Move the current binary aside to <path>.bak before installing the new one. */
+async function backupCurrentBinary(component: Component, host: Host): Promise<void> {
+  const binPath = `${BIN_DIR}/${binaryBaseName(component)}`;
+  const result = await host.withElevation(
+    `[ -f ${binPath} ] && mv -f ${binPath} ${binPath}.bak || true`,
+    `Back up ${component} binary`,
+  );
+  if (result.success && !result.skipped) info("Backup", `Previous binary saved to ${binPath}.bak`);
+}
+
+/** Copy the current env file and secrets aside to .bak before reconfiguring. */
+async function backupCurrentConfig(component: Component, host: Host): Promise<void> {
+  const envPath = `${ENV_DIR}/${component}.env`;
+  const result = await host.withElevation(
+    [
+      `[ -f ${envPath} ] && cp -p ${envPath} ${envPath}.bak || true`,
+      `[ -d ${SECRETS_DIR} ] && cp -ap ${SECRETS_DIR} ${SECRETS_DIR}.bak 2>/dev/null || true`,
+    ].join(" && "),
+    `Back up ${component} configuration`,
+  );
+  if (result.success && !result.skipped) info("Backup", `Previous configuration saved to ${envPath}.bak`);
+}
+
+/** Restart the service if it's already running, otherwise start it. */
+async function bringServiceUp(component: Component, host: Host): Promise<boolean> {
+  return (await isUnitActiveOn(host, unitName(component)))
+    ? restartService(component, host)
+    : startService(component, host);
+}
+
+/** Restore the .bak binary and configuration, then bring the service back up. */
+async function performRollback(component: Component, host: Host): Promise<void> {
+  const binPath = `${BIN_DIR}/${binaryBaseName(component)}`;
+  const envPath = `${ENV_DIR}/${component}.env`;
+  const unit = unitName(component);
+
+  info("Rollback", "Restoring previous version…");
+  await host.withElevation(
+    `[ -f ${binPath}.bak ] && cp -p ${binPath}.bak ${binPath} && chmod +x ${binPath} || true`,
+    `Restore ${component} binary`,
+  );
+  await host.withElevation(
+    [
+      `[ -f ${envPath}.bak ] && cp -p ${envPath}.bak ${envPath} || true`,
+      `[ -d ${SECRETS_DIR}.bak ] && cp -ap ${SECRETS_DIR}.bak/. ${SECRETS_DIR}/ 2>/dev/null || true`,
+    ].join(" && "),
+    `Restore ${component} configuration`,
+  );
+  pass("Rollback", "Previous binary and configuration restored");
+
+  if (await bringServiceUp(component, host)) {
+    pass("Rollback", `${unit} is back on the previous version`);
+  } else {
+    warn("Rollback", "Service did not restart after rollback. Manual intervention may be needed");
+    p.log.info(`  ${pc.cyan(`systemctl start ${unit}`)}`);
+  }
+}
+
 /**
- * Configure env, write unit, and start the service. Loops on failure to allow
- * the user to reconfigure and retry without re-downloading the binary.
- * Returns accumulated non-fatal errors (or null on a hard cancel/abort).
+ * Configure env, write unit, and bring the service up, looping on failure so
+ * the user can reconfigure and retry without re-downloading the binary.
+ * On an update the service is restarted and a rollback option is offered if it
+ * fails. Returns accumulated non-fatal errors (or null on a hard cancel/abort).
  */
 async function configureAndStart(
   component: Component,
   autoDefaults: Record<string, string>,
   host: Host,
+  isUpdate = false,
 ): Promise<string[] | null> {
   const errors: string[] = [];
+  const unit = unitName(component);
+  const verb = isUpdate ? "restart" : "start";
 
   // eslint-disable-next-line no-constant-condition
   while (true) {
@@ -722,20 +784,25 @@ async function configureAndStart(
       errors.push("Systemd unit not installed (may need manual setup)");
     }
 
-    const started = await startService(component, host);
-    if (started) return errors;
+    if (await bringServiceUp(component, host)) return errors;
 
-    const unit = unitName(component);
     printServiceFailureDiagnostics(unit);
 
+    // On a fresh install, disable the broken unit so it doesn't start on boot.
+    // On an update, leave it enabled so a rollback can bring the old version back.
     await host.withElevation(
-      `systemctl disable --now ${unit} 2>/dev/null; systemctl reset-failed ${unit} 2>/dev/null`,
-      `Disable ${unit}`,
+      isUpdate
+        ? `systemctl reset-failed ${unit} 2>/dev/null || true`
+        : `systemctl disable --now ${unit} 2>/dev/null; systemctl reset-failed ${unit} 2>/dev/null`,
+      isUpdate ? `Reset failed state for ${unit}` : `Disable ${unit}`,
     );
 
     const action = await p.select({
       message: "How would you like to proceed?",
       options: [
+        ...(isUpdate
+          ? [{ value: "rollback", label: "Roll back to previous version (restore backup)" }]
+          : []),
         { value: "retry", label: "Reconfigure and try again" },
         { value: "continue", label: "Continue anyway (service not running)" },
         { value: "abort", label: "Abort" },
@@ -743,8 +810,12 @@ async function configureAndStart(
     });
 
     if (p.isCancel(action) || action === "abort") return null;
+    if (action === "rollback") {
+      await performRollback(component, host);
+      return null;
+    }
     if (action === "continue") {
-      errors.push("Service did not start successfully");
+      errors.push(`Service did not ${verb} successfully`);
       return errors;
     }
     // retry → loop back to configureEnv
@@ -778,11 +849,13 @@ export async function installComponent(opts: {
 
   const { archivePath, versionString, isUpdate } = artifact;
 
-  // 3. Stop existing service if updating
+  // 3. Prepare for update: back up binary + config, then optionally hard-reset state
   if (isUpdate) {
-    await stopService(component, host);
+    await backupCurrentBinary(component, host);
+    await backupCurrentConfig(component, host);
 
     if (hardReset) {
+      await stopService(component, host);
       const unit = unitName(component);
       info("Hard reset", `Cleaning state for ${unit}…`);
       const result = await host.withElevation(
@@ -797,9 +870,9 @@ export async function installComponent(opts: {
   const installed = await installBinary(component, archivePath, host);
   if (!installed) return { success: false, version: versionString, errors: ["Installation failed or skipped"] };
 
-  // 5. Configure env, install unit, start service (with retry loop)
+  // 5. Configure env, install unit, restart (update) or start (fresh install)
   const autoDefaults = { ...getAutoDefaults(component), ...(opts.envOverrides ?? {}) };
-  const errors = await configureAndStart(component, autoDefaults, host);
+  const errors = await configureAndStart(component, autoDefaults, host, isUpdate);
   if (errors === null) return { success: false, version: versionString, errors: ["Aborted"] };
 
   // 6. Update manifest

--- a/packages/xinity-cli/tests/unit/env-file.test.ts
+++ b/packages/xinity-cli/tests/unit/env-file.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { parseEnvString, serializeEnvFile } from "../../src/lib/env-file.ts";
+
+describe("parseEnvString", () => {
+  test("parses simple KEY=value lines", () => {
+    expect(parseEnvString("A=1\nB=two")).toEqual({ A: "1", B: "two" });
+  });
+
+  test("skips blank lines and comments", () => {
+    expect(parseEnvString("# comment\n\nA=1\n  # indented\n")).toEqual({ A: "1" });
+  });
+
+  test("trims whitespace around the = separator", () => {
+    expect(parseEnvString("KEY = value")).toEqual({ KEY: "value" });
+  });
+
+  test("strips matching surrounding quotes while preserving inner spaces", () => {
+    expect(parseEnvString('A="hello world"')).toEqual({ A: "hello world" });
+    expect(parseEnvString("B = ' spaced '")).toEqual({ B: " spaced " });
+  });
+
+  test("keeps '=' characters that appear in the value", () => {
+    expect(parseEnvString("URL=postgres://u:p@h/db?x=1")).toEqual({
+      URL: "postgres://u:p@h/db?x=1",
+    });
+  });
+
+  test("handles empty values", () => {
+    expect(parseEnvString("A=")).toEqual({ A: "" });
+  });
+});
+
+describe("serializeEnvFile", () => {
+  test("round-trips values that need quoting", () => {
+    const values = { A: "1", B: "two words", C: "https://x.test" };
+    expect(parseEnvString(serializeEnvFile(values))).toEqual(values);
+  });
+});


### PR DESCRIPTION
## Description

The CLI's up update path is now recoverable.  
Instead of overwriting the binary in place and leaving a broken service when the new version fails, it backs up the current binary and config, installs the new version, and restarts.  
If the restart fails, the user can roll back to the previous binary and config. The backup stays in place.

Also fixes a few adjacent CLI issues found along the way: 
- empty secret values no longer corrupt later secrets
- env parsing trims around =
- a stored boolean is no longer overridden by its schema default
-  a dead dev-build guard in self-update was removed. 

## Type of change

Bug fix

## Testing

A unit test was introduced for env file parsing. 

## Checklist

- [x] Tests pass locally (`bun test`), or no testable code was changed
- [x] New or changed behavior is covered by tests, or this change does not require tests
- [x] Documentation is updated, or no user-facing behavior or configuration was changed
- [x] There are no breaking changes, or they are marked with `!` in the commit type and described above
- [x] No security-sensitive changes (authentication, credentials, input handling), or they have been reviewed
- [x] No new dependencies were added, or they have been reviewed for license and maintenance status