### PR TITLE
ci: add OpenCode GitHub Action to auto-review JAAvander PRs

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,0 +1,37 @@
+name: OpenCode
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  opencode-auto-review:
+    # Automatically review PRs opened/updated by a trusted author only.
+    # No @opencode mention trigger exists, so untrusted commenters cannot
+    # invoke the agent or inject prompts.
+    if: github.event_name == 'pull_request' && github.event.pull_request.user.login == 'JAAvander'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - uses: anomalyco/opencode/github@latest
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          model: opencode-go/glm-5.2
+          use_github_token: true
+          prompt: |
+            Review this pull request thoroughly. Look for bugs, correctness
+            issues, security problems, and deviations from the repo's
+            conventions (see AGENTS.md, CONTRIBUTING.md, and the .claude/skills
+            directory). Verify changes with tests and typecheck where possible.
+            Leave your findings as a PR review.


### PR DESCRIPTION
Adds an `opencode` GitHub Action workflow (`.github/workflows/opencode.yml`) that automatically reviews pull requests opened or updated by **JAAvander**, using the `opencode-go/glm-5.2` model.

## What this does
- Triggers on `pull_request` (opened / reopened / synchronize) when the PR author is `JAAvander`.
- Runs the OpenCode agent (`anomalyco/opencode/github@latest`) with a review prompt — no `@opencode` mention needed.
- Posts the review using the workflow's `GITHUB_TOKEN`.

## Why no mention trigger
Only the author-gated auto-review for `JAAvander` remains. There is no `@opencode` mention job, so untrusted commenters cannot invoke the agent (token burn + prompt-injection surface given contents/PR write perms).

## Before this works
The repo secret `OPENCODE_API_KEY` must be set (OpenCode Go subscription key):
```
gh secret set OPENCODE_API_KEY --repo xinity-ai/xinity-ai
```
Replaces the previous `CLAUDE_CODE_OAUTH_TOKEN` setup (that secret has been removed).