### PR TITLE
fix/dashboard-ux-fixes

### DIFF
--- a/packages/xinity-ai-dashboard/src/lib/server/auth-server.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/auth-server.ts
@@ -269,7 +269,7 @@ export const auth = betterAuth({
       ac,
       roles,
       cancelPendingInvitationsOnReInvite: true,
-      requireEmailVerificationOnInvitation: true,
+      requireEmailVerificationOnInvitation: !!serverEnv.MAIL_URL,
       // disableOrganizationDeletion: true,
       async sendInvitationEmail(data, request) {
         const encodedEmail = encodeURIComponent(data.email);

--- a/packages/xinity-ai-dashboard/src/lib/server/gateway-proxy.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/gateway-proxy.ts
@@ -1,0 +1,31 @@
+import { error } from "@sveltejs/kit";
+import { serverEnv } from "$lib/server/serverenv";
+import { rootLogger } from "$lib/server/logging";
+
+const log = rootLogger.child({ name: "gateway-proxy" });
+
+/**
+ * Fetches `${GATEWAY_URL}${path}`, returning the upstream Response unchanged
+ * (non-2xx included, so the gateway's own error body passes through). A failed
+ * connection becomes a 502/504 instead of an opaque 500; a client abort is
+ * re-thrown so it stays a cancellation.
+ */
+export async function fetchGateway(
+  path: string,
+  init: RequestInit,
+  traceId?: string,
+): Promise<Response> {
+  try {
+    return await fetch(`${serverEnv.GATEWAY_URL}${path}`, init);
+  } catch (err) {
+    if (init.signal?.aborted || (err instanceof Error && err.name === "AbortError")) {
+      throw err;
+    }
+    const code = (err as { cause?: { code?: string } })?.cause?.code;
+    log.error({ err, path, code, traceId }, "Gateway request failed");
+    if (code === "ETIMEDOUT" || code === "UND_ERR_CONNECT_TIMEOUT") {
+      error(504, "The inference gateway did not respond in time. Please try again.");
+    }
+    error(502, "Could not reach the inference gateway. It may be offline or restarting.");
+  }
+}

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/ai-api-keys/ApiKeyListing.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/ai-api-keys/ApiKeyListing.svelte
@@ -82,12 +82,19 @@
     }
   }
 
+  // Reassign apiKeys (rather than mutating a key in place) so the derived list
+  // recomputes and the UI repaints; an in-place property write on the load data
+  // is not reactive.
+  function patchKey(id: string, patch: Partial<ApiKeyDto>) {
+    apiKeys = apiKeys.map((k) => (k.id === id ? { ...k, ...patch } : k));
+  }
+
   function toggleEnabled(key: ApiKeyDto) {
     const newState = !key.enabled;
     updateOptimistically({
       apiPromise: () => orpc.apiKey.toggleEnabled({ id: key.id, enabled: newState }),
-      update: () => (key.enabled = newState),
-      undo: () => (key.enabled = !newState),
+      update: () => patchKey(key.id, { enabled: newState }),
+      undo: () => patchKey(key.id, { enabled: !newState }),
     });
   }
 
@@ -95,8 +102,8 @@
     const newState = !key.collectData;
     updateOptimistically({
       apiPromise: () => orpc.apiKey.toggleCollectData({ id: key.id, collectData: newState }),
-      update: () => (key.collectData = newState),
-      undo: () => (key.collectData = !newState),
+      update: () => patchKey(key.id, { collectData: newState }),
+      undo: () => patchKey(key.id, { collectData: !newState }),
     });
   }
 </script>

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/+page.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/+page.svelte
@@ -378,7 +378,19 @@
                   {/if}
                   {#if deployment.status.phase === 'failed' && deployment.status.failureLogs}
                     <Collapsible.Root class="mt-2">
-                      <Collapsible.Trigger class="text-xs text-muted-foreground hover:underline cursor-pointer">View logs</Collapsible.Trigger>
+                      <div class="flex items-center gap-2">
+                        <Collapsible.Trigger class="text-xs text-muted-foreground hover:underline cursor-pointer">View logs</Collapsible.Trigger>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          class="h-6 px-2 text-xs text-muted-foreground"
+                          onclick={() => copyToClipboard(deployment.status.failureLogs ?? '')}
+                          title="Copy all logs"
+                        >
+                          <Copy class="w-3.5 h-3.5" />
+                          Copy logs
+                        </Button>
+                      </div>
                       <Collapsible.Content>
                         <pre class="mt-2 p-3 bg-muted rounded text-xs font-mono overflow-x-auto max-h-64 overflow-y-auto whitespace-pre-wrap wrap-break-word">{deployment.status.failureLogs}</pre>
                       </Collapsible.Content>

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/ModelSelectorModal.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/ModelSelectorModal.svelte
@@ -11,10 +11,23 @@
   import { Badge } from "$lib/components/ui/badge";
 
   // Icons
-  import { X, Search, ExternalLink, Info, ShieldAlert, HardDrive, Loader2, AlertCircle } from "@lucide/svelte";
+  import { X, Search, ExternalLink, Info, ShieldAlert, HardDrive, Loader2, AlertCircle,
+    LayoutGrid, MessageSquare, Boxes, ArrowUpDown } from "@lucide/svelte";
+  // Icons for the not-yet-available model types (see MODEL_TYPES below):
+  // import { Mic, Image as ImageIcon, AudioLines } from "@lucide/svelte";
 
   /** Minimum number of filtered results before auto-loading the next page. */
   const MIN_RESULTS_THRESHOLD = 10;
+
+  const MODEL_TYPES = [
+    { value: "all", label: "All", icon: LayoutGrid },
+    { value: "chat", label: "Chat", icon: MessageSquare },
+    { value: "embedding", label: "Embedding", icon: Boxes },
+    { value: "rerank", label: "Rerank", icon: ArrowUpDown },
+    // { value: "transcription", label: "Transcription", icon: Mic },
+    // { value: "image", label: "Image", icon: ImageIcon },
+    // { value: "tts", label: "Text to Speech", icon: AudioLines },
+  ] as const;
 
   // --- Props ---
   let {
@@ -33,7 +46,7 @@
 
   // --- Filter State ---
   let searchTerm = $state("");
-  let selectedType = $state<"all" | "chat" | "embedding" | "rerank">("all");
+  let selectedType = $state<(typeof MODEL_TYPES)[number]["value"]>("all");
   const selectedTags = $state<Set<string>>(new Set());
   let sentinel = $state<HTMLElement | null>(null);
 
@@ -157,29 +170,29 @@
 
     <!-- Controls -->
     <div class="p-5 border-b bg-card space-y-4">
-      <div class="flex flex-col md:flex-row gap-4">
-        <div class="relative grow">
-          <Input
-            type="text"
-            placeholder="Search by name, description, or ID..."
-            bind:value={searchTerm}
-            class="pr-10"
-          />
-          <div class="absolute inset-y-0 right-0 flex items-center pr-3 pointer-events-none text-muted-foreground">
-            <Search class="w-4 h-4" />
-          </div>
+      <div class="relative">
+        <Input
+          type="text"
+          placeholder="Search by name, description, or ID..."
+          bind:value={searchTerm}
+          class="pr-10"
+        />
+        <div class="absolute inset-y-0 right-0 flex items-center pr-3 pointer-events-none text-muted-foreground">
+          <Search class="w-4 h-4" />
         </div>
+      </div>
 
-        <div class="flex bg-muted p-1 rounded-lg shrink-0">
-          {#each ["all", "chat", "embedding", "rerank"] as type}
-            <button
-              class="px-4 py-2 rounded-md text-sm font-medium transition-all duration-200 capitalize {selectedType === type ? 'bg-background text-primary shadow-sm' : 'text-muted-foreground hover:text-foreground'}"
-              onclick={() => (selectedType = type as any)}
-            >
-              {type}
-            </button>
-          {/each}
-        </div>
+      <div class="flex flex-wrap gap-2 items-center">
+        <span class="text-xs font-semibold text-muted-foreground uppercase tracking-wider mr-1">Type:</span>
+        {#each MODEL_TYPES as t}
+          <button
+            class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium border transition-colors duration-200 {selectedType === t.value ? 'bg-primary text-primary-foreground border-primary shadow-sm' : 'bg-background text-muted-foreground border-border hover:border-primary/50 hover:text-foreground'}"
+            onclick={() => (selectedType = t.value)}
+          >
+            <t.icon class="w-3.5 h-3.5" />
+            {t.label}
+          </button>
+        {/each}
       </div>
 
       {#if allTags.length > 0}

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/test-chat/+server.ts
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/test-chat/+server.ts
@@ -8,7 +8,7 @@
  */
 import type { RequestHandler } from "./$types";
 import { auth } from "$lib/server/auth-server";
-import { serverEnv } from "$lib/server/serverenv";
+import { fetchGateway } from "$lib/server/gateway-proxy";
 import { error } from "@sveltejs/kit";
 
 export const POST: RequestHandler = async ({ request, locals }) => {
@@ -43,7 +43,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
     headers["X-Application"] = applicationName;
   }
 
-  const upstream = await fetch(`${serverEnv.GATEWAY_URL}/v1/chat/completions`, {
+  const upstream = await fetchGateway("/v1/chat/completions", {
     method: "POST",
     headers,
     body: JSON.stringify({
@@ -53,7 +53,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
       store: typeof store === "boolean" ? store : false,
     }),
     signal: request.signal,
-  });
+  }, locals.traceId);
 
   // Pass the upstream response through unchanged (status + body). For SSE
   // success this streams chunks; for non-2xx the gateway returns a small JSON

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/test-embed/+server.ts
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/test-embed/+server.ts
@@ -7,7 +7,7 @@
  */
 import type { RequestHandler } from "./$types";
 import { auth } from "$lib/server/auth-server";
-import { serverEnv } from "$lib/server/serverenv";
+import { fetchGateway } from "$lib/server/gateway-proxy";
 import { error } from "@sveltejs/kit";
 
 export const POST: RequestHandler = async ({ request, locals }) => {
@@ -27,7 +27,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
   if (typeof model !== "string" || !model) error(400, "Missing model");
   if (typeof input !== "string" || !input) error(400, "Missing input");
 
-  const upstream = await fetch(`${serverEnv.GATEWAY_URL}/v1/embeddings`, {
+  const upstream = await fetchGateway("/v1/embeddings", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -35,7 +35,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
     },
     body: JSON.stringify({ model, input }),
     signal: request.signal,
-  });
+  }, locals.traceId);
 
   return new Response(upstream.body, {
     status: upstream.status,

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/test-rerank/+server.ts
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/test-rerank/+server.ts
@@ -7,7 +7,7 @@
  */
 import type { RequestHandler } from "./$types";
 import { auth } from "$lib/server/auth-server";
-import { serverEnv } from "$lib/server/serverenv";
+import { fetchGateway } from "$lib/server/gateway-proxy";
 import { error } from "@sveltejs/kit";
 
 export const POST: RequestHandler = async ({ request, locals }) => {
@@ -33,7 +33,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
   if (typeof query !== "string" || !query) error(400, "Missing query");
   if (!Array.isArray(documents) || documents.length === 0) error(400, "Missing documents");
 
-  const upstream = await fetch(`${serverEnv.GATEWAY_URL}/v1/rerank`, {
+  const upstream = await fetchGateway("/v1/rerank", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -41,7 +41,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
     },
     body: JSON.stringify({ model, query, documents }),
     signal: request.signal,
-  });
+  }, locals.traceId);
 
   return new Response(upstream.body, {
     status: upstream.status,

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/testHelpers.ts
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/testHelpers.ts
@@ -2,8 +2,17 @@ export async function formatErrorBody(res: Response): Promise<string> {
   const text = await res.text().catch(() => "");
   try {
     const parsed = JSON.parse(text);
+    // Gateway / OpenAI-style error body.
     if (parsed?.error?.message) {
       return String(parsed.error.message);
+    }
+    // SvelteKit error() and the dashboard's handleError use { message, traceId? }.
+    if (typeof parsed?.message === "string") {
+      return parsed.message;
+    }
+    // Some backends report the reason under { detail }.
+    if (typeof parsed?.detail === "string") {
+      return parsed.detail;
     }
   } catch {
     // raw text fallback below

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/organizations/+page.server.ts
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/organizations/+page.server.ts
@@ -1,16 +1,33 @@
 import type { PageServerLoad } from "./$types";
 import { auth } from "$lib/server/auth-server";
+import { rootLogger } from "$lib/server/logging";
+
+const log = rootLogger.child({ name: "organizations.page" });
 
 export const load: PageServerLoad = async ({ request, parent }) => {
-  const [organizations, allInvites, { session }] = await Promise.all([
+  const [organizations, invites, { session }] = await Promise.all([
     auth.api.listOrganizations({ headers: request.headers }),
-    auth.api.listUserInvitations({ headers: request.headers }),
+    listPendingInvitations(request.headers),
     parent(),
   ]);
 
   return {
     organizations: organizations ?? [],
-    invites: allInvites.filter((invite) => invite.status === "pending"),
+    invites,
     activeOrganizationId: session.activeOrganizationId,
   };
 };
+
+/**
+ * Lists the session user's pending invitations, falling back to an empty list
+ * on failure.
+ */
+async function listPendingInvitations(headers: Headers) {
+  try {
+    const invites = await auth.api.listUserInvitations({ headers });
+    return invites.filter((invite) => invite.status === "pending");
+  } catch (err) {
+    log.warn({ err }, "Failed to list user invitations");
+    return [];
+  }
+}

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/training/+page.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/training/+page.svelte
@@ -8,6 +8,6 @@
   <div class="p-6 compact:p-3 bg-white rounded-lg shadow-md">
     <h2 class="mb-6 compact:mb-3 text-xl font-semibold">Training Configuration</h2>
 
-    <div>Coming mid 2026</div>
+    <div>Coming soon</div>
   </div>
 </div>


### PR DESCRIPTION
## Description

A collection of dashboard UX and robustness fixes.

- **API key reactivity**: enabling/disabling a key and toggling logging now update the UI immediately. The optimistic handlers mutated a nested property on non-reactive load data; they now reassign the list so the derived state recomputes.
- **Organizations page 500 on unverified email**: on installs without a mail server, the first user's email is never verified, and `listUserInvitations` threw `EMAIL_VERIFICATION_REQUIRED_FOR_INVITATION`, 500-ing the page. The org-page load now degrades to an empty invite list on failure, and `requireEmailVerificationOnInvitation` is gated on `MAIL_URL` (matching `requireEmailVerification` / `sendOnSignUp`).
- **Model-testing 502s**: a refused/timed-out connection to the inference gateway surfaced as an opaque 500 "Internal Error". The test proxies now map connection failures to `502` (and timeouts to `504`) via a shared `fetchGateway` helper, and the client error formatter surfaces the real message.
- **Model-type filter scalability**: the type filter is now a wrapping single-select pill group driven by a typed list, ready to scale as more model types land.

## Type of change

Bug fix

## Testing

No new automated tests were added: the changes are UI reactivity, HTTP error-status mapping, and load-time resilience, validated by the existing tests plus manual verification.

## Checklist

- [x] Tests pass locally (`bun test`), or no testable code was changed
- [x] New or changed behavior is covered by tests, or this change does not require tests
- [x] Documentation is updated, or no user-facing behavior or configuration was changed
- [x] There are no breaking changes, or they are marked with `!` in the commit type and described above
- [x] No security-sensitive changes (authentication, credentials, input handling), or they have been reviewed
- [x] No new dependencies were added, or they have been reviewed for license and maintenance status