### PR TITLE
fix: release tar artifacts instead of zip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
           if [ -f example.env ]; then cp example.env .env; fi
           bun run build
 
-      - name: Compile all targets and zip
+      - name: Compile all targets and package
         working-directory: ${{ matrix.workdir }}
         run: |
           if [ -f example.env ] && [ ! -f .env ]; then cp example.env .env; fi
@@ -85,11 +85,8 @@ jobs:
                 --outfile "${BINARY_NAME}"
             fi
 
-            zip "${{ matrix.package }}-${suffix}.zip" "${BINARY_NAME}" *.map 2>/dev/null || \
-              zip "${{ matrix.package }}-${suffix}.zip" "${BINARY_NAME}"
-            # v1.0.0+ packaging (TODO flip on at 1.0.0, drop the zip lines above):
-            # tar -czf "${{ matrix.package }}-${suffix}.tar.gz" "${BINARY_NAME}" *.map 2>/dev/null || \
-            #   tar -czf "${{ matrix.package }}-${suffix}.tar.gz" "${BINARY_NAME}"
+            tar -czf "${{ matrix.package }}-${suffix}.tar.gz" "${BINARY_NAME}" *.map 2>/dev/null || \
+              tar -czf "${{ matrix.package }}-${suffix}.tar.gz" "${BINARY_NAME}"
             rm -f "${BINARY_NAME}" *.map
 
             echo "::endgroup::"
@@ -100,7 +97,6 @@ jobs:
         with:
           name: release-${{ matrix.package }}
           path: |
-            ${{ matrix.workdir }}/*.zip
             ${{ matrix.workdir }}/*.tar.gz
           retention-days: 1
 
@@ -306,9 +302,9 @@ jobs:
             Or manually:
 
             ```bash
-            curl -fSL "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/xinity-cli-linux-x64.zip" \
-              -o cli.zip
-            unzip cli.zip
+            curl -fSL "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/xinity-cli-linux-x64.tar.gz" \
+              -o cli.tar.gz
+            tar -xzf cli.tar.gz
             mv xinity ~/.local/bin/xinity
             chmod +x ~/.local/bin/xinity
             ```
@@ -319,19 +315,19 @@ jobs:
 
             ```bash
             # x64 (Haswell+, 2013 and later, recommended)
-            curl -fSL "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/xinity-ai-gateway-linux-x64.zip" \
-              -o gateway.zip
-            unzip gateway.zip
+            curl -fSL "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/xinity-ai-gateway-linux-x64.tar.gz" \
+              -o gateway.tar.gz
+            tar -xzf gateway.tar.gz
             chmod +x xinity-ai-gateway
             ./xinity-ai-gateway
 
             # x64-baseline (Nehalem+, maximum compatibility)
-            curl -fSL "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/xinity-ai-gateway-linux-x64-baseline.zip" \
-              -o gateway.zip
+            curl -fSL "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/xinity-ai-gateway-linux-x64-baseline.tar.gz" \
+              -o gateway.tar.gz
 
             # arm64
-            curl -fSL "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/xinity-ai-gateway-linux-arm64.zip" \
-              -o gateway.zip
+            curl -fSL "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/xinity-ai-gateway-linux-arm64.tar.gz" \
+              -o gateway.tar.gz
             ```
 
             Replace `xinity-ai-gateway` with `xinity-ai-daemon`, `xinity-infoserver`, or `xinity-ai-dashboard` as needed.

--- a/deployment/cli/README.md
+++ b/deployment/cli/README.md
@@ -5,7 +5,7 @@ The Xinity CLI is the recommended way to deploy Xinity on any Linux server with 
 ## Prerequisites
 
 - Linux with systemd
-- `curl` and `unzip`
+- `curl` and `tar`
 - For the daemon: a machine with GPU capacity running Ollama
 
 ## Install the CLI

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,19 @@
+# Troubleshooting
+
+## CLI update fails with "Neither ... .tar.gz nor ... .zip found in release"
+
+Starting with v0.21.0, release artifacts are packaged as `.tar.gz` instead of `.zip`. CLI versions older than v0.19.5 do not support `.tar.gz` and will fail when trying to update to a release that only includes `.tar.gz` assets.
+
+To resolve this, reinstall the CLI using the install script:
+
+```bash
+curl -fsSL https://github.com/xinity-ai/xinity-ai/releases/latest/download/install.sh | bash
+```
+
+This installs the latest CLI, which handles `.tar.gz` assets. After that, `xinity update` works normally again.
+
+If you need to install a specific version:
+
+```bash
+curl -fsSL https://github.com/xinity-ai/xinity-ai/releases/latest/download/install.sh | bash -s -- --version v0.21.0
+```

--- a/packages/xinity-cli/src/lib/installer.ts
+++ b/packages/xinity-cli/src/lib/installer.ts
@@ -70,8 +70,6 @@ export async function preflightCheck(
   if (needsExtractor) {
     const target = host.isRemote ? "the remote host" : "this machine";
     await check("tar", `required on ${target} for binary extraction`, "apt install tar / dnf install tar / pacman -S tar");
-    // TODO drop unzip on v1.0.0
-    await check("unzip", `required on ${target} to install pre-1.0.0 releases`, "apt install unzip / dnf install unzip / pacman -S unzip");
   }
 
   // curl is needed on remote hosts for downloading release assets

--- a/packages/xinity-cli/src/lib/remote-probe.ts
+++ b/packages/xinity-cli/src/lib/remote-probe.ts
@@ -31,8 +31,7 @@ export async function collectRemoteState(
 ): Promise<RemoteState> {
   const filesToCheck: string[] = [];
   const filesToRead: string[] = [];
-  // TODO drop unzip on v1.0.0
-  const commandsToCheck: string[] = ["systemctl", "weed", "ollama", "docker", "nvidia-smi", "tar", "unzip", "curl"];
+  const commandsToCheck: string[] = ["systemctl", "weed", "ollama", "docker", "nvidia-smi", "tar", "curl"];
   const unitsToCheck: string[] = ["xinity-ai-seaweedfs.service", "ollama.service", "ollama"];
 
   // SeaweedFS paths

--- a/packages/xinity-cli/tests/helpers/cli-runner.ts
+++ b/packages/xinity-cli/tests/helpers/cli-runner.ts
@@ -35,7 +35,7 @@ export async function runCli(opts: RunCliOptions = {}): Promise<CliResult> {
     stdout: "pipe",
     stderr: "pipe",
     stdin: opts.stdin ? new Response(opts.stdin).body! : "ignore",
-    env: { ...process.env, ...env },
+    env: { ...process.env, LC_ALL: "C", ...env },
     cwd: join(import.meta.dir, "../.."),
   });
 

--- a/packages/xinity-cli/tests/helpers/fixtures.ts
+++ b/packages/xinity-cli/tests/helpers/fixtures.ts
@@ -7,9 +7,9 @@ import type { CliConfig } from "../../src/lib/config.ts";
 
 export function makeAsset(overrides: Partial<ReleaseAsset> = {}): ReleaseAsset {
   return {
-    name: "xinity-ai-gateway-linux-x64.zip",
+    name: "xinity-ai-gateway-linux-x64.tar.gz",
     apiUrl: "https://api.github.com/repos/test/repo/releases/assets/123",
-    browserDownloadUrl: "https://github.com/test/repo/releases/download/v1.0.0/gateway.zip",
+    browserDownloadUrl: "https://github.com/test/repo/releases/download/v1.0.0/gateway.tar.gz",
     size: 1024 * 1024,
     ...overrides,
   };
@@ -20,10 +20,10 @@ export function makeRelease(overrides: Partial<Release> = {}): Release {
     tagName: "v1.0.0",
     name: "Release v1.0.0",
     assets: [
-      makeAsset({ name: "xinity-ai-gateway-linux-x64.zip" }),
+      makeAsset({ name: "xinity-ai-gateway-linux-x64.tar.gz" }),
       makeAsset({ name: "xinity-ai-dashboard.tar.gz" }),
-      makeAsset({ name: "xinity-ai-daemon-linux-x64.zip" }),
-      makeAsset({ name: "xinity-cli-linux-x64.zip" }),
+      makeAsset({ name: "xinity-ai-daemon-linux-x64.tar.gz" }),
+      makeAsset({ name: "xinity-cli-linux-x64.tar.gz" }),
       makeAsset({ name: "db-migrations.tar.gz" }),
       makeAsset({ name: "SHASUMS256.txt" }),
     ],
@@ -56,7 +56,7 @@ export function makeConfig(overrides: Partial<CliConfig> = {}): CliConfig {
 
 /** SHA256 checksum file content for testing. */
 export const SAMPLE_CHECKSUMS = [
-  "abc123def456abc123def456abc123def456abc123def456abc123def456abc12345  xinity-ai-gateway-linux-x64.zip",
+  "abc123def456abc123def456abc123def456abc123def456abc123def456abc12345  xinity-ai-gateway-linux-x64.tar.gz",
   "def456abc123def456abc123def456abc123def456abc123def456abc123def45678  xinity-ai-dashboard.tar.gz",
-  "789abcdef012789abcdef012789abcdef012789abcdef012789abcdef012789abc  xinity-cli-linux-x64.zip",
+  "789abcdef012789abcdef012789abcdef012789abcdef012789abcdef012789abc  xinity-cli-linux-x64.tar.gz",
 ].join("\n");

--- a/packages/xinity-cli/tests/unit/github.test.ts
+++ b/packages/xinity-cli/tests/unit/github.test.ts
@@ -48,15 +48,15 @@ describe("github", () => {
 
     test("uses correct prefix per component", () => {
       const release = makeRelease([
-        "xinity-cli-linux-x64.zip",
-        "xinity-infoserver-linux-x64.zip",
-        "xinity-ai-daemon-linux-x64.zip",
-        "xinity-ai-dashboard-linux-x64.zip",
+        "xinity-cli-linux-x64.tar.gz",
+        "xinity-infoserver-linux-x64.tar.gz",
+        "xinity-ai-daemon-linux-x64.tar.gz",
+        "xinity-ai-dashboard-linux-x64.tar.gz",
       ]);
-      expect(pickReleaseAsset(release, "cli", "x64")).toBe("xinity-cli-linux-x64.zip");
-      expect(pickReleaseAsset(release, "infoserver", "x64")).toBe("xinity-infoserver-linux-x64.zip");
-      expect(pickReleaseAsset(release, "daemon", "x64")).toBe("xinity-ai-daemon-linux-x64.zip");
-      expect(pickReleaseAsset(release, "dashboard", "x64")).toBe("xinity-ai-dashboard-linux-x64.zip");
+      expect(pickReleaseAsset(release, "cli", "x64")).toBe("xinity-cli-linux-x64.tar.gz");
+      expect(pickReleaseAsset(release, "infoserver", "x64")).toBe("xinity-infoserver-linux-x64.tar.gz");
+      expect(pickReleaseAsset(release, "daemon", "x64")).toBe("xinity-ai-daemon-linux-x64.tar.gz");
+      expect(pickReleaseAsset(release, "dashboard", "x64")).toBe("xinity-ai-dashboard-linux-x64.tar.gz");
     });
 
     test("only 'arm64' maps to arm64; everything else becomes x64", () => {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -128,10 +128,8 @@ TAG="$(printf '%s' "$RELEASE_JSON" | grep '"tag_name"' | head -1 | sed 's/.*: *"
 
 if printf '%s' "$RELEASE_JSON" | grep -q "\"name\": *\"${ASSET_PREFIX}.tar.gz\""; then
   ASSET_NAME="${ASSET_PREFIX}.tar.gz"
-elif printf '%s' "$RELEASE_JSON" | grep -q "\"name\": *\"${ASSET_PREFIX}.zip\""; then
-  ASSET_NAME="${ASSET_PREFIX}.zip"
 else
-  fail "Neither ${ASSET_PREFIX}.tar.gz nor ${ASSET_PREFIX}.zip found in release ${TAG}"
+  fail "${ASSET_PREFIX}.tar.gz not found in release ${TAG}"
 fi
 
 info "Installing xinity CLI ${TAG} (${SUFFIX})"
@@ -190,19 +188,8 @@ fi
 # ── Extract and install ─────────────────────────────────────────────────────
 
 mkdir -p "${TMP_DIR}/extracted"
-case "$ASSET_NAME" in
-  *.tar.gz)
-    command -v tar &>/dev/null || fail "'tar' is required but not found"
-    tar -xzf "${TMP_DIR}/${ASSET_NAME}" -C "${TMP_DIR}/extracted"
-    ;;
-  *.zip)
-    command -v unzip &>/dev/null || fail "'unzip' is required but not found"
-    unzip -o "${TMP_DIR}/${ASSET_NAME}" -d "${TMP_DIR}/extracted" >/dev/null
-    ;;
-  *)
-    fail "Unknown archive format: ${ASSET_NAME}"
-    ;;
-esac
+command -v tar &>/dev/null || fail "'tar' is required but not found"
+tar -xzf "${TMP_DIR}/${ASSET_NAME}" -C "${TMP_DIR}/extracted"
 
 mkdir -p "$INSTALL_DIR"
 mv "${TMP_DIR}/extracted/xinity" "${INSTALL_DIR}/xinity"


### PR DESCRIPTION
## Description

Switch release artifact packaging from `.zip` to `.tar.gz`.

- CI now produces `.tar.gz` archives instead of .zip archives. `.tar.gz` has better support with tooling that is more often directly built into the os. This switch was preconfigured for a long time. Many of the previous releases of the cli would already check for a tar archive first, and only then fall back to zip files.  With this, a extensive range of versions of the cli will be handle to support both, allowing this update to be seamless to everyone who does not have a very old cli version.
- `install.sh` and release notes updated for `.tar.gz`
- Preflight checks no longer require `unzip` on target hosts. Tar tooling is much more common preinstalled on linux
- CLI retains the `.zip` fallback in `pickReleaseAsset` and `extractCommandArgv` so installing older (pre-0.21) releases still works
- Added `docs/troubleshooting.md` with guidance for users on CLI versions older than 0.19.5

## Type of change

Bug fix | CI / build / tooling

## Testing

- `pickReleaseAsset` tests updated: fixtures and component-prefix test use `.tar.gz` assets. The "falls back to zip" test is kept to cover backward compat with older releases.
- `SAMPLE_CHECKSUMS` fixture updated to `.tar.gz` filenames so checksum verification tests match the new asset format.
- `LC_ALL=C` in the test runner subprocess env fixes 10 integration tests that depend on English yargs output (cli-help, configure, doctor argument validation).

## Checklist

- [x] Tests pass locally (`bun test`), or no testable code was changed
- [x] New or changed behavior is covered by tests, or this change does not require tests
- [x] Documentation is updated, or no user-facing behavior or configuration was changed
- [x] There are no breaking changes, or they are marked with `!` in the commit type and described above
- [x] No security-sensitive changes (authentication, credentials, input handling), or they have been reviewed
- [x] No new dependencies were added, or they have been reviewed for license and maintenance status