### PR TITLE
fix: docker container optimizations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,21 +157,10 @@ jobs:
           path: staging/
           retention-days: 1
 
-  # Catch out-of-sync Dockerfiles before paying for a multi-arch build.
-  check-dockerfile-sync:
-    name: Verify Dockerfile sync
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: ${{ env.BUN_VERSION }}
-      - run: bun scripts/sync-dockerfile-manifests.ts --check
-
   # Tag-gated so `workflow_dispatch` from a branch can't push `:latest`.
   build-images:
     name: "Image: ${{ matrix.image }}"
-    needs: check-dockerfile-sync
+    needs: build-binaries
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
@@ -186,17 +175,17 @@ jobs:
       matrix:
         include:
           - image: xinity-ai-gateway
-            context: .
-            dockerfile: packages/xinity-ai-gateway/Dockerfile
+            dockerfile: ci/dockerfiles/Dockerfile.gateway
           - image: xinity-ai-dashboard
-            context: .
-            dockerfile: packages/xinity-ai-dashboard/Dockerfile
+            dockerfile: ci/dockerfiles/Dockerfile.dashboard
           - image: xinity-infoserver
-            context: .
-            dockerfile: packages/xinity-infoserver/Dockerfile
+            dockerfile: ci/dockerfiles/Dockerfile.infoserver
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          sparse-checkout: ci/dockerfiles
+          sparse-checkout-cone-mode: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -210,6 +199,28 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download binary artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: release-${{ matrix.image }}
+          path: .artifacts
+
+      - name: Organize binaries by arch
+        run: |
+          mkdir -p build-context/linux/amd64 build-context/linux/arm64
+          for f in .artifacts/*.tar.gz; do
+            name=$(basename "$f" .tar.gz)
+            # Skip x64-baseline tarball; it's for standalone installs, not containers
+            case "$name" in
+              *baseline*) continue ;;
+            esac
+            case "$name" in
+              *arm64) tar -xzf "$f" -C build-context/linux/arm64/ ;;
+              *x64)   tar -xzf "$f" -C build-context/linux/amd64/ ;;
+            esac
+          done
+          find build-context -type f
 
       - name: Docker metadata
         id: meta
@@ -232,7 +243,7 @@ jobs:
       - name: Build and push image
         uses: docker/build-push-action@v6
         with:
-          context: ${{ matrix.context }}
+          context: ./build-context
           file: ${{ matrix.dockerfile }}
           push: true
           platforms: linux/amd64,linux/arm64

--- a/ci/dockerfiles/Dockerfile.dashboard
+++ b/ci/dockerfiles/Dockerfile.dashboard
@@ -1,0 +1,15 @@
+FROM debian:12-slim
+
+ARG TARGETARCH
+
+RUN groupadd -r appuser && useradd -r -g appuser -d /app -s /sbin/nologin appuser
+
+WORKDIR /app
+COPY --chown=appuser:appuser --chmod=755 linux/${TARGETARCH}/xinity-ai-dashboard /app/xinity-ai-dashboard
+
+USER appuser
+
+ENV HTTP_PORT=4121
+EXPOSE 4121/tcp
+
+CMD [ "/app/xinity-ai-dashboard" ]

--- a/ci/dockerfiles/Dockerfile.dashboard
+++ b/ci/dockerfiles/Dockerfile.dashboard
@@ -2,12 +2,16 @@ FROM debian:12-slim
 
 ARG TARGETARCH
 
-RUN groupadd -r appuser && useradd -r -g appuser -d /app -s /sbin/nologin appuser
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN groupadd -g 1000 xinity && useradd -u 1000 -g xinity -d /app -s /sbin/nologin xinity
 
 WORKDIR /app
-COPY --chown=appuser:appuser --chmod=755 linux/${TARGETARCH}/xinity-ai-dashboard /app/xinity-ai-dashboard
+COPY --chown=xinity:xinity --chmod=755 linux/${TARGETARCH}/xinity-ai-dashboard /app/xinity-ai-dashboard
 
-USER appuser
+USER xinity
 
 ENV HTTP_PORT=4121
 EXPOSE 4121/tcp

--- a/ci/dockerfiles/Dockerfile.gateway
+++ b/ci/dockerfiles/Dockerfile.gateway
@@ -2,12 +2,16 @@ FROM debian:12-slim
 
 ARG TARGETARCH
 
-RUN groupadd -r appuser && useradd -r -g appuser -d /app -s /sbin/nologin appuser
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN groupadd -g 1000 xinity && useradd -u 1000 -g xinity -d /app -s /sbin/nologin xinity
 
 WORKDIR /app
-COPY --chown=appuser:appuser --chmod=755 linux/${TARGETARCH}/xinity-ai-gateway /app/xinity-ai-gateway
+COPY --chown=xinity:xinity --chmod=755 linux/${TARGETARCH}/xinity-ai-gateway /app/xinity-ai-gateway
 
-USER appuser
+USER xinity
 
 ENV PORT=3418
 EXPOSE 3418/tcp

--- a/ci/dockerfiles/Dockerfile.gateway
+++ b/ci/dockerfiles/Dockerfile.gateway
@@ -1,0 +1,15 @@
+FROM debian:12-slim
+
+ARG TARGETARCH
+
+RUN groupadd -r appuser && useradd -r -g appuser -d /app -s /sbin/nologin appuser
+
+WORKDIR /app
+COPY --chown=appuser:appuser --chmod=755 linux/${TARGETARCH}/xinity-ai-gateway /app/xinity-ai-gateway
+
+USER appuser
+
+ENV PORT=3418
+EXPOSE 3418/tcp
+
+CMD [ "/app/xinity-ai-gateway" ]

--- a/ci/dockerfiles/Dockerfile.infoserver
+++ b/ci/dockerfiles/Dockerfile.infoserver
@@ -1,0 +1,15 @@
+FROM debian:12-slim
+
+ARG TARGETARCH
+
+RUN groupadd -r appuser && useradd -r -g appuser -d /app -s /sbin/nologin appuser
+
+WORKDIR /app
+COPY --chown=appuser:appuser --chmod=755 linux/${TARGETARCH}/xinity-infoserver /app/xinity-infoserver
+
+USER appuser
+
+ENV MODEL_INFO_DIR=/data/models.d PORT=8090
+EXPOSE 8090/tcp
+
+CMD [ "/app/xinity-infoserver" ]

--- a/ci/dockerfiles/Dockerfile.infoserver
+++ b/ci/dockerfiles/Dockerfile.infoserver
@@ -2,12 +2,16 @@ FROM debian:12-slim
 
 ARG TARGETARCH
 
-RUN groupadd -r appuser && useradd -r -g appuser -d /app -s /sbin/nologin appuser
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN groupadd -g 1000 xinity && useradd -u 1000 -g xinity -d /app -s /sbin/nologin xinity
 
 WORKDIR /app
-COPY --chown=appuser:appuser --chmod=755 linux/${TARGETARCH}/xinity-infoserver /app/xinity-infoserver
+COPY --chown=xinity:xinity --chmod=755 linux/${TARGETARCH}/xinity-infoserver /app/xinity-infoserver
 
-USER appuser
+USER xinity
 
 ENV MODEL_INFO_DIR=/data/models.d PORT=8090
 EXPOSE 8090/tcp


### PR DESCRIPTION
## Description

The release workflow was building Docker images with multi-stage Dockerfiles that pulled the full repo, installed all workspace deps, and compiled from source inside the container. Now that `build-binaries` already produces standalone executables, the image build can skip all of that and just COPY the binary into a minimal base. This:

- Makes the final container images significantly smaller
- Makes the image build much faster (the dashboard build in particular was slow)
- Ties all components into one pipeline, so a situation where the binary works but the container does not becomes much less likely

- New slim Dockerfiles in `ci/dockerfiles/` for gateway, dashboard, and infoserver (debian:12-slim + single binary)
- `build-images` now depends on `build-binaries` instead of `check-dockerfile-sync`
- Per-service binary artifacts are downloaded, organized by arch, and built from `./build-context`
- Only `ci/dockerfiles` is checked out (no full repo clone needed)
- `check-dockerfile-sync` job removed (no longer applicable)
- `ca-certificates` installed for outbound HTTPS
- Container user renamed from `appuser` to `xinity`, pinned to UID/GID 1000 for volume permission predictability

## Type of change

CI / build / tooling

## Testing

- Verified artifact naming, binary naming, and arch directory wiring all match between `build-binaries` upload and `build-images` download
- No application code changed

## Checklist

- [x] Tests pass locally (`bun test`), or no testable code was changed
- [x] New or changed behavior is covered by tests, or this change does not require tests
- [x] Documentation is updated, or no user-facing behavior or configuration was changed
- [x] There are no breaking changes, or they are marked with `!` in the commit type and described above
- [x] No security-sensitive changes (authentication, credentials, input handling), or they have been reviewed
- [x] No new dependencies were added, or they have been reviewed for license and maintenance status