### PR TITLE
fix(gateway): openai compatibility with the transcription api 

### DIFF
--- a/packages/common-log/src/index.ts
+++ b/packages/common-log/src/index.ts
@@ -1,2 +1,3 @@
 export { logEnvSchema, type LogEnv } from "./env-schema";
 export { createLogger, type LoggerOptions } from "./factory";
+export { type Logger } from "pino";

--- a/packages/xinity-ai-daemon/src/modules/model-installation/vllm.test.ts
+++ b/packages/xinity-ai-daemon/src/modules/model-installation/vllm.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, mock, beforeEach } from "bun:test";
+import { describe, test, expect, mock, beforeEach, spyOn } from "bun:test";
 import { firstValueFrom } from "rxjs";
 import type { VllmOps } from "./vllm-ops";
 import { installationLookup } from "xinity-infoserver";
@@ -482,6 +482,28 @@ describe("syncVllmInstallations$", () => {
 
     const startCall = (ops.start as ReturnType<typeof mock>).mock.calls[0]!;
     expect(startCall[1].extraArgs).not.toContain("--runner");
+  });
+
+  test("does not warm up transcription models with a chat completion", async () => {
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(new Response("{}"));
+    try {
+      const id = crypto.randomUUID();
+      const inst = makeInstallation("whisper-model", id, 9106);
+      mockFetchModel.mockImplementation((lookup) => Promise.resolve({ type: "transcription", providers: { vllm: lookupValue(lookup) } }));
+      const ops = createMockOps({
+        listRunning: mock(() => Promise.resolve([])),
+        checkHealth: mock(() => Promise.resolve(true)),
+        isAlive: mock(() => Promise.resolve(true)),
+      });
+
+      await firstValueFrom(syncVllmInstallations$([inst], ops));
+
+      expect(ops.start).toHaveBeenCalled();
+      const warmupCalls = fetchSpy.mock.calls.filter(([url]) => String(url).includes("/v1/chat/completions"));
+      expect(warmupCalls).toHaveLength(0);
+    } finally {
+      fetchSpy.mockRestore();
+    }
   });
 
   test("uses providers.vllm from the catalog rather than the installation row's model column", async () => {

--- a/packages/xinity-ai-daemon/src/modules/model-installation/vllm.ts
+++ b/packages/xinity-ai-daemon/src/modules/model-installation/vllm.ts
@@ -92,7 +92,7 @@ async function warmupChatModel(port: number, model: string): Promise<void> {
 }
 
 async function markInstallationReady(installation: ModelInstallation, providerModel: string, modelType?: string): Promise<void> {
-  if (modelType !== "embedding" && modelType !== "rerank") {
+  if (modelType !== "embedding" && modelType !== "rerank" && modelType !== "transcription") {
     await warmupChatModel(installation.port, providerModel);
   }
   await updateInstallationState(installation.id, "ready", { statusMessage: "vLLM server healthy" });

--- a/packages/xinity-ai-dashboard/src/lib/server/info-client.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/info-client.ts
@@ -4,8 +4,10 @@
 import { building } from "$app/environment";
 import { createInfoserverClient } from "xinity-infoserver";
 import { serverEnv } from "./serverenv";
+import { rootLogger } from "./logging";
 
 export const infoClient = building ? null : createInfoserverClient({
   baseUrl: serverEnv.INFOSERVER_URL,
   cacheTtlMs: serverEnv.INFOSERVER_CACHE_TTL_MS,
+  logger: rootLogger.child({ name: "infoserver-client" }),
 });

--- a/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/model.procedure.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/model.procedure.ts
@@ -21,7 +21,7 @@ const listModels = rootOs
   .input(z.object({
     page: z.coerce.number().min(1).default(1),
     pageSize: z.coerce.number().min(1).max(100).default(50),
-    type: z.enum(["chat", "embedding", "rerank"]).optional(),
+    type: z.enum(["chat", "embedding", "rerank", "transcription"]).optional(),
     family: z.string().optional(),
     tags: z.array(z.string()).optional(),
   }))

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/+page.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/+page.svelte
@@ -117,7 +117,7 @@
   // Test button only renders for entries we resolved to a supported type.
   type ModelTypeKnowledge =
     | { status: "loading" }
-    | { status: "known"; type: "chat" | "embedding" | "rerank" }
+    | { status: "known"; type: "chat" | "embedding" | "rerank" | "transcription" }
     | { status: "unknown" };
   let modelKnowledge = $state<Record<string, ModelTypeKnowledge>>({});
 
@@ -145,7 +145,8 @@
     deployment: DeploymentDefinition,
   ): "chat" | "embedding" | "rerank" | null {
     const k = modelKnowledge[deployment.specifier ?? deployment.modelSpecifier];
-    return k?.status === "known" ? k.type : null;
+    if (k?.status !== "known" || k.type === "transcription") return null;
+    return k.type;
   }
 
   function openTest(

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/+page.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/+page.svelte
@@ -385,7 +385,7 @@
                           variant="ghost"
                           size="sm"
                           class="h-6 px-2 text-xs text-muted-foreground"
-                          onclick={() => copyToClipboard(deployment.status.failureLogs ?? '')}
+                          onclick={() => copyToClipboard(deployment.status?.failureLogs ?? '')}
                           title="Copy all logs"
                         >
                           <Copy class="w-3.5 h-3.5" />

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/ModelSelectorModal.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/ModelSelectorModal.svelte
@@ -12,9 +12,9 @@
 
   // Icons
   import { X, Search, ExternalLink, Info, ShieldAlert, HardDrive, Loader2, AlertCircle,
-    LayoutGrid, MessageSquare, Boxes, ArrowUpDown } from "@lucide/svelte";
+    LayoutGrid, MessageSquare, Boxes, ArrowUpDown, Mic } from "@lucide/svelte";
   // Icons for the not-yet-available model types (see MODEL_TYPES below):
-  // import { Mic, Image as ImageIcon, AudioLines } from "@lucide/svelte";
+  // import { Image as ImageIcon, AudioLines } from "@lucide/svelte";
 
   /** Minimum number of filtered results before auto-loading the next page. */
   const MIN_RESULTS_THRESHOLD = 10;
@@ -24,7 +24,7 @@
     { value: "chat", label: "Chat", icon: MessageSquare },
     { value: "embedding", label: "Embedding", icon: Boxes },
     { value: "rerank", label: "Rerank", icon: ArrowUpDown },
-    // { value: "transcription", label: "Transcription", icon: Mic },
+    { value: "transcription", label: "Transcription", icon: Mic },
     // { value: "image", label: "Image", icon: ImageIcon },
     // { value: "tts", label: "Text to Speech", icon: AudioLines },
   ] as const;

--- a/packages/xinity-ai-gateway/src/gatewayServer.ts
+++ b/packages/xinity-ai-gateway/src/gatewayServer.ts
@@ -11,6 +11,7 @@ import { handleEmbeddingGeneration } from "./llm-forward/endpoints/handle-embedd
 import { handleModelsRequest } from "./llm-forward/endpoints/handle-models";
 import { handleCreateResponseRequest, handleGetOrDeleteResponseRequest } from "./llm-forward/endpoints/handle-responses";
 import { handleRerank } from "./llm-forward/endpoints/handle-rerank";
+import { handleTranscription } from "./llm-forward/endpoints/handle-transcription";
 import { handleMetrics, withMetrics } from "./metrics";
 import { getTlsConfig } from "common-env";
 import { logMigrationFailureFatal } from "common-db";
@@ -38,6 +39,7 @@ const meteredEndpoints: Array<[string, (req: Request) => Promise<Response> | Res
   ["/v1/chat/completions", handleChatCompletion],
   ["/v1/completions", handleCompletion],
   ["/v1/embeddings", handleEmbeddingGeneration],
+  ["/v1/audio/transcriptions", handleTranscription],
   ["/v1/models", handleModelsRequest],
   ["/v1/rerank", handleRerank],
   ["/v1/responses", handleCreateResponseRequest],

--- a/packages/xinity-ai-gateway/src/llm-forward/ai-sdk.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/ai-sdk.ts
@@ -18,31 +18,36 @@ export type AuthorizedModelContext = ResolvedModel & {
   provider: OpenAICompatibleProvider;
 };
 
-export async function resolveModel(
-  req: Request
-): Promise<Response | ResolvedModel> {
+/**
+ * Authenticate the request and resolve the active application (the
+ * `X-Application` header overrides the key's default). Shared by the JSON
+ * endpoints (via resolveModel) and the multipart transcription endpoint.
+ */
+export async function resolveAuth(req: Request): Promise<Response | AuthResult> {
   const authHeader = req.headers.get("authorization") || "";
   const authCheckResponse = await checkAuth(authHeader);
   if (authCheckResponse instanceof Response) {
     return authCheckResponse;
   }
 
-  // Resolve application: X-Application header overrides key's default
   const xAppHeader = req.headers.get("x-application");
-  let resolvedApplicationId = authCheckResponse.applicationId;
-
-  if (xAppHeader) {
-    const appId = await resolveApplicationByName(xAppHeader, authCheckResponse.orgId);
-    if (!appId) {
-      return errorResponse(`Application "${xAppHeader}" not found`, 404);
-    }
-    resolvedApplicationId = appId;
+  if (!xAppHeader) {
+    return authCheckResponse;
   }
+  const appId = await resolveApplicationByName(xAppHeader, authCheckResponse.orgId);
+  if (!appId) {
+    return errorResponse(`Application "${xAppHeader}" not found`, 404);
+  }
+  return { ...authCheckResponse, applicationId: appId };
+}
 
-  const auth: AuthResult = {
-    ...authCheckResponse,
-    applicationId: resolvedApplicationId,
-  };
+export async function resolveModel(
+  req: Request
+): Promise<Response | ResolvedModel> {
+  const auth = await resolveAuth(req);
+  if (auth instanceof Response) {
+    return auth;
+  }
 
   let body: Record<string, unknown>;
   try {

--- a/packages/xinity-ai-gateway/src/llm-forward/backend-fetch.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/backend-fetch.ts
@@ -37,3 +37,21 @@ export function backendPostJson(
     authToken: target.authToken ?? undefined,
   });
 }
+
+/**
+ * Post a multipart form to a daemon-proxied backend endpoint with the standard
+ * timeout. No Content-Type is set so fetch derives the multipart boundary.
+ */
+export function backendPostForm(
+  target: BackendTarget,
+  path: string,
+  form: FormData,
+  clientSignal: AbortSignal,
+): Promise<Response> {
+  return backendFetch(backendUrl(target.host, target.model, path, target.tls), {
+    method: "POST",
+    body: form,
+    signal: AbortSignal.any([clientSignal, AbortSignal.timeout(env.BACKEND_TIMEOUT_MS)]),
+    authToken: target.authToken ?? undefined,
+  });
+}

--- a/packages/xinity-ai-gateway/src/llm-forward/backend-schemas.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/backend-schemas.ts
@@ -81,3 +81,20 @@ export const BackendCompletionChunkSchema = z.looseObject({
   usage: BackendUsageSchema,
 });
 
+// ---------------------------------------------------------------------------
+// Transcriptions (/v1/audio/transcriptions)
+// ---------------------------------------------------------------------------
+
+/** vLLM streams transcriptions as chat-completion-style chunks (`object: "transcription.chunk"`). */
+export const BackendTranscriptionChunkSchema = z.looseObject({
+  ...backendResponseEnvelope,
+  choices: z.array(z.looseObject({
+    delta: z.looseObject({
+      content: z.string().nullable().optional(),
+    }),
+    finish_reason: z.string().nullable().optional(),
+    logprobs: z.unknown().nullable().optional(),
+  })).default([]),
+  usage: BackendUsageSchema,
+});
+

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-chatCompletion.test.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-chatCompletion.test.ts
@@ -346,6 +346,48 @@ describe("handleChatCompletion", () => {
 });
 
 // ---------------------------------------------------------------------------
+// logprobs
+// ---------------------------------------------------------------------------
+
+describe("handleChatCompletion, logprobs", () => {
+  test("forwards logprobs and top_logprobs to the backend", async () => {
+    const req = new Request("http://localhost:4000/v1/chat/completions", {
+      method: "POST",
+      headers: { "Authorization": "Bearer test" },
+      body: JSON.stringify({
+        model: "test-model",
+        messages: [{ role: "user", content: "Hi" }],
+        logprobs: true,
+        top_logprobs: 5,
+      }),
+    });
+
+    const res = await handleChatCompletion(req);
+    expect(res.status).toBe(200);
+    expect(lastUpstreamBody?.logprobs).toBe(true);
+    expect(lastUpstreamBody?.top_logprobs).toBe(5);
+  });
+
+  test("passes backend logprobs through to the client", async () => {
+    nextUpstreamResponse = makeRawJsonResponse({
+      id: "test-id", object: "chat.completion", created: 123, model: "test-model",
+      choices: [{
+        index: 0,
+        message: { role: "assistant", content: "Hello" },
+        finish_reason: "stop",
+        logprobs: { content: [{ token: "Hello", logprob: -0.1 }] },
+      }],
+      usage: { prompt_tokens: 5, completion_tokens: 5, total_tokens: 10 },
+    });
+
+    const res = await handleChatCompletion(makeRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.choices[0].logprobs).toEqual({ content: [{ token: "Hello", logprob: -0.1 }] });
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Tool calling tests
 // ---------------------------------------------------------------------------
 

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-chatCompletion.test.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-chatCompletion.test.ts
@@ -57,6 +57,8 @@ mock.module("../model-data", () => ({
 mock.module("../backend-fetch", () => ({
   backendUrl: (host: string, _model: string, path: string, _tls: boolean) => `http://${host}${path}`,
   backendFetch: (url: string | URL | Request, init?: RequestInit) => fetch(url, init),
+  backendPostForm: (target: { host: string }, path: string, form: FormData, clientSignal: AbortSignal) =>
+    fetch(`http://${target.host}${path}`, { method: "POST", body: form, signal: clientSignal }),
   backendPostJson: (target: { host: string }, path: string, body: unknown, clientSignal: AbortSignal) =>
     fetch(`http://${target.host}${path}`, {
       method: "POST",

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-chatCompletion.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-chatCompletion.ts
@@ -32,6 +32,8 @@ export const ChatCompletionBodySchema = z.looseObject({
   frequency_penalty: z.number().optional(),
   presence_penalty: z.number().optional(),
   seed: z.number().optional(),
+  logprobs: z.boolean().optional(),
+  top_logprobs: z.number().optional(),
   metadata: z.record(z.string(), z.unknown()).nullable().optional(),
   response_format: z.object({
     type: z.enum(["text", "json_object", "json_schema"]),
@@ -112,7 +114,7 @@ const chatStreamSpec: StreamSpec<z.infer<typeof BackendChatChunkSchema>, ChatAcc
   }),
 };
 
-const ChatSyncChoiceSchema = z.looseObject({
+export const ChatSyncChoiceSchema = z.looseObject({
   index: z.number(),
   message: z.looseObject({
     role: z.string(),
@@ -163,6 +165,8 @@ export const handleChatCompletion = withEndpointGuards({
       frequency_penalty: body.frequency_penalty,
       presence_penalty: body.presence_penalty,
       seed: body.seed,
+      logprobs: body.logprobs,
+      top_logprobs: body.top_logprobs,
       response_format: body.response_format,
       tools: body.tools,
       tool_choice: body.tool_choice,

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-completions.test.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-completions.test.ts
@@ -53,6 +53,8 @@ mock.module("../model-data", () => ({
 mock.module("../backend-fetch", () => ({
   backendUrl: (host: string, _model: string, path: string, _tls: boolean) => `http://${host}${path}`,
   backendFetch: (url: string | URL | Request, init?: RequestInit) => fetch(url, init),
+  backendPostForm: (target: { host: string }, path: string, form: FormData, clientSignal: AbortSignal) =>
+    fetch(`http://${target.host}${path}`, { method: "POST", body: form, signal: clientSignal }),
   backendPostJson: (target: { host: string }, path: string, body: unknown, clientSignal: AbortSignal) =>
     fetch(`http://${target.host}${path}`, {
       method: "POST",

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-completions.test.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-completions.test.ts
@@ -111,6 +111,7 @@ function makeCompletionJsonResponse(model: string, text: string): Response {
 
 let server: ReturnType<typeof Bun.serve>;
 let nextUpstreamResponse: Response | null = null;
+let lastUpstreamBody: Record<string, unknown> | null = null;
 
 beforeAll(() => {
   server = Bun.serve({
@@ -123,7 +124,8 @@ beforeAll(() => {
           nextUpstreamResponse = null;
           return r;
         }
-        const body = (await req.json()) as { stream?: boolean };
+        const body = (await req.json()) as Record<string, unknown>;
+        lastUpstreamBody = body;
         if (body.stream) return makeCompletionSseResponse("test-model", ["Hello"]);
         return makeCompletionJsonResponse("test-model", "Hello");
       }
@@ -139,6 +141,7 @@ afterEach(() => {
   mockLogChatStream.mockClear();
   mockLogChatSync.mockClear();
   nextUpstreamResponse = null;
+  lastUpstreamBody = null;
 });
 
 afterAll(() => {
@@ -165,6 +168,36 @@ describe("handleCompletion", () => {
     expect(text).toContain('"object":"text_completion"');
     expect(text).toContain('"text":"Hello"');
     expect(text).toContain("data: [DONE]");
+  });
+
+  test("forwards logprobs to the backend", async () => {
+    const req = new Request("http://localhost:4000/v1/completions", {
+      method: "POST",
+      headers: { "Authorization": "Bearer test" },
+      body: JSON.stringify({ model: "test-model", prompt: "Hi", logprobs: 5 }),
+    });
+
+    const res = await handleCompletion(req);
+    expect(res.status).toBe(200);
+    expect(lastUpstreamBody?.logprobs).toBe(5);
+  });
+
+  test("passes backend logprobs through to the client", async () => {
+    nextUpstreamResponse = Response.json({
+      id: "test-id", object: "text_completion", created: 123, model: "test-model",
+      choices: [{ index: 0, text: "Hello", finish_reason: "stop", logprobs: { tokens: ["Hello"], token_logprobs: [-0.1] } }],
+      usage: { prompt_tokens: 5, completion_tokens: 5, total_tokens: 10 },
+    });
+    const req = new Request("http://localhost:4000/v1/completions", {
+      method: "POST",
+      headers: { "Authorization": "Bearer test" },
+      body: JSON.stringify({ model: "test-model", prompt: "Hi" }),
+    });
+
+    const res = await handleCompletion(req);
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.choices[0].logprobs).toEqual({ tokens: ["Hello"], token_logprobs: [-0.1] });
   });
 
   test("should handle non-streaming completion", async () => {

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-completions.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-completions.ts
@@ -23,6 +23,7 @@ export const CompletionBodySchema = z.looseObject({
   presence_penalty: z.number().optional(),
   stream: z.boolean().optional().default(false),
   seed: z.number().optional(),
+  logprobs: z.number().optional(),
   stop: z.union([z.string(), z.array(z.string())]).optional(),
   store: z.boolean().optional(),
   metadata: z.record(z.string(), z.unknown()).nullable().optional(),
@@ -62,7 +63,7 @@ const completionStreamSpec: StreamSpec<z.infer<typeof BackendCompletionChunkSche
   }),
 };
 
-const CompletionSyncChoiceSchema = z.looseObject({
+export const CompletionSyncChoiceSchema = z.looseObject({
   index: z.number(),
   text: z.string(),
   finish_reason: z.string().nullable().optional(),
@@ -112,6 +113,7 @@ export const handleCompletion = withEndpointGuards({
       frequency_penalty: body.frequency_penalty,
       presence_penalty: body.presence_penalty,
       seed: body.seed,
+      logprobs: body.logprobs,
       stop: body.stop,
       stream: body.stream,
     };

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-embeddings.test.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-embeddings.test.ts
@@ -54,6 +54,8 @@ mock.module("../model-data", () => ({
 mock.module("../backend-fetch", () => ({
   backendUrl: (host: string, _model: string, path: string, _tls: boolean) => `http://${host}${path}`,
   backendFetch: (url: string | URL | Request, init?: RequestInit) => fetch(url, init),
+  backendPostForm: (target: { host: string }, path: string, form: FormData, clientSignal: AbortSignal) =>
+    fetch(`http://${target.host}${path}`, { method: "POST", body: form, signal: clientSignal }),
   backendPostJson: (target: { host: string }, path: string, body: unknown, clientSignal: AbortSignal) =>
     fetch(`http://${target.host}${path}`, {
       method: "POST",

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-responses.test.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-responses.test.ts
@@ -51,6 +51,8 @@ mock.module("../model-data", () => ({
 mock.module("../backend-fetch", () => ({
   backendUrl: (host: string, _model: string, path: string, _tls: boolean) => `http://${host}${path}`,
   backendFetch: (url: string | URL | Request, init?: RequestInit) => fetch(url, init),
+  backendPostForm: (target: { host: string }, path: string, form: FormData, clientSignal: AbortSignal) =>
+    fetch(`http://${target.host}${path}`, { method: "POST", body: form, signal: clientSignal }),
   backendPostJson: (target: { host: string }, path: string, body: unknown, clientSignal: AbortSignal) =>
     fetch(`http://${target.host}${path}`, {
       method: "POST",

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-transcription.test.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-transcription.test.ts
@@ -56,7 +56,8 @@ mock.module("../../callLogger", () => ({
   logChatStream: mock(() => Promise.resolve()),
   logChatSync: mock(() => Promise.resolve()),
 }));
-mock.module("../../usageRecorder", () => ({ recordUsageEvent: mock(() => {}) }));
+const recordUsageEvent = mock((_event: { inputTokens: number; outputTokens: number }) => {});
+mock.module("../../usageRecorder", () => ({ recordUsageEvent }));
 
 const { handleTranscription } = await import("./handle-transcription");
 
@@ -96,6 +97,7 @@ beforeAll(() => {
 afterEach(() => {
   checkAuth.mockClear();
   getModelInfo.mockClear();
+  recordUsageEvent.mockClear();
   lastForm = null;
   nextResponse = null;
 });
@@ -180,6 +182,29 @@ describe("handleTranscription", () => {
     const text = await res.text();
     expect(text).toContain('"delta":"OK"');
     expect(text).toContain('"type":"transcript.text.done"');
+  });
+
+  test("records usage from a streamed transcription", async () => {
+    const res = await handleTranscription(makeReq({ model: "whisper", stream: "true" }));
+    await res.text(); // drain the stream so its usage callback fires
+    expect(recordUsageEvent).toHaveBeenCalledTimes(1);
+    const event = recordUsageEvent.mock.calls[0]![0];
+    expect(event.inputTokens).toBe(5);
+    expect(event.outputTokens).toBe(2);
+  });
+
+  test("records usage from a non-streamed transcription when the backend reports it", async () => {
+    nextResponse = Response.json({ text: "hi", usage: { prompt_tokens: 3, completion_tokens: 4, total_tokens: 7 } });
+    await handleTranscription(makeReq({ model: "whisper" }));
+    expect(recordUsageEvent).toHaveBeenCalledTimes(1);
+    const event = recordUsageEvent.mock.calls[0]![0];
+    expect(event.inputTokens).toBe(3);
+    expect(event.outputTokens).toBe(4);
+  });
+
+  test("records no usage event when the backend omits usage", async () => {
+    await handleTranscription(makeReq({ model: "whisper" }));
+    expect(recordUsageEvent).not.toHaveBeenCalled();
   });
 
   test("forwards non-model form fields (language) to the backend", async () => {

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-transcription.test.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-transcription.test.ts
@@ -31,6 +31,7 @@ mock.module("../auth", () => ({ checkAuth }));
 
 let mockPort = 0;
 const transcriptionModel = () => ({
+  nodeId: "node-1",
   host: `localhost:${mockPort}`,
   model: "whisper-backend",
   driver: "vllm",

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-transcription.test.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-transcription.test.ts
@@ -1,0 +1,218 @@
+import { describe, test, expect, mock, beforeAll, afterAll, jest, afterEach } from "bun:test";
+
+mock.module("../../env", () => ({
+  env: {
+    HOST: "localhost",
+    PORT: 4010,
+    DB_CONNECTION_URL: "postgresql://localhost/test",
+    REDIS_URL: "redis://localhost:6379",
+    WEB_SEARCH_ENGINE_URL: undefined,
+    RESPONSE_CACHE_TTL_SECONDS: 3600,
+    INFOSERVER_URL: "http://localhost:3000",
+    INFOSERVER_CACHE_TTL_MS: 30000,
+    LOAD_BALANCE_STRATEGY: "random",
+    BACKEND_TIMEOUT_MS: 300000,
+    LOG_LEVEL: "info",
+    LOG_DIR: undefined,
+    METRICS_AUTH: undefined,
+  },
+}));
+
+import type { checkAuth as checkAuthT } from "../auth";
+import type { getModelInfo as getModelInfoT } from "../model-data";
+
+const checkAuth = jest.fn<typeof checkAuthT>(async () => ({
+  orgId: "org-1",
+  keyId: "key-1",
+  applicationId: "app-1",
+  collectData: true,
+}));
+mock.module("../auth", () => ({ checkAuth }));
+
+let mockPort = 0;
+const transcriptionModel = () => ({
+  host: `localhost:${mockPort}`,
+  model: "whisper-backend",
+  driver: "vllm",
+  authToken: null,
+  tls: false,
+  type: "transcription",
+  tags: [],
+  requestParams: {},
+  release: () => {},
+});
+const getModelInfo = jest.fn<typeof getModelInfoT>(async () => transcriptionModel());
+mock.module("../model-data", () => ({ getModelInfo }));
+
+mock.module("../backend-fetch", () => ({
+  backendUrl: (host: string, _model: string, path: string) => `http://${host}${path}`,
+  backendFetch: (url: string | URL | Request, init?: RequestInit) => fetch(url, init),
+  backendPostForm: (target: { host: string }, path: string, form: FormData, signal: AbortSignal) =>
+    fetch(`http://${target.host}${path}`, { method: "POST", body: form, signal }),
+  hasCustomCa: false,
+}));
+
+mock.module("../../callLogger", () => ({
+  logChatStream: mock(() => Promise.resolve()),
+  logChatSync: mock(() => Promise.resolve()),
+}));
+mock.module("../../usageRecorder", () => ({ recordUsageEvent: mock(() => {}) }));
+
+const { handleTranscription } = await import("./handle-transcription");
+
+let server: any;
+let lastForm: { model: unknown; hasFile: boolean; stream: unknown; language: unknown } | null = null;
+let nextResponse: Response | null = null;
+
+beforeAll(() => {
+  server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname === "/v1/audio/transcriptions") {
+        if (nextResponse) {
+          const r = nextResponse;
+          nextResponse = null;
+          return r;
+        }
+        const form = await req.formData();
+        lastForm = { model: form.get("model"), hasFile: form.get("file") instanceof Blob, stream: form.get("stream"), language: form.get("language") };
+        if (form.get("stream") === "true") {
+          // vLLM streams chat-completion-style `transcription.chunk` SSE.
+          const sse = [
+            'data: {"id":"trsc-1","object":"transcription.chunk","created":1,"model":"whisper-backend","choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}\n\n',
+            'data: {"id":"trsc-1","object":"transcription.chunk","created":1,"model":"whisper-backend","choices":[{"delta":{"content":" world"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}}\n\n',
+            "data: [DONE]\n\n",
+          ].join("");
+          return new Response(sse, { headers: { "Content-Type": "text/event-stream" } });
+        }
+        return Response.json({ text: "hello world" });
+      }
+      return new Response("Not Found", { status: 404 });
+    },
+  });
+  mockPort = server.port;
+});
+afterEach(() => {
+  checkAuth.mockClear();
+  getModelInfo.mockClear();
+  lastForm = null;
+  nextResponse = null;
+});
+afterAll(() => server.stop());
+
+function makeReq(fields: Record<string, string>, withFile = true): Request {
+  const form = new FormData();
+  for (const [k, v] of Object.entries(fields)) form.append(k, v);
+  if (withFile) form.append("file", new Blob(["fake-audio"], { type: "audio/wav" }), "audio.wav");
+  return new Request("http://localhost:4000/v1/audio/transcriptions", {
+    method: "POST",
+    headers: { Authorization: "Bearer test" },
+    body: form,
+  });
+}
+
+describe("handleTranscription", () => {
+  test("forwards the multipart form and returns the transcription", async () => {
+    const res = await handleTranscription(makeReq({ model: "whisper" }));
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.text).toBe("hello world");
+    expect(lastForm?.model).toBe("whisper-backend");
+    expect(lastForm?.hasFile).toBe(true);
+  });
+
+  test("translates a vLLM transcription stream into OpenAI events", async () => {
+    const res = await handleTranscription(makeReq({ model: "whisper", stream: "true" }));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("text/event-stream");
+    expect(lastForm?.stream).toBe("true");
+
+    const text = await res.text();
+    expect(text).toContain('"type":"transcript.text.delta"');
+    expect(text).toContain('"delta":"Hello"');
+    expect(text).toContain('"type":"transcript.text.done"');
+    expect(text).toContain('"text":"Hello world"');
+    expect(text).toContain('"input_tokens":5');
+    expect(text).not.toContain("transcription.chunk");
+  });
+
+  test("emits transcript.text.done without usage when the backend sends none, and ends without a [DONE] sentinel", async () => {
+    nextResponse = new Response(
+      'data: {"id":"t","object":"transcription.chunk","created":1,"model":"m","choices":[{"delta":{"content":"Hi there"},"finish_reason":"stop"}]}\n\n',
+      { headers: { "Content-Type": "text/event-stream" } },
+    );
+    const res = await handleTranscription(makeReq({ model: "whisper", stream: "true" }));
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain('"type":"transcript.text.done"');
+    expect(text).toContain('"text":"Hi there"');
+    expect(text).not.toContain('"usage"');
+    expect(text).not.toContain('"input_tokens"');
+  });
+
+  test("skips empty/role-only chunks so no spurious delta event is emitted", async () => {
+    nextResponse = new Response(
+      [
+        'data: {"id":"t","object":"transcription.chunk","created":1,"model":"m","choices":[{"delta":{},"finish_reason":null}]}\n\n',
+        'data: {"id":"t","object":"transcription.chunk","created":1,"model":"m","choices":[{"delta":{"content":"Solo"},"finish_reason":"stop"}]}\n\n',
+        "data: [DONE]\n\n",
+      ].join(""),
+      { headers: { "Content-Type": "text/event-stream" } },
+    );
+    const res = await handleTranscription(makeReq({ model: "whisper", stream: "true" }));
+    const text = await res.text();
+    expect(text.split('"type":"transcript.text.delta"').length - 1).toBe(1);
+    expect(text).toContain('"text":"Solo"');
+  });
+
+  test("skips a malformed chunk and still completes the stream", async () => {
+    nextResponse = new Response(
+      [
+        "data: not-json\n\n",
+        'data: {"id":"t","object":"transcription.chunk","created":1,"model":"m","choices":[{"delta":{"content":"OK"},"finish_reason":"stop"}]}\n\n',
+        "data: [DONE]\n\n",
+      ].join(""),
+      { headers: { "Content-Type": "text/event-stream" } },
+    );
+    const res = await handleTranscription(makeReq({ model: "whisper", stream: "true" }));
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain('"delta":"OK"');
+    expect(text).toContain('"type":"transcript.text.done"');
+  });
+
+  test("forwards non-model form fields (language) to the backend", async () => {
+    const res = await handleTranscription(makeReq({ model: "whisper", language: "es" }));
+    expect(res.status).toBe(200);
+    expect(lastForm?.language).toBe("es");
+  });
+
+  test("rejects a non-transcription model type with 400", async () => {
+    getModelInfo.mockImplementationOnce(async () => ({ ...transcriptionModel(), type: "chat" }));
+    const res = await handleTranscription(makeReq({ model: "gpt" }));
+    expect(res.status).toBe(400);
+  });
+
+  test("returns 400 when the file is missing", async () => {
+    const res = await handleTranscription(makeReq({ model: "whisper" }, false));
+    expect(res.status).toBe(400);
+  });
+
+  test("returns 400 when the model is missing", async () => {
+    const res = await handleTranscription(makeReq({}, true));
+    expect(res.status).toBe(400);
+  });
+
+  test("returns 404 when the model is not found", async () => {
+    getModelInfo.mockImplementationOnce(async () => undefined);
+    const res = await handleTranscription(makeReq({ model: "nope" }));
+    expect(res.status).toBe(404);
+  });
+
+  test("maps a backend 5xx to 502", async () => {
+    nextResponse = new Response("boom", { status: 500 });
+    const res = await handleTranscription(makeReq({ model: "whisper" }));
+    expect(res.status).toBe(502);
+  });
+});

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-transcription.test.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-transcription.test.ts
@@ -256,6 +256,16 @@ describe("handleTranscription", () => {
     expect(failedRequests()).toHaveLength(1);
   });
 
+  test("records a failed request when the stream ends without a terminal chunk", async () => {
+    nextResponse = new Response(
+      'data: {"id":"t","object":"transcription.chunk","created":1,"model":"m","choices":[{"delta":{"content":"partial"},"finish_reason":null}]}\n\n',
+      { headers: { "Content-Type": "text/event-stream" } },
+    );
+    const res = await handleTranscription(makeReq({ model: "whisper", stream: "true" }));
+    await res.text();
+    expect(failedRequests()).toHaveLength(1);
+  });
+
   test("does not record a failed request before a node is leased", async () => {
     getModelInfo.mockImplementationOnce(async () => undefined);
     const res = await handleTranscription(makeReq({ model: "nope" }));

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-transcription.test.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-transcription.test.ts
@@ -57,8 +57,10 @@ mock.module("../../callLogger", () => ({
   logChatStream: mock(() => Promise.resolve()),
   logChatSync: mock(() => Promise.resolve()),
 }));
-const recordUsageEvent = mock((_event: { inputTokens: number; outputTokens: number }) => {});
+const recordUsageEvent = mock((_event: { inputTokens: number; outputTokens: number; success?: boolean }) => {});
 mock.module("../../usageRecorder", () => ({ recordUsageEvent }));
+
+const failedRequests = () => recordUsageEvent.mock.calls.filter(([e]) => e.success === false);
 
 const { handleTranscription } = await import("./handle-transcription");
 
@@ -240,5 +242,24 @@ describe("handleTranscription", () => {
     nextResponse = new Response("boom", { status: 500 });
     const res = await handleTranscription(makeReq({ model: "whisper" }));
     expect(res.status).toBe(502);
+  });
+
+  test("records a failed request when the backend returns 5xx", async () => {
+    nextResponse = new Response("boom", { status: 500 });
+    await handleTranscription(makeReq({ model: "whisper" }));
+    expect(failedRequests()).toHaveLength(1);
+  });
+
+  test("records a failed request for a non-transcription model type", async () => {
+    getModelInfo.mockImplementationOnce(async () => ({ ...transcriptionModel(), type: "chat" }));
+    await handleTranscription(makeReq({ model: "gpt" }));
+    expect(failedRequests()).toHaveLength(1);
+  });
+
+  test("does not record a failed request before a node is leased", async () => {
+    getModelInfo.mockImplementationOnce(async () => undefined);
+    const res = await handleTranscription(makeReq({ model: "nope" }));
+    expect(res.status).toBe(404);
+    expect(recordUsageEvent).not.toHaveBeenCalled();
   });
 });

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-transcription.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-transcription.ts
@@ -7,18 +7,22 @@ import {
   handleEndpointError,
   handleStreamError,
   readSSEStream,
+  recordUsage,
   SSE_RESPONSE_HEADERS,
   sseEncoder,
   validateModelType,
 } from "../util";
 import { backendPostForm } from "../backend-fetch";
-import { BackendTranscriptionChunkSchema } from "../backend-schemas";
+import { BackendTranscriptionChunkSchema, BackendUsageSchema } from "../backend-schemas";
 import { rootLogger } from "../../logger";
 
 const log = rootLogger.child({ name: "handle-transcription" });
 
 /** Translate vLLM's chat-completion-style transcription stream into OpenAI's `transcript.text.delta`/`transcript.text.done` events (no `[DONE]` sentinel). */
-function streamTranscriptionAsOpenAI(backendResponse: Response): Response {
+function streamTranscriptionAsOpenAI(
+  backendResponse: Response,
+  onUsage: (usage: { prompt_tokens: number; completion_tokens: number }) => void,
+): Response {
   const stream = new ReadableStream({
     async start(controller) {
       let fullText = "";
@@ -50,6 +54,7 @@ function streamTranscriptionAsOpenAI(backendResponse: Response): Response {
 
         const done: Record<string, unknown> = { type: "transcript.text.done", text: fullText };
         if (usage) {
+          onUsage({ prompt_tokens: usage.prompt_tokens, completion_tokens: usage.completion_tokens });
           done.usage = {
             type: "tokens",
             input_tokens: usage.prompt_tokens,
@@ -80,6 +85,7 @@ export async function handleTranscription(req: Request): Promise<Response> {
       return errorResponse("Method not allowed", 405);
     }
 
+    const callStartTime = Date.now();
     const auth = await resolveAuth(req);
     if (auth instanceof Response) {
       return auth;
@@ -124,14 +130,35 @@ export async function handleTranscription(req: Request): Promise<Response> {
     }
 
     if (wantsStream) {
-      return streamTranscriptionAsOpenAI(backendResponse);
+      return streamTranscriptionAsOpenAI(backendResponse, (usage) =>
+        recordUsage({ usage, auth, modelInfo, callStartTime, logCalls: false }),
+      );
     }
 
-    return new Response(backendResponse.body, {
+    const contentType = backendResponse.headers.get("content-type") ?? "application/json";
+    const body = await backendResponse.text();
+    if (contentType.includes("application/json")) {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(body);
+      } catch {
+        parsed = undefined;
+      }
+      const usage = BackendUsageSchema.safeParse((parsed as { usage?: unknown } | undefined)?.usage);
+      if (usage.success && usage.data) {
+        recordUsage({
+          usage: { prompt_tokens: usage.data.prompt_tokens, completion_tokens: usage.data.completion_tokens },
+          auth,
+          modelInfo,
+          callStartTime,
+          logCalls: false,
+        });
+      }
+    }
+
+    return new Response(body, {
       status: backendResponse.status,
-      headers: {
-        "Content-Type": backendResponse.headers.get("content-type") ?? "application/json",
-      },
+      headers: { "Content-Type": contentType },
     });
   } catch (error) {
     return handleEndpointError(error, log);

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-transcription.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-transcription.ts
@@ -1,0 +1,139 @@
+import { resolveAuth } from "../ai-sdk";
+import { getModelInfo } from "../model-data";
+import { releaseCallbacks } from "../release-registry";
+import {
+  errorResponse,
+  forwardBackendError,
+  handleEndpointError,
+  handleStreamError,
+  readSSEStream,
+  SSE_RESPONSE_HEADERS,
+  sseEncoder,
+  validateModelType,
+} from "../util";
+import { backendPostForm } from "../backend-fetch";
+import { BackendTranscriptionChunkSchema } from "../backend-schemas";
+import { rootLogger } from "../../logger";
+
+const log = rootLogger.child({ name: "handle-transcription" });
+
+/** Translate vLLM's chat-completion-style transcription stream into OpenAI's `transcript.text.delta`/`transcript.text.done` events (no `[DONE]` sentinel). */
+function streamTranscriptionAsOpenAI(backendResponse: Response): Response {
+  const stream = new ReadableStream({
+    async start(controller) {
+      let fullText = "";
+      let usage: { prompt_tokens: number; completion_tokens: number; total_tokens: number } | undefined;
+      try {
+        for await (const event of readSSEStream(backendResponse)) {
+          if (event.data === "[DONE]") break;
+          let json: unknown;
+          try {
+            json = JSON.parse(event.data);
+          } catch {
+            continue;
+          }
+          const parsed = BackendTranscriptionChunkSchema.safeParse(json);
+          if (!parsed.success) {
+            log.warn({ issues: parsed.error.issues }, "Malformed backend transcription chunk, skipping");
+            continue;
+          }
+          if (parsed.data.usage) {
+            usage = parsed.data.usage;
+          }
+          const content = parsed.data.choices[0]?.delta.content;
+          if (typeof content === "string" && content.length > 0) {
+            fullText += content;
+            const delta = { type: "transcript.text.delta", delta: content };
+            controller.enqueue(sseEncoder.encode(`data: ${JSON.stringify(delta)}\n\n`));
+          }
+        }
+
+        const done: Record<string, unknown> = { type: "transcript.text.done", text: fullText };
+        if (usage) {
+          done.usage = {
+            type: "tokens",
+            input_tokens: usage.prompt_tokens,
+            output_tokens: usage.completion_tokens,
+            total_tokens: usage.total_tokens,
+          };
+        }
+        controller.enqueue(sseEncoder.encode(`data: ${JSON.stringify(done)}\n\n`));
+        controller.close();
+      } catch (e) {
+        handleStreamError(e, controller, log);
+      }
+    },
+  });
+  return new Response(stream, { headers: SSE_RESPONSE_HEADERS });
+}
+
+/** Catalog model type for this STT endpoint (TTS would be a separate `speech` type). */
+export const TRANSCRIPTION_MODEL_TYPE = "transcription";
+
+/**
+ * OpenAI-compatible `/v1/audio/transcriptions`. Multipart (the audio file), so
+ * it resolves the model from the form rather than the JSON `resolveModel` path.
+ */
+export async function handleTranscription(req: Request): Promise<Response> {
+  try {
+    if (req.method !== "POST") {
+      return errorResponse("Method not allowed", 405);
+    }
+
+    const auth = await resolveAuth(req);
+    if (auth instanceof Response) {
+      return auth;
+    }
+
+    const form = await req.formData().catch(() => null);
+    if (!form) {
+      return errorResponse("Expected a multipart/form-data body", 400);
+    }
+
+    const originalModel = form.get("model");
+    if (typeof originalModel !== "string" || originalModel.length === 0) {
+      return errorResponse("Missing or invalid 'model' field", 400);
+    }
+    if (!(form.get("file") instanceof Blob)) {
+      return errorResponse("Missing 'file' field", 400);
+    }
+
+    const modelInfo = await getModelInfo(auth.orgId, originalModel, auth.keyId);
+    if (!modelInfo) {
+      return errorResponse("Model not found", 404);
+    }
+    releaseCallbacks.set(req, modelInfo.release);
+
+    const typeError = validateModelType(modelInfo, [TRANSCRIPTION_MODEL_TYPE]);
+    if (typeError) {
+      return typeError;
+    }
+
+    const wantsStream = form.get("stream") === "true" || form.get("stream") === "1";
+
+    form.set("model", modelInfo.model);
+    if (wantsStream) {
+      form.set("stream", "true");
+      form.set("stream_include_usage", "true");
+    }
+
+    // `as FormData` bridges the global vs undici FormData type mismatch.
+    const backendResponse = await backendPostForm(modelInfo, "/v1/audio/transcriptions", form as FormData, req.signal);
+    if (!backendResponse.ok) {
+      return forwardBackendError(backendResponse, log);
+    }
+
+    if (wantsStream) {
+      return streamTranscriptionAsOpenAI(backendResponse);
+    }
+
+    return new Response(backendResponse.body, {
+      status: backendResponse.status,
+      headers: {
+        "Content-Type": backendResponse.headers.get("content-type") ?? "application/json",
+      },
+    });
+  } catch (error) {
+    return handleEndpointError(error, log);
+  }
+}

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-transcription.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-transcription.ts
@@ -29,10 +29,11 @@ function streamTranscriptionAsOpenAI(
   const stream = new ReadableStream({
     async start(controller) {
       let fullText = "";
+      let completed = false;
       let usage: { prompt_tokens: number; completion_tokens: number; total_tokens: number } | undefined;
       try {
         for await (const event of readSSEStream(backendResponse)) {
-          if (event.data === "[DONE]") break;
+          if (event.data === "[DONE]") { completed = true; break; }
           let json: unknown;
           try {
             json = JSON.parse(event.data);
@@ -47,7 +48,11 @@ function streamTranscriptionAsOpenAI(
           if (parsed.data.usage) {
             usage = parsed.data.usage;
           }
-          const content = parsed.data.choices[0]?.delta.content;
+          const choice = parsed.data.choices[0];
+          if (choice?.finish_reason) {
+            completed = true;
+          }
+          const content = choice?.delta.content;
           if (typeof content === "string" && content.length > 0) {
             fullText += content;
             const delta = { type: "transcript.text.delta", delta: content };
@@ -57,11 +62,6 @@ function streamTranscriptionAsOpenAI(
 
         const done: Record<string, unknown> = { type: "transcript.text.done", text: fullText };
         if (usage) {
-          recordUsage({
-            ...logFields,
-            usage: { prompt_tokens: usage.prompt_tokens, completion_tokens: usage.completion_tokens },
-            logCalls: false,
-          });
           done.usage = {
             type: "tokens",
             input_tokens: usage.prompt_tokens,
@@ -71,6 +71,17 @@ function streamTranscriptionAsOpenAI(
         }
         controller.enqueue(sseEncoder.encode(`data: ${JSON.stringify(done)}\n\n`));
         controller.close();
+
+        // No finish_reason or [DONE] means the backend stream was truncated, matching the chat path.
+        if (!completed) {
+          recordFailedRequest(logFields);
+        } else if (usage) {
+          recordUsage({
+            ...logFields,
+            usage: { prompt_tokens: usage.prompt_tokens, completion_tokens: usage.completion_tokens },
+            logCalls: false,
+          });
+        }
       } catch (e) {
         if (!isAbortError(e)) recordFailedRequest(logFields);
         handleStreamError(e, controller, log);

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-transcription.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-transcription.ts
@@ -6,11 +6,14 @@ import {
   forwardBackendError,
   handleEndpointError,
   handleStreamError,
+  isAbortError,
   readSSEStream,
+  recordFailedRequest,
   recordUsage,
   SSE_RESPONSE_HEADERS,
   sseEncoder,
   validateModelType,
+  type FailedRequestContext,
 } from "../util";
 import { backendPostForm } from "../backend-fetch";
 import { BackendTranscriptionChunkSchema, BackendUsageSchema } from "../backend-schemas";
@@ -21,7 +24,7 @@ const log = rootLogger.child({ name: "handle-transcription" });
 /** Translate vLLM's chat-completion-style transcription stream into OpenAI's `transcript.text.delta`/`transcript.text.done` events (no `[DONE]` sentinel). */
 function streamTranscriptionAsOpenAI(
   backendResponse: Response,
-  onUsage: (usage: { prompt_tokens: number; completion_tokens: number }) => void,
+  logFields: FailedRequestContext,
 ): Response {
   const stream = new ReadableStream({
     async start(controller) {
@@ -54,7 +57,11 @@ function streamTranscriptionAsOpenAI(
 
         const done: Record<string, unknown> = { type: "transcript.text.done", text: fullText };
         if (usage) {
-          onUsage({ prompt_tokens: usage.prompt_tokens, completion_tokens: usage.completion_tokens });
+          recordUsage({
+            ...logFields,
+            usage: { prompt_tokens: usage.prompt_tokens, completion_tokens: usage.completion_tokens },
+            logCalls: false,
+          });
           done.usage = {
             type: "tokens",
             input_tokens: usage.prompt_tokens,
@@ -65,6 +72,7 @@ function streamTranscriptionAsOpenAI(
         controller.enqueue(sseEncoder.encode(`data: ${JSON.stringify(done)}\n\n`));
         controller.close();
       } catch (e) {
+        if (!isAbortError(e)) recordFailedRequest(logFields);
         handleStreamError(e, controller, log);
       }
     },
@@ -80,12 +88,22 @@ export const TRANSCRIPTION_MODEL_TYPE = "transcription";
  * it resolves the model from the form rather than the JSON `resolveModel` path.
  */
 export async function handleTranscription(req: Request): Promise<Response> {
+  const callStartTime = Date.now();
+  let leased: FailedRequestContext | undefined;
+
+  // Counts a failure against the leased node, except 499 (client disconnect).
+  const noteFailedRequest = (res: Response): Response => {
+    if (leased && res.status >= 400 && res.status !== 499) {
+      recordFailedRequest(leased);
+    }
+    return res;
+  };
+
   try {
     if (req.method !== "POST") {
       return errorResponse("Method not allowed", 405);
     }
 
-    const callStartTime = Date.now();
     const auth = await resolveAuth(req);
     if (auth instanceof Response) {
       return auth;
@@ -109,10 +127,11 @@ export async function handleTranscription(req: Request): Promise<Response> {
       return errorResponse("Model not found", 404);
     }
     releaseCallbacks.set(req, modelInfo.release);
+    leased = { auth, modelInfo, callStartTime };
 
     const typeError = validateModelType(modelInfo, [TRANSCRIPTION_MODEL_TYPE]);
     if (typeError) {
-      return typeError;
+      return noteFailedRequest(typeError);
     }
 
     const wantsStream = form.get("stream") === "true" || form.get("stream") === "1";
@@ -126,13 +145,11 @@ export async function handleTranscription(req: Request): Promise<Response> {
     // `as FormData` bridges the global vs undici FormData type mismatch.
     const backendResponse = await backendPostForm(modelInfo, "/v1/audio/transcriptions", form as FormData, req.signal);
     if (!backendResponse.ok) {
-      return forwardBackendError(backendResponse, log);
+      return noteFailedRequest(await forwardBackendError(backendResponse, log));
     }
 
     if (wantsStream) {
-      return streamTranscriptionAsOpenAI(backendResponse, (usage) =>
-        recordUsage({ usage, auth, modelInfo, callStartTime, logCalls: false }),
-      );
+      return streamTranscriptionAsOpenAI(backendResponse, { auth, modelInfo, callStartTime });
     }
 
     const contentType = backendResponse.headers.get("content-type") ?? "application/json";
@@ -161,6 +178,6 @@ export async function handleTranscription(req: Request): Promise<Response> {
       headers: { "Content-Type": contentType },
     });
   } catch (error) {
-    return handleEndpointError(error, log);
+    return noteFailedRequest(handleEndpointError(error, log));
   }
 }

--- a/packages/xinity-ai-gateway/src/llm-forward/model-data.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/model-data.ts
@@ -3,11 +3,16 @@ import { getDB } from "../db";
 import { env } from "../env";
 import { createInfoserverClient, deploymentLookup, deploymentEarlyLookup, lookupKey, resolveTagsForDriver, resolveRequestParamsForDriver, type ModelLookup } from "xinity-infoserver";
 import { selectHost as _selectHost, type LoadBalanceStrategy } from "./load-balancer";
+import { rootLogger } from "../logger";
 
 /** Indirection for testability. tests can swap this without mock.module. */
 export const _deps = { selectHost: _selectHost };
 
-const infoClient = createInfoserverClient({ baseUrl: env.INFOSERVER_URL, cacheTtlMs: env.INFOSERVER_CACHE_TTL_MS });
+const infoClient = createInfoserverClient({
+  baseUrl: env.INFOSERVER_URL,
+  cacheTtlMs: env.INFOSERVER_CACHE_TTL_MS,
+  logger: rootLogger.child({ name: "infoserver-client" }),
+});
 
 async function publicModelSpecifierToModelSource(orgId: string, specifier: string) {
 

--- a/packages/xinity-ai-gateway/src/llm-forward/model-data.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/model-data.ts
@@ -81,7 +81,7 @@ type ModelInfo = {
   /** Per-node auth token for authenticating requests to the daemon. */
   authToken: string | null;
   tls: boolean;
-  /** Model type from the catalog (chat, embedding, rerank). Undefined if catalog entry is unavailable. */
+  /** Model type from the catalog (chat, embedding, rerank, transcription). Undefined if catalog entry is unavailable. */
   type?: string;
   /** Model tags from the catalog (e.g. "tools", "custom_code", "vision"). Undefined if catalog entry is unavailable. */
   tags?: string[];

--- a/packages/xinity-ai-gateway/src/llm-forward/responses/schemas.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/responses/schemas.ts
@@ -161,7 +161,7 @@ const UsageSchema = z.object({
 
 export type Usage = z.infer<typeof UsageSchema>;
 
-const ResponseObjectSchema = z.object({
+export const ResponseObjectSchema = z.object({
   id: z.string(),
   object: z.literal("response"),
   created_at: z.number(),

--- a/packages/xinity-ai-gateway/src/openai-compat-openapi.ts
+++ b/packages/xinity-ai-gateway/src/openai-compat-openapi.ts
@@ -1,10 +1,10 @@
 import { z } from "zod";
 import type { OpenAPI } from "@orpc/openapi";
-import { ChatCompletionBodySchema } from "./llm-forward/endpoints/handle-chatCompletion";
-import { CompletionBodySchema } from "./llm-forward/endpoints/handle-completions";
+import { ChatCompletionBodySchema, ChatSyncChoiceSchema } from "./llm-forward/endpoints/handle-chatCompletion";
+import { CompletionBodySchema, CompletionSyncChoiceSchema } from "./llm-forward/endpoints/handle-completions";
 import { EmbeddingBodySchema } from "./llm-forward/endpoints/handle-embeddings";
 import { RerankBodySchema } from "./llm-forward/endpoints/handle-rerank";
-import { CreateResponseBodySchema } from "./llm-forward/responses/schemas";
+import { CreateResponseBodySchema, ResponseObjectSchema } from "./llm-forward/responses/schemas";
 
 const TAG = "OpenAI Compatible";
 const SECURITY = [{ bearerAuth: [] }];
@@ -38,16 +38,6 @@ const errorResponseSchema = {
   },
 };
 
-const usageSchema = {
-  type: "object",
-  additionalProperties: true,
-  properties: {
-    prompt_tokens: { type: "integer" },
-    completion_tokens: { type: "integer" },
-    total_tokens: { type: "integer" },
-  },
-};
-
 const modelObjectSchema = {
   type: "object",
   additionalProperties: true,
@@ -78,7 +68,76 @@ const modelsListResponseSchema = {
   },
 };
 
-const passthroughObject = { type: "object", additionalProperties: true };
+// Response shapes for the spec: authored in Zod, converted via `toSchema` like
+// the requests. `looseObject` keeps them open (documentation, not validation).
+const ChatTokenLogprobSchema = z.looseObject({
+  token: z.string(),
+  logprob: z.number(),
+  bytes: z.array(z.number().int()).nullable(),
+  top_logprobs: z.array(z.looseObject({
+    token: z.string(),
+    logprob: z.number(),
+    bytes: z.array(z.number().int()).nullable(),
+  })),
+});
+const ChatLogprobsSchema = z.looseObject({
+  content: z.array(ChatTokenLogprobSchema).nullable(),
+  refusal: z.array(ChatTokenLogprobSchema).nullable(),
+});
+
+// Legacy completions logprobs: parallel arrays, not chat's per-token objects.
+const CompletionLogprobsSchema = z.looseObject({
+  tokens: z.array(z.string()),
+  token_logprobs: z.array(z.number()),
+  top_logprobs: z.array(z.record(z.string(), z.number())).nullable(),
+  text_offset: z.array(z.number().int()),
+});
+
+const ChatUsageSchema = z.looseObject({
+  prompt_tokens: z.number().int(),
+  completion_tokens: z.number().int(),
+  total_tokens: z.number().int(),
+});
+
+const ChatCompletionResponseSchema = z.looseObject({
+  id: z.string(),
+  object: z.literal("chat.completion"),
+  created: z.number().int(),
+  model: z.string(),
+  choices: z.array(z.looseObject({ ...ChatSyncChoiceSchema.shape, logprobs: ChatLogprobsSchema.nullable().optional() })),
+  usage: ChatUsageSchema.optional(),
+});
+
+const CompletionResponseSchema = z.looseObject({
+  id: z.string(),
+  object: z.literal("text_completion"),
+  created: z.number().int(),
+  model: z.string(),
+  choices: z.array(z.looseObject({ ...CompletionSyncChoiceSchema.shape, logprobs: CompletionLogprobsSchema.nullable().optional() })),
+  usage: ChatUsageSchema.optional(),
+});
+
+const EmbeddingResponseSchema = z.looseObject({
+  object: z.literal("list"),
+  data: z.array(z.looseObject({
+    object: z.literal("embedding"),
+    index: z.number().int(),
+    embedding: z.array(z.number()),
+  })),
+  model: z.string(),
+  usage: ChatUsageSchema.optional(),
+});
+
+const RerankResponseSchema = z.looseObject({
+  id: z.string().optional(),
+  model: z.string().optional(),
+  results: z.array(z.looseObject({
+    index: z.number().int(),
+    relevance_score: z.number(),
+    document: z.looseObject({ text: z.string() }).optional(),
+  })),
+  usage: ChatUsageSchema.optional(),
+});
 
 function jsonContent(schemaRef: string) {
   return { "application/json": { schema: { $ref: schemaRef } } };
@@ -121,19 +180,18 @@ function streamableJsonResponse(description: string, schemaRef: string) {
 
 export const openaiCompatSchemas = {
   Error: errorResponseSchema,
-  Usage: usageSchema,
   ModelObject: modelObjectSchema,
   ModelsListResponse: modelsListResponseSchema,
   ChatCompletionRequest: toSchema(ChatCompletionBodySchema),
-  ChatCompletionResponse: passthroughObject,
+  ChatCompletionResponse: toSchema(ChatCompletionResponseSchema),
   CompletionRequest: toSchema(CompletionBodySchema),
-  CompletionResponse: passthroughObject,
+  CompletionResponse: toSchema(CompletionResponseSchema),
   EmbeddingRequest: toSchema(EmbeddingBodySchema),
-  EmbeddingResponse: passthroughObject,
+  EmbeddingResponse: toSchema(EmbeddingResponseSchema),
   RerankRequest: toSchema(RerankBodySchema),
-  RerankResponse: passthroughObject,
+  RerankResponse: toSchema(RerankResponseSchema),
   CreateResponseRequest: toSchema(CreateResponseBodySchema),
-  ResponseObject: passthroughObject,
+  ResponseObject: toSchema(ResponseObjectSchema),
 } as Record<string, OpenAPI.SchemaObject>;
 
 export const openaiCompatPaths = {

--- a/packages/xinity-ai-gateway/src/openai-compat-openapi.ts
+++ b/packages/xinity-ai-gateway/src/openai-compat-openapi.ts
@@ -139,6 +139,39 @@ const RerankResponseSchema = z.looseObject({
   usage: ChatUsageSchema.optional(),
 });
 
+const TranscriptionResponseSchema = z.looseObject({
+  text: z.string(),
+  language: z.string().optional(),
+  duration: z.number().optional(),
+  segments: z.array(z.looseObject({
+    id: z.number().int(),
+    start: z.number(),
+    end: z.number(),
+    text: z.string(),
+  })).optional(),
+  words: z.array(z.looseObject({
+    word: z.string(),
+    start: z.number(),
+    end: z.number(),
+  })).optional(),
+});
+
+// SSE events emitted when `stream: true`.
+const TranscriptTextDeltaEventSchema = z.looseObject({
+  type: z.literal("transcript.text.delta"),
+  delta: z.string(),
+});
+const TranscriptTextDoneEventSchema = z.looseObject({
+  type: z.literal("transcript.text.done"),
+  text: z.string(),
+  usage: z.looseObject({
+    type: z.literal("tokens"),
+    input_tokens: z.number().int(),
+    output_tokens: z.number().int(),
+    total_tokens: z.number().int(),
+  }).optional(),
+});
+
 function jsonContent(schemaRef: string) {
   return { "application/json": { schema: { $ref: schemaRef } } };
 }
@@ -190,6 +223,9 @@ export const openaiCompatSchemas = {
   EmbeddingResponse: toSchema(EmbeddingResponseSchema),
   RerankRequest: toSchema(RerankBodySchema),
   RerankResponse: toSchema(RerankResponseSchema),
+  TranscriptionResponse: toSchema(TranscriptionResponseSchema),
+  TranscriptTextDeltaEvent: toSchema(TranscriptTextDeltaEventSchema),
+  TranscriptTextDoneEvent: toSchema(TranscriptTextDoneEventSchema),
   CreateResponseRequest: toSchema(CreateResponseBodySchema),
   ResponseObject: toSchema(ResponseObjectSchema),
 } as Record<string, OpenAPI.SchemaObject>;
@@ -303,6 +339,60 @@ export const openaiCompatPaths = {
       requestBody: jsonRequest("#/components/schemas/RerankRequest"),
       responses: {
         "200": jsonResponse("Reranked documents", "#/components/schemas/RerankResponse"),
+        ...errorResponses,
+      },
+    },
+  },
+  "/v1/audio/transcriptions": {
+    post: {
+      tags: [TAG],
+      summary: "Transcribe audio to text",
+      description: [
+        "OpenAI: https://platform.openai.com/docs/api-reference/audio/createTranscription",
+        "",
+        "Xinity notes:",
+        "- Only available for deployments whose model type is `transcription` (e.g. Whisper).",
+        `- ${APP_HEADER_NOTE}`,
+        "- `response_format` `json` (default) and `verbose_json` return JSON; `text`/`srt`/`vtt` return the raw text body.",
+      ].join("\n"),
+      security: SECURITY,
+      // Hand-written: a multipart binary upload can't be derived from a Zod schema.
+      requestBody: {
+        required: true,
+        content: {
+          "multipart/form-data": {
+            schema: {
+              type: "object",
+              required: ["file", "model"],
+              properties: {
+                file: { type: "string", format: "binary", description: "The audio file to transcribe." },
+                model: { type: "string" },
+                language: { type: "string", description: "Input language as an ISO-639-1 code (optional; improves accuracy)." },
+                prompt: { type: "string", description: "Optional text to guide the model's style or continue a prior segment." },
+                response_format: { type: "string", enum: ["json", "text", "srt", "verbose_json", "vtt"], default: "json" },
+                temperature: { type: "number" },
+                stream: { type: "boolean", default: false, description: "Stream the transcription as SSE `transcript.text.delta` then `transcript.text.done` events." },
+              },
+            },
+          },
+        },
+      },
+      responses: {
+        "200": {
+          description: "Transcription. JSON for `json`/`verbose_json`; the raw `text`/`srt`/`vtt` body; or, when `stream: true`, an SSE stream of `transcript.text.delta` events ending with `transcript.text.done`.",
+          content: {
+            "application/json": { schema: { $ref: "#/components/schemas/TranscriptionResponse" } },
+            "text/plain": { schema: { type: "string" } },
+            "text/event-stream": {
+              schema: {
+                oneOf: [
+                  { $ref: "#/components/schemas/TranscriptTextDeltaEvent" },
+                  { $ref: "#/components/schemas/TranscriptTextDoneEvent" },
+                ],
+              },
+            },
+          },
+        },
         ...errorResponses,
       },
     },

--- a/packages/xinity-infoserver/api-schemas.ts
+++ b/packages/xinity-infoserver/api-schemas.ts
@@ -6,7 +6,7 @@ export const PaginationSchema = z.object({
 });
 
 export const ModelListQuerySchema = PaginationSchema.extend({
-  type: z.enum(["embedding", "chat", "rerank"]).optional(),
+  type: z.enum(["embedding", "chat", "rerank", "transcription"]).optional(),
   family: z.string().optional(),
   tag: z
     .union([z.string(), z.array(z.string())])

--- a/packages/xinity-infoserver/client.test.ts
+++ b/packages/xinity-infoserver/client.test.ts
@@ -33,6 +33,36 @@ const embedModel: ModelWithSpecifier = {
   providers: { ollama: "nomic-embed-text" },
 };
 
+// Declares an entryVersion far beyond any real release, so every running
+// instance is too old to use it and must filter it out.
+const futureModel: ModelWithSpecifier = {
+  publicSpecifier: "future-model",
+  _source: "test",
+  name: "Future Model",
+  description: "Requires a newer xinity than we run",
+  weight: 10,
+  minKvCache: 2,
+  url: "https://example.com",
+  entryVersion: "999.0.0",
+  type: "chat",
+  family: "llama",
+  providers: { vllm: "org/future" },
+};
+
+// Version-compatible but structurally invalid (`weight` is not a number), so it
+// must fail content validation and be dropped without poisoning the listing.
+const malformedModel = {
+  publicSpecifier: "malformed-model",
+  _source: "test",
+  name: "Malformed Model",
+  description: "Invalid content",
+  weight: "heavy",
+  minKvCache: 1,
+  url: "https://example.com",
+  entryVersion: "0.1.0",
+  providers: {},
+} as unknown as ModelWithSpecifier;
+
 describe("createInfoserverClient", () => {
   let server: ReturnType<typeof Bun.serve>;
   let requestLog: { method: string; url: string; body?: string }[];
@@ -59,6 +89,12 @@ describe("createInfoserverClient", () => {
         if (url.pathname === "/api/v1/models/nomic-embed") {
           return Response.json(embedModel);
         }
+        if (url.pathname === "/api/v1/models/future-model") {
+          return Response.json(futureModel);
+        }
+        if (url.pathname === "/api/v1/models/malformed-model") {
+          return Response.json(malformedModel);
+        }
         if (url.pathname === "/api/v1/models/not-found") {
           return new Response("Not Found", { status: 404 });
         }
@@ -73,12 +109,12 @@ describe("createInfoserverClient", () => {
 
         // GET /api/v1/models
         if (url.pathname === "/api/v1/models") {
-          return Response.json({
-            models: [testModel, embedModel],
-            total: 2,
-            page: 1,
-            pageSize: 20,
-          });
+          // `family=mixed` returns a list also containing an incompatible and a
+          // malformed model, so consumers can assert both get filtered out.
+          const models = url.searchParams.get("family") === "mixed"
+            ? [testModel, futureModel, malformedModel, embedModel]
+            : [testModel, embedModel];
+          return Response.json({ models, total: models.length, page: 1, pageSize: 20 });
         }
 
         // POST /api/v1/models/resolve
@@ -88,6 +124,8 @@ describe("createInfoserverClient", () => {
           for (const s of specifiers) {
             if (s === "llama-3.3-70b") result[s] = testModel;
             else if (s === "nomic-embed") result[s] = embedModel;
+            else if (s === "future-model") result[s] = futureModel;
+            else if (s === "malformed-model") result[s] = malformedModel;
             else result[s] = null;
           }
           return Response.json(result);
@@ -207,6 +245,45 @@ describe("createInfoserverClient", () => {
       expect(requestLog[0]!.url).toContain("pageSize=10");
       expect(requestLog[0]!.url).toContain("type=chat");
       expect(requestLog[0]!.url).toContain("family=llama");
+    });
+  });
+
+  describe("entryVersion gating and content validation", () => {
+    it("treats a model requiring a newer xinity as not found", async () => {
+      const client = makeClient();
+      const model = await client.fetchModel({ kind: "canonical", specifier: "future-model" });
+      expect(model).toBeUndefined();
+    });
+
+    it("does not cache a gated model, so it reappears once supported", async () => {
+      const client = makeClient();
+      await client.fetchModel({ kind: "canonical", specifier: "future-model" });
+      await client.fetchModel({ kind: "canonical", specifier: "future-model" });
+      // Both calls hit the server: a not_found result is never cached.
+      expect(requestLog).toHaveLength(2);
+    });
+
+    it("treats a model with invalid content as not found", async () => {
+      const client = makeClient();
+      const model = await client.fetchModel({ kind: "canonical", specifier: "malformed-model" });
+      expect(model).toBeUndefined();
+    });
+
+    it("drops incompatible and malformed models from a listing, keeping the rest", async () => {
+      const client = makeClient();
+      const result = await client.fetchModels({ family: "mixed" });
+      const specifiers = result.models.map((m) => m.publicSpecifier);
+      expect(specifiers).toEqual(["llama-3.3-70b", "nomic-embed"]);
+      expect(specifiers).not.toContain("future-model");
+      expect(specifiers).not.toContain("malformed-model");
+    });
+
+    it("maps gated and malformed batch entries to null", async () => {
+      const client = makeClient();
+      const result = await client.fetchModelsBatch(["llama-3.3-70b", "future-model", "malformed-model"]);
+      expect(result["llama-3.3-70b"]).toBeDefined();
+      expect(result["future-model"]).toBeNull();
+      expect(result["malformed-model"]).toBeNull();
     });
   });
 

--- a/packages/xinity-infoserver/client.ts
+++ b/packages/xinity-infoserver/client.ts
@@ -2,15 +2,19 @@
  * Lightweight infoserver client that fetches from the API endpoints
  * with time-limited in-memory caching. Replaces the old ModelCatalog class.
  */
-import type { ModelWithSpecifier } from "./definitions/model-definition";
+import { ModelSchema, type ModelWithSpecifier } from "./definitions/model-definition";
 import { resolveDriverForProviderModel, resolveTagsForDriver, resolveAllTags, resolveArgsForDriver, resolveRequestParamsForDriver, type RequestParamMap } from "./model-tags";
 import { lookupKey, type ModelLookup } from "./lookup-helpers";
+import { satisfiesMinVersion } from "./semver";
+import { version } from "../../package.json";
 
 export interface InfoserverClientConfig {
   /** Base URL of the infoserver (e.g. "http://localhost:8090"). */
   baseUrl: string;
   /** How long cached responses remain valid before re-fetching (ms). */
   cacheTtlMs: number;
+  /** Optional logger; reports models dropped for failing content validation. */
+  logger?: import("common-log").Logger;
 }
 
 function lookupCacheKey(lookup: ModelLookup): string {
@@ -19,10 +23,11 @@ function lookupCacheKey(lookup: ModelLookup): string {
 
 /**
  * Typed result from a single-model lookup.
- * Distinguishes between a found model, a model that genuinely does not exist in
- * the catalog (404), and an unreachable info server (network error / 5xx).
- * Only `found` results are cached. `not_found` is intentionally never cached
- * so a re-added model is picked up within the next TTL window.
+ * Distinguishes between a found model, a model not available to this instance
+ * (absent from the catalog, unsupported by this version, or invalid), and an
+ * unreachable info server (network error / 5xx).
+ * Only `found` results are cached. `not_found` is intentionally never cached so a
+ * re-added or newly-supported model is picked up within the next TTL window.
  */
 export type FetchModelStatus =
   | { status: "found"; model: ModelWithSpecifier }
@@ -52,6 +57,27 @@ interface CacheEntry<T> {
 export function createInfoserverClient(config: InfoserverClientConfig) {
   const cache = new Map<string, CacheEntry<any>>();
   const baseUrl = config.baseUrl.replace(/\/$/, "");
+
+  /**
+   * Filters models this instance cannot use. Version-gates first, so a model built
+   * for a newer xinity is dropped before validation rather than rejected for shapes
+   * we don't yet understand; the rest are content-validated. Failures are dropped,
+   * not thrown, so one bad entry can't sink a whole listing. Fail-open: a model
+   * without `entryVersion` is kept.
+   */
+  function gateAndValidate(raw: unknown): ModelWithSpecifier | null {
+    if (raw === null || typeof raw !== "object") return null;
+    const { entryVersion } = raw as { entryVersion?: unknown };
+    if (typeof entryVersion === "string" && !satisfiesMinVersion(version, entryVersion)) {
+      return null;
+    }
+    const parsed = ModelSchema.safeParse(raw);
+    if (!parsed.success) {
+      config.logger?.warn({ issues: parsed.error.issues }, "Dropping model that failed content validation");
+      return null;
+    }
+    return parsed.data as ModelWithSpecifier;
+  }
 
   function isFresh(entry: CacheEntry<any> | undefined): entry is CacheEntry<any> {
     return entry !== undefined && Date.now() - entry.fetchedAt < config.cacheTtlMs;
@@ -91,7 +117,8 @@ export function createInfoserverClient(config: InfoserverClientConfig) {
       const res = await fetch(url);
       if (res.status === 404) return { status: "not_found" };
       if (!res.ok) return { status: "unavailable", error: `HTTP ${res.status}` };
-      const model = await res.json() as ModelWithSpecifier;
+      const model = gateAndValidate(await res.json());
+      if (!model) return { status: "not_found" };
       cache.set(key, { data: model, fetchedAt: Date.now() });
       return { status: "found", model };
     } catch (err) {
@@ -108,9 +135,10 @@ export function createInfoserverClient(config: InfoserverClientConfig) {
 
   async function fetchModelsByFamily(family: string): Promise<ModelWithSpecifier[]> {
     const key = `family:${family}`;
-    return cachedFetch(key, () =>
-      fetchJsonOrThrow<ModelWithSpecifier[]>(`/api/v1/models/family/${encodeURIComponent(family)}`),
-    );
+    return cachedFetch(key, async () => {
+      const models = await fetchJsonOrThrow<unknown[]>(`/api/v1/models/family/${encodeURIComponent(family)}`);
+      return models.map(gateAndValidate).filter((m): m is ModelWithSpecifier => m !== null);
+    });
   }
 
   async function fetchModels(params?: FetchModelsParams): Promise<PaginatedModels> {
@@ -124,20 +152,27 @@ export function createInfoserverClient(config: InfoserverClientConfig) {
     }
 
     const key = `list:${qs.toString()}`;
-    return cachedFetch(key, () =>
-      fetchJsonOrThrow<PaginatedModels>(`/api/v1/models?${qs}`),
-    );
+    return cachedFetch(key, async () => {
+      const res = await fetchJsonOrThrow<PaginatedModels>(`/api/v1/models?${qs}`);
+      const models = res.models.map(gateAndValidate).filter((m): m is ModelWithSpecifier => m !== null);
+      return { ...res, models };
+    });
   }
 
   async function fetchModelsBatch(specifiers: string[]): Promise<Record<string, ModelWithSpecifier | null>> {
     const key = `batch:${specifiers.slice().sort().join(",")}`;
-    return cachedFetch(key, () =>
-      fetchJsonOrThrow<Record<string, ModelWithSpecifier | null>>(`/api/v1/models/resolve`, {
+    return cachedFetch(key, async () => {
+      const raw = await fetchJsonOrThrow<Record<string, unknown>>(`/api/v1/models/resolve`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ specifiers }),
-      }),
-    );
+      });
+      const resolved: Record<string, ModelWithSpecifier | null> = {};
+      for (const [specifier, model] of Object.entries(raw)) {
+        resolved[specifier] = gateAndValidate(model);
+      }
+      return resolved;
+    });
   }
 
   // Convenience methods that combine a fetch with pure tag helpers.

--- a/packages/xinity-infoserver/client.ts
+++ b/packages/xinity-infoserver/client.ts
@@ -39,7 +39,7 @@ export interface PaginatedModels {
 export interface FetchModelsParams {
   page?: number;
   pageSize?: number;
-  type?: "chat" | "embedding" | "rerank";
+  type?: "chat" | "embedding" | "rerank" | "transcription";
   family?: string;
   tags?: string[];
 }

--- a/packages/xinity-infoserver/definitions/model-definition.ts
+++ b/packages/xinity-infoserver/definitions/model-definition.ts
@@ -79,7 +79,7 @@ export const ModelSchema = z.looseObject({
     "where total_tokens is chosen based on desired concurrent capacity."
   ),
   url: z.url().describe("External documentation url, for curious users that want to know more"),
-  type: z.enum(["embedding", "chat", "rerank"]).default("chat").optional().describe("Usage type of the model in question"),
+  type: z.enum(["embedding", "chat", "rerank", "transcription"]).default("chat").optional().describe("Usage type of the model in question"),
   family: z.string().default("unknown").optional().describe("Family of the model. May be unknown"),
   tags: z.array(TagEnum).default([]).optional().describe("Default tags, used when providerTags is absent for a given driver. Also the searchable superset"),
   isCustom: z.boolean().default(false).optional(),


### PR DESCRIPTION
## Description

Brings the gateway's OpenAI-compatible surface closer to spec and hardens the infoserver catalog client.

- **OpenAPI response docs + logprobs**: documents the real response schemas for chat, completions, embeddings, rerank, and responses (previously bare `additionalProperties`), and forwards `logprobs`/`top_logprobs` to the backend for chat and legacy completions.
- **Audio transcription endpoint**: adds `/v1/audio/transcriptions` (multipart), translating vLLM's chat-completion-style transcription stream into OpenAI's `transcript.text.delta`/`transcript.text.done` events. Token usage is recorded for both the streamed and non-streamed paths, the same way as every other endpoint. Reuses the existing auth and model-type validation path.
- **Catalog version gating + validation**: the infoserver client now respects a model's `entryVersion`, dropping models that require a newer xinity than the running instance, then content-validates the rest. Invalid models are dropped (logged), not thrown, so one bad entry can't sink a whole listing. Net effect: models an instance can't support are never offered in the UI.
- **Logger injection**: the shared client takes an optional `common-log` logger instead of importing the infoserver's env-coupled logger, keeping its import chain env-free for the gateway and dashboard.

No breaking changes: catalogs without `entryVersion` are unaffected (version check is fail-open), and no new dependencies are added.

## Type of change

Bug fix | New feature

## Testing

New coverage added: transcription endpoint (non-stream, vLLM to OpenAI stream translation, usage recording on both paths, type/file/validation guards), logprobs forwarding (chat + completions), and infoserver client version-gating + content validation (single lookup, list, batch).

## Checklist

- [x] Tests pass locally (`bun test`), or no testable code was changed
- [x] New or changed behavior is covered by tests, or this change does not require tests
- [x] Documentation is updated, or no user-facing behavior or configuration was changed
- [x] There are no breaking changes, or they are marked with `!` in the commit type and described above
- [x] No security-sensitive changes (authentication, credentials, input handling), or they have been reviewed
- [x] No new dependencies were added, or they have been reviewed for license and maintenance status