### PR TITLE
feat(cli): fleet management

### DIFF
--- a/deployment/cli/README.md
+++ b/deployment/cli/README.md
@@ -37,17 +37,44 @@ A Xinity deployment spans two kinds of machines:
 
 The daemon is always deployed separately on each inference node, regardless of how the control plane is deployed.
 
-## Deploy the Control Plane
+## Choosing a Path
 
-Run this on the machine that will serve the API and dashboard:
+- **One machine, batteries included:** `xinity up all` guides you through everything interactively and can provision things like the database for you along the way. Start here if you don't have a database available, dont know how to set up dependencies yourself, or want to run everything on the same machine.
+- **Multiple machines, infrastructure already available:** define a stack. It manages all hosts from one declarative definition, but expects a reachable PostgreSQL and Redis to point at. 
+
+## Deploy over Multiple Machines with a Stack (recommended)
+
+For anything beyond a single machine, define a *stack*: a local, declarative description of the whole deployment that the CLI reconciles the machines against.
+
+```bash
+xinity stack init prod       # pinned release version, shared settings (database, Redis,
+                             # metrics auth), stack-wide settings per component
+xinity stack edit prod       # add hosts (e.g. root@10.0.0.4: gateway, dashboard;
+                             # root@10.0.0.7: daemon) and group daemons into fleets
+xinity stack up prod         # one reviewed plan, then applied host by host
+```
+
+`stack up` connects to every host, checks installed versions and configuration against the stack, and plans database migrations, installs, updates, config changes, and removal of components the stack no longer tracks. Nothing is changed until the plan is confirmed. Re-run it after any edit; it only applies what differs.
+
+Key properties:
+
+- **Layered configuration.** Shared values (like `DB_CONNECTION_URL`) are entered once and inherited everywhere; component-type settings apply stack-wide; fleets carry daemon overrides; per-host overrides exist as the escape hatch.
+- **Pinned versions.** The stack holds every component at its pinned release. `stack up` offers available updates and never applies one without an explicit yes.
+- **Health checks.** `xinity stack doctor prod` (alias: `status`) runs the doctor on every host and prints each failing check; `--fleet <name>` limits it to one fleet.
+
+Host addresses are anything ssh accepts; use `root@ip` for zero prompts, or a sudo-capable user (one password prompt per host, asked up front).
+
+**Bring your own infrastructure.** A stack deploys and reconciles Xinity's own components; it deliberately does not provision the infrastructure underneath them. `stack init` asks for your PostgreSQL and Redis connection URLs as given facts (migrations are then handled for you). If you need that infrastructure created first, the assistants under `xinity up infra-*` do exactly that, and the URLs they produce go straight into the stack's shared settings.
+
+## Deploy on a Single Machine
+
+For a one-machine setup, `xinity up all` walks through everything in place without a stack definition:
 
 ```bash
 xinity up all
 ```
 
-This installs and configures gateway, dashboard, and the database as systemd services. The CLI walks through required configuration interactively.
-
-To install components individually:
+Like every `up` run, this works in phases: configuration is collected first (nothing touches the machine), the planned actions are shown with their config diffs, and only a single confirmation executes them. The same gate can instead print an equivalent bash script for auditing. To install components individually:
 
 ```bash
 xinity up db          # PostgreSQL migrations + Redis discovery
@@ -80,7 +107,7 @@ These commands handle detection, installation, service management, and connectiv
 
 ## Remote Management
 
-All commands support `--target-host` for managing a remote Linux server over SSH:
+The single-host commands (`up`, `rm`, `configure`, `doctor`) support `--target-host` for managing a remote Linux server over SSH; stacks connect to their hosts on their own:
 
 ```bash
 xinity up all --target-host user@server
@@ -88,7 +115,7 @@ xinity doctor --target-host user@server
 xinity configure dashboard --target-host user@server
 ```
 
-The CLI establishes a persistent SSH connection and caches sudo credentials for the session, so you authenticate once regardless of how many elevated operations are needed.
+The CLI establishes a persistent SSH connection per host and sets up root privileges once up front (connecting as root needs nothing, passwordless sudo is auto-detected, otherwise one password prompt), so you authenticate at most once regardless of how many elevated operations follow.
 
 ## Secrets Management
 
@@ -122,10 +149,10 @@ After `xinity up gateway`:
 ### Reconfiguring
 
 ```bash
-xinity configure gateway    # re-prompts for config and secrets
+xinity configure gateway    # menu editor over the gateway's environment
 ```
 
-The service is automatically restarted after saving to pick up the new configuration.
+The editor shows the current values; on save, a review lists exactly what would change (secrets masked) and nothing is written until confirmed. The service is restarted afterwards to pick up the new configuration.
 
 ### Rotating secrets
 

--- a/deployment/cli/README.md
+++ b/deployment/cli/README.md
@@ -54,7 +54,7 @@ xinity stack edit prod       # add hosts (e.g. root@10.0.0.4: gateway, dashboard
 xinity stack up prod         # one reviewed plan, then applied host by host
 ```
 
-`stack up` connects to every host, checks installed versions and configuration against the stack, and plans database migrations, installs, updates, config changes, and removal of components the stack no longer tracks. Nothing is changed until the plan is confirmed. Re-run it after any edit; it only applies what differs.
+`stack up` connects to every host, checks installed versions and configuration against the stack, and plans database migrations, installs, updates, config changes, and removal of components the stack no longer tracks. Hosts deleted from the definition entirely are evacuated too: the CLI keeps a local record of the hosts it manages and removes everything from those that left. Nothing is changed until the plan is confirmed. Re-run it after any edit; it only applies what differs.
 
 Key properties:
 

--- a/docs/features/cli.md
+++ b/docs/features/cli.md
@@ -8,9 +8,17 @@ For the full command reference with flags and examples, see the [CLI package REA
 
 ### Install and manage services (`xinity up` / `xinity rm`)
 
-Deploy the full Xinity stack or individual components as systemd units. `xinity up all` runs a guided setup sequence covering database, Redis, infoserver, gateway, dashboard, and optionally the daemon with Ollama. Individual infrastructure utilities (`infra-ollama`, `infra-redis`, `infra-postgres`, `infra-seaweedfs`, `infra-prometheus`) detect, install, and configure dependencies automatically.
+Deploy individual components (or a whole machine with `up all`) as systemd units. Every `up` run is plan-based: configuration and versions are collected first without touching the host, the assembled actions are shown with a config diff, and nothing changes until a single confirmation, which can alternatively produce an equivalent bash script. Infrastructure utilities (`infra-ollama`, `infra-redis`, `infra-postgres`, `infra-seaweedfs`, `infra-prometheus`) detect, install, and configure dependencies.
 
 `xinity rm` removes installed components, with an optional `--purge` flag to also delete state data.
+
+### Multi-host deployments (`xinity stack`)
+
+A stack is a local, declarative definition of a whole deployment: shared configuration (database, Redis, metrics auth), stack-wide settings per component type, hosts with their assigned components, and daemon *fleets* (named groups of inference nodes sharing configuration). Configuration is layered so every value lives at the highest level possible; per-host overrides exist but are the escape hatch.
+
+`xinity stack up` compares every host against the definition, plans migrations, installs, updates, reconfigurations, and removal of components the stack no longer tracks, and applies everything after one review gate. Each stack pins a release version; all components are held at it and updates are offered, never automatic. `xinity stack doctor` (alias `status`) health-checks all hosts, or one fleet via `--fleet`.
+
+Stacks assume the infrastructure underneath (PostgreSQL, Redis) already exists and take its connection URLs as given; the `infra-*` assistants can provision it beforehand. For a guided single-machine install that also provisions infrastructure, `xinity up all` is the intended path.
 
 ### Health checking (`xinity doctor`)
 
@@ -22,7 +30,7 @@ Call any dashboard API route from the command line. Routes are discovered dynami
 
 ### Configuration (`xinity configure`)
 
-Set CLI-level config (API key, dashboard URL) or interactively edit a component's environment file. Configuration is stored in `~/.config/xinity/config.json`.
+Set CLI-level config (API key, dashboard URL) or edit a component's environment through the menu editor. Component changes are reviewed as a diff and applied only after confirmation, followed by a service restart. CLI configuration is stored in `~/.config/xinity/config.json`.
 
 ### Self-update (`xinity update`)
 
@@ -30,7 +38,7 @@ Downloads the latest release, verifies SHA-256, and atomically replaces the bina
 
 ### Remote management (`--target-host`)
 
-Every command accepts `--target-host` to operate on a remote server via SSH. Uses ControlMaster multiplexing for session reuse and batches remote checks into single SSH calls for performance. Privilege elevation (sudo) is handled interactively with policy remembered for the session.
+The single-host commands (`up`, `rm`, `configure`, `doctor`) accept `--target-host` to operate on a remote server via SSH; stacks manage their own host lists. Uses ControlMaster multiplexing for session reuse and batches remote checks into single SSH calls for performance. Root privileges are established once up front (root detected, passwordless sudo auto-detected, otherwise one password prompt per host).
 
 ### Shell completion (`xinity completion`)
 

--- a/docs/features/cli.md
+++ b/docs/features/cli.md
@@ -40,6 +40,8 @@ Downloads the latest release, verifies SHA-256, and atomically replaces the bina
 
 The single-host commands (`up`, `rm`, `configure`, `doctor`) accept `--target-host` to operate on a remote server via SSH; stacks manage their own host lists. Uses ControlMaster multiplexing for session reuse and batches remote checks into single SSH calls for performance. Root privileges are established once up front (root detected, passwordless sudo auto-detected, otherwise one password prompt per host).
 
+For stacks with many hosts, SSH key-based root login eliminates repeated authentication prompts entirely. Set up an SSH key pair, add the public key to each host's `/root/.ssh/authorized_keys`, and ensure `PermitRootLogin prohibit-password` is set in `/etc/ssh/sshd_config`. With an SSH agent running, even passphrase-protected keys require only one unlock per session regardless of host count. This is the recommended setup for fleet-scale deployments.
+
 ### Shell completion (`xinity completion`)
 
 Generates completion scripts for bash, zsh, and fish. Includes dynamic completion of `act` route names from the live dashboard.

--- a/docs/features/cli.md
+++ b/docs/features/cli.md
@@ -16,7 +16,7 @@ Deploy individual components (or a whole machine with `up all`) as systemd units
 
 A stack is a local, declarative definition of a whole deployment: shared configuration (database, Redis, metrics auth), stack-wide settings per component type, hosts with their assigned components, and daemon *fleets* (named groups of inference nodes sharing configuration). Configuration is layered so every value lives at the highest level possible; per-host overrides exist but are the escape hatch.
 
-`xinity stack up` compares every host against the definition, plans migrations, installs, updates, reconfigurations, and removal of components the stack no longer tracks, and applies everything after one review gate. Each stack pins a release version; all components are held at it and updates are offered, never automatic. `xinity stack doctor` (alias `status`) health-checks all hosts, or one fleet via `--fleet`.
+`xinity stack up` compares every host against the definition, plans migrations, installs, updates, reconfigurations, and removal of components the stack no longer tracks, and applies everything after one review gate. A local state file records which hosts the stack manages, so hosts deleted from the definition are evacuated (all managed components removed) on the next `up`. Each stack pins a release version; all components are held at it, re-pinning happens from the release list in `stack edit`, and nothing updates automatically. `xinity stack doctor` (alias `status`) health-checks all hosts, or one fleet via `--fleet`.
 
 Stacks assume the infrastructure underneath (PostgreSQL, Redis) already exists and take its connection URLs as given; the `infra-*` assistants can provision it beforehand. For a guided single-machine install that also provisions infrastructure, `xinity up all` is the intended path.
 
@@ -30,7 +30,7 @@ Call any dashboard API route from the command line. Routes are discovered dynami
 
 ### Configuration (`xinity configure`)
 
-Set CLI-level config (API key, dashboard URL) or edit a component's environment through the menu editor. Component changes are reviewed as a diff and applied only after confirmation, followed by a service restart. CLI configuration is stored in `~/.config/xinity/config.json`.
+Set CLI-level config (API key, dashboard URL) or edit a component's environment through the menu editor. Component changes are reviewed as a diff and applied only after confirmation, followed by a service restart. CLI configuration is stored in `~/.config/xinity/config.json` (`$XDG_CONFIG_HOME` is honored when set).
 
 ### Self-update (`xinity update`)
 

--- a/packages/xinity-cli/README.md
+++ b/packages/xinity-cli/README.md
@@ -49,14 +49,26 @@ xinity update --check    # check for updates without installing
 
 | Flag | Description |
 |---|---|
-| `--target-host <host>` | Run the command on a remote server via SSH (any valid ssh host alias or address) |
 | `--version` | Print the CLI version |
+
+The single-host commands (`up`, `rm`, `configure`, `doctor`) additionally accept `--target-host <host>` to run against a remote server via SSH. Multi-host operations use stacks (`xinity stack`), which carry their own host lists.
+
+## How Changes Are Applied: Plan → Review → Apply
+
+`xinity up`, `xinity configure`, and `xinity stack up` all follow the same model. No command modifies a machine as it goes; they work in phases:
+
+1. **Collect.** Versions are resolved, current state is read off the host(s), and configuration is gathered through the menu editor (required values are marked and block saving; advanced settings are collapsed behind a toggle). This phase is strictly read-only on the target.
+2. **Review.** The assembled actions are shown as a numbered plan: what gets installed, updated, reconfigured, or removed, including the exact configuration diff (`+` added, `~` changed, `-` removed, secret values masked).
+3. **Gate.** One confirmation applies everything. Choosing **Abort** leaves the machines untouched. A third, secondary option prints the equivalent bash script instead of running anything, for auditing or manual execution (note: the script contains secrets in plain text).
+4. **Apply.** Runs unattended, since root privileges were established when the command started. Updates back up the previous binary and configuration and roll back automatically when the new version fails to start.
+
+`--dry-run` (on `xinity up`) stops after the review, so the plan can be inspected with zero risk.
 
 ## Commands
 
 ### `xinity up <component>`
 
-Install or update a Xinity service component as a systemd unit. Walks through configuration interactively when options have changed.
+Install or update a Xinity service component as a systemd unit, via the plan → review → apply flow described above. `up all` guides through the full sequence (database, Redis, optional infoserver/daemon/Ollama) and carries values declared in earlier steps into the later components, so nothing is asked twice.
 
 ```bash
 xinity up gateway
@@ -89,7 +101,7 @@ xinity up all
 | `--dry-run` | `false` | Show what would be done without making changes |
 | `--hard-reset` | `false` | Fully reset component state during reinstall |
 
-Core components go through: pre-flight checks, version resolution from GitHub, download with SHA-256 verification, interactive environment configuration, systemd unit generation, service start, and health verification. On updates, the previous binary and config are backed up. On start failure, rollback to the previous version is offered.
+During `up all`, infrastructure the plan decides to provision (a PostgreSQL container, a Redis install) is only executed after the gate as well; the planning phase never changes machine state.
 
 ### `xinity rm <component>`
 
@@ -155,9 +167,11 @@ Set CLI configuration values or interactively configure a service component's en
 ```bash
 xinity configure apiKey sk-...        # set a CLI config value
 xinity configure apiKey --reset       # clear a value
-xinity configure gateway              # interactive env editor for the gateway
+xinity configure gateway              # menu editor for the gateway's environment
 xinity configure                      # interactive CLI config menu
 ```
+
+Component configuration uses the same plan → review → apply flow: the menu editor shows current values (required keys marked, advanced settings collapsed), the review lists only what actually changed as a diff, and nothing is written until the gate is confirmed, after which the service restarts with the new configuration.
 
 **CLI config keys:** `apiKey`, `dashboardUrl`, `githubProjectUrl`, `githubToken`
 
@@ -168,6 +182,43 @@ xinity configure                      # interactive CLI config menu
 | `--reset` | Clear the specified config key |
 
 Configuration is stored in `~/.config/xinity/config.json` (mode 0600, directory mode 0700).
+
+### `xinity stack <action>`
+
+Declarative multi-host deployments. A stack is a local definition (`~/.config/xinity/stacks/<name>.json`, mode 600) holding shared configuration, stack-wide settings per component type, hosts (address + components), daemon fleets, and the pinned release version. `stack up` compares every host against the definition and applies only what differs.
+
+```bash
+xinity stack init prod       # shared + per-component settings, pinned version
+xinity stack edit prod       # hosts, fleets, settings, release version
+xinity stack up prod         # one plan, one gate, applied across all hosts
+xinity stack doctor prod     # health-check every host (alias: status)
+```
+
+**Actions:**
+
+| Action | Description |
+|---|---|
+| `init <name>` | Create a stack: pinned release version, shared settings (database, Redis, metrics auth, ...), then stack-wide settings per component. Required values block saving, so a fresh stack is deployable from the start. |
+| `ls` | List stacks |
+| `show <name>` | Print a stack summary |
+| `edit <name>` | Menu editor for everything in the stack. `--fleet <fleet>` jumps straight to that fleet's daemon settings. |
+| `up <name>` | Plan and apply the whole stack at its pinned version. `--target-version <v>` re-pins. |
+| `doctor <name>` (alias `status`) | Doctor every host, printing each failing check. `--fleet <fleet>` limits to that fleet's hosts. |
+| `rm <name>` | Choice of removing only the local definition or tearing down all tracked components on the hosts (best effort). `--fleet <fleet>` removes a fleet: definition only, or with daemon teardown. |
+
+**Configuration is layered**, most general first, later wins: schema defaults → shared env/secrets → per-component-type settings → fleet overrides (daemon only) → per-host overrides. Values live at the highest level possible; per-host overrides (e.g. `MACHINE_NAME`) are the escape hatch, never the norm. Shared-owned keys are not offered in lower-level editors.
+
+**What `stack up` does**, per host, after one review gate:
+
+- applies database migrations for the pinned release (skipped when the stack already applied them)
+- removes components that are installed but no longer tracked by the stack
+- installs, updates, or reconfigures each tracked component to match the pinned version and resolved configuration, with the config diff visible in the plan
+
+**Versions are pinned.** Every component in a stack is held at the stack's `pinnedVersion`. `stack up` checks for a newer release and asks before re-pinning; nothing updates silently.
+
+**Bring your own infrastructure.** Stacks manage Xinity's components, not the infrastructure beneath them: `stack init` takes your PostgreSQL and Redis connection URLs as given (migrations are then run for you). To have the CLI provision that infrastructure first, use the interactive assistants (`xinity up infra-postgres`, `xinity up infra-redis`, with `--target-host` for remote machines) and feed the resulting URLs into the stack. For a guided single-machine setup that can provision everything in one pass, `xinity up all` remains the right tool.
+
+Host addresses are anything ssh accepts (`root@10.0.0.5`, an ssh alias) or `local` for the machine the CLI runs on. A fleet is a named group of daemon hosts sharing configuration overrides, e.g. one pool per GPU type.
 
 ### `xinity update`
 
@@ -202,9 +253,9 @@ xinity completion fish > ~/.config/fish/completions/xinity.fish
 
 ## Remote Host Support
 
-All commands accept `--target-host` to operate on a remote server via SSH. The CLI uses SSH ControlMaster multiplexing to keep a single connection open for the session.
+The single-host commands (`up`, `rm`, `configure`, `doctor`) accept `--target-host`; stacks connect to their hosts on their own. The CLI uses SSH ControlMaster multiplexing to keep a single connection open per host for the session.
 
-Privilege elevation is handled interactively: the CLI auto-detects passwordless sudo, prompts for a sudo password when needed, or offers a manual mode. The elevation policy is remembered for the session.
+Root privileges are established once, up front: connecting as root needs nothing, passwordless sudo is detected automatically, and otherwise the sudo password is asked exactly once per host. Everything afterwards runs unattended.
 
 For the `doctor` command, all remote file and service checks are batched into a single SSH call to minimize round-trips over high-latency connections.
 

--- a/packages/xinity-cli/README.md
+++ b/packages/xinity-cli/README.md
@@ -62,7 +62,7 @@ The single-host commands (`up`, `rm`, `configure`, `doctor`) additionally accept
 3. **Gate.** One confirmation applies everything. Choosing **Abort** leaves the machines untouched. A third, secondary option prints the equivalent bash script instead of running anything, for auditing or manual execution (note: the script contains secrets in plain text).
 4. **Apply.** Runs unattended, since root privileges were established when the command started. Updates back up the previous binary and configuration and roll back automatically when the new version fails to start.
 
-`--dry-run` (on `xinity up`) stops after the review, so the plan can be inspected with zero risk.
+`--dry-run` (on `xinity up` and `xinity stack up`) stops after the review, so the plan can be inspected with zero risk.
 
 ## Commands
 
@@ -181,11 +181,11 @@ Component configuration uses the same plan → review → apply flow: the menu e
 |---|---|
 | `--reset` | Clear the specified config key |
 
-Configuration is stored in `~/.config/xinity/config.json` (mode 0600, directory mode 0700).
+Configuration is stored in `$XDG_CONFIG_HOME/xinity/config.json` (mode 0600, directory mode 0700).
 
 ### `xinity stack <action>`
 
-Declarative multi-host deployments. A stack is a local definition (`~/.config/xinity/stacks/<name>.json`, mode 600) holding shared configuration, stack-wide settings per component type, hosts (address + components), daemon fleets, and the pinned release version. `stack up` compares every host against the definition and applies only what differs.
+Declarative multi-host deployments. A stack is a local definition (`~/.config/xinity/stacks/<name>.json`, mode 600) holding shared configuration, stack-wide settings per component type, hosts (address + components), daemon fleets, and the pinned release version. `stack up` compares every host against the definition and applies only what differs. A separate state file (`$XDG_CONFIG_HOME/xinity/stacks/state/<name>.json`) records which hosts the stack actually manages, so a host deleted from the definition is still torn down on the next `up`.
 
 ```bash
 xinity stack init prod       # shared + per-component settings, pinned version
@@ -198,23 +198,24 @@ xinity stack doctor prod     # health-check every host (alias: status)
 
 | Action | Description |
 |---|---|
-| `init <name>` | Create a stack: pinned release version, shared settings (database, Redis, metrics auth, ...), then stack-wide settings per component. Required values block saving, so a fresh stack is deployable from the start. |
+| `init <name>` | Create a stack: shared settings (database, Redis, metrics auth, ...), then stack-wide settings per component. Required values block saving, so a fresh stack is deployable from the start. |
 | `ls` | List stacks |
 | `show <name>` | Print a stack summary |
 | `edit <name>` | Menu editor for everything in the stack. `--fleet <fleet>` jumps straight to that fleet's daemon settings. |
 | `up <name>` | Plan and apply the whole stack at its pinned version. `--target-version <v>` re-pins. |
 | `doctor <name>` (alias `status`) | Doctor every host, printing each failing check. `--fleet <fleet>` limits to that fleet's hosts. |
-| `rm <name>` | Choice of removing only the local definition or tearing down all tracked components on the hosts (best effort). `--fleet <fleet>` removes a fleet: definition only, or with daemon teardown. |
+| `rm <name>` | Delete the local stack definition and state; hosts stay untouched. To uninstall components first, remove the hosts from the stack and run `up` before deleting it. Fleets are removed through `stack edit`. |
 
 **Configuration is layered**, most general first, later wins: schema defaults → shared env/secrets → per-component-type settings → fleet overrides (daemon only) → per-host overrides. Values live at the highest level possible; per-host overrides (e.g. `MACHINE_NAME`) are the escape hatch, never the norm. Shared-owned keys are not offered in lower-level editors.
 
 **What `stack up` does**, per host, after one review gate:
 
 - applies database migrations for the pinned release (skipped when the stack already applied them)
+- evacuates hosts that were removed from the definition: every managed component is uninstalled and the host is forgotten (unreachable hosts are forgotten without teardown; hosts claimed by another stack are left to it)
 - removes components that are installed but no longer tracked by the stack
 - installs, updates, or reconfigures each tracked component to match the pinned version and resolved configuration, with the config diff visible in the plan
 
-**Versions are pinned.** Every component in a stack is held at the stack's `pinnedVersion`. `stack up` checks for a newer release and asks before re-pinning; nothing updates silently.
+**Versions are pinned.** Every component in a stack is held at the stack's `pinnedVersion`. The version option in `stack edit` opens a searchable list of the published releases (latest, prereleases, and the current pin marked) to re-pin from, or use `stack up --target-version`. Nothing updates silently.
 
 **Bring your own infrastructure.** Stacks manage Xinity's components, not the infrastructure beneath them: `stack init` takes your PostgreSQL and Redis connection URLs as given (migrations are then run for you). To have the CLI provision that infrastructure first, use the interactive assistants (`xinity up infra-postgres`, `xinity up infra-redis`, with `--target-host` for remote machines) and feed the resulting URLs into the stack. For a guided single-machine setup that can provision everything in one pass, `xinity up all` remains the right tool.
 

--- a/packages/xinity-cli/src/commands/act.ts
+++ b/packages/xinity-cli/src/commands/act.ts
@@ -81,9 +81,8 @@ async function callRoute(
 
   const hasBody = route.method !== "GET" && route.method !== "DELETE";
 
-  // For GET requests, add remaining data as query params
   let fetchUrl = fullUrl;
-  if (route.method === "GET" && Object.keys(remainingData).length > 0) {
+  if (!hasBody && Object.keys(remainingData).length > 0) {
     const params = new URLSearchParams();
     for (const [k, v] of Object.entries(remainingData)) {
       if (v !== undefined) params.set(k, String(v));

--- a/packages/xinity-cli/src/commands/act.ts
+++ b/packages/xinity-cli/src/commands/act.ts
@@ -123,8 +123,14 @@ async function callRoute(
   }
 
   spin.stop(`${route.method} ${path}`);
-  const json = await res.json();
-  console.log(JSON.stringify(json, null, 2));
+  const text = await res.text();
+  if (text) {
+    try {
+      console.log(JSON.stringify(JSON.parse(text), null, 2));
+    } catch {
+      console.log(text);
+    }
+  }
 }
 
 function parseJsonOrExit(text: string, source: string): Record<string, unknown> {

--- a/packages/xinity-cli/src/commands/configure.ts
+++ b/packages/xinity-cli/src/commands/configure.ts
@@ -3,8 +3,7 @@ import { menuConfigureCli, loadConfig, saveConfig, updateConfig } from "../lib/c
 import { menuConfigureEnv } from "../lib/env-prompt.ts";
 import type { Component } from "../lib/component-meta.ts";
 import type { CliConfig } from "../lib/config.ts";
-import { createLocalHost } from "../lib/host.ts";
-import { connectRemoteHost } from "../lib/remote-host.ts";
+import { connectHost } from "../lib/remote-host.ts";
 
 const CLI_CONFIG_KEYS = ["apiKey", "dashboardUrl", "githubProjectUrl", "githubToken"] as const;
 const COMPONENTS = ["cli", "gateway", "dashboard", "daemon", "infoserver"] as const;
@@ -52,7 +51,7 @@ export const configureCommand: CommandModule = {
     if (component === "cli") {
       await menuConfigureCli();
     } else {
-      const host = targetHostArg ? await connectRemoteHost(targetHostArg) : createLocalHost();
+      const host = await connectHost(targetHostArg);
       try {
         await menuConfigureEnv(component as Component, host);
       } finally {

--- a/packages/xinity-cli/src/commands/configure.ts
+++ b/packages/xinity-cli/src/commands/configure.ts
@@ -1,6 +1,6 @@
 import type { CommandModule } from "yargs";
 import { menuConfigureCli, loadConfig, saveConfig, updateConfig } from "../lib/config.ts";
-import { menuConfigureEnv } from "../lib/env-prompt.ts";
+import { configureComponentFlow } from "../lib/up-plan.ts";
 import type { Component } from "../lib/component-meta.ts";
 import type { CliConfig } from "../lib/config.ts";
 import { connectHost } from "../lib/remote-host.ts";
@@ -53,7 +53,7 @@ export const configureCommand: CommandModule = {
     } else {
       const host = await connectHost(targetHostArg);
       try {
-        await menuConfigureEnv(component as Component, host);
+        await configureComponentFlow(component as Component, host);
       } finally {
         await host.dispose();
       }

--- a/packages/xinity-cli/src/commands/configure.ts
+++ b/packages/xinity-cli/src/commands/configure.ts
@@ -3,7 +3,7 @@ import { menuConfigureCli, loadConfig, saveConfig, updateConfig } from "../lib/c
 import { configureComponentFlow } from "../lib/up-plan.ts";
 import type { Component } from "../lib/component-meta.ts";
 import type { CliConfig } from "../lib/config.ts";
-import { connectHost } from "../lib/remote-host.ts";
+import { connectHost, TARGET_HOST_OPTION } from "../lib/remote-host.ts";
 
 const CLI_CONFIG_KEYS = ["apiKey", "dashboardUrl", "githubProjectUrl", "githubToken"] as const;
 const COMPONENTS = ["cli", "gateway", "dashboard", "daemon", "infoserver"] as const;
@@ -27,7 +27,8 @@ export const configureCommand: CommandModule = {
         type: "boolean",
         describe: "Clear the specified config key",
         default: false,
-      }),
+      })
+      .option("target-host", TARGET_HOST_OPTION),
   handler: async (argv) => {
     const key = argv.key as string;
     const value = argv.value as string | undefined;

--- a/packages/xinity-cli/src/commands/doctor.ts
+++ b/packages/xinity-cli/src/commands/doctor.ts
@@ -1,16 +1,16 @@
 import type { CommandModule } from "yargs";
-import * as p from "../lib/clack.ts";
-import pc from "picocolors";
-import { runDoctor, type CheckResult, type ComponentReport, type DoctorReport } from "../lib/doctor.ts";
-import { connectHost } from "../lib/remote-host.ts";
+import { intro, outro, spinner } from "../lib/clack.ts";
+import { bold, dim, green, red, yellow } from "picocolors";
+import { runDoctor, buildSummaryLine, type CheckResult, type ComponentReport, type DoctorReport } from "../lib/doctor.ts";
+import { connectHost, TARGET_HOST_OPTION } from "../lib/remote-host.ts";
 
 // ─── Status symbols ──────────────────────────────────────────────────────────
 
 const SYMBOLS: Record<string, string> = {
-  pass: pc.green("✓"),
-  fail: pc.red("✗"),
-  warn: pc.yellow("⚠"),
-  skip: pc.dim("○"),
+  pass: green("✓"),
+  fail: red("✗"),
+  warn: yellow("⚠"),
+  skip: dim("○"),
 };
 
 // ─── Report renderer ─────────────────────────────────────────────────────────
@@ -28,11 +28,11 @@ function renderReport(report: DoctorReport, verbose: boolean): void {
 }
 
 function renderComponentSection(comp: ComponentReport, verbose: boolean): void {
-  const name = pc.bold(comp.component.toUpperCase());
+  const name = bold(comp.component.toUpperCase());
   const ver = comp.version?.replace(/^v/, "") ?? null;
-  const version = ver ? pc.dim(`  v${ver}`) : "";
+  const version = ver ? dim(`  v${ver}`) : "";
   process.stdout.write(`  ${name}${version}\n`);
-  process.stdout.write(`  ${pc.dim("─".repeat(SEP_WIDTH))}\n`);
+  process.stdout.write(`  ${dim("─".repeat(SEP_WIDTH))}\n`);
 
   for (const check of comp.checks) {
     renderCheckLine(check, verbose);
@@ -40,7 +40,7 @@ function renderComponentSection(comp: ComponentReport, verbose: boolean): void {
 }
 
 function renderCheckLine(check: CheckResult, verbose: boolean): void {
-  const symbol = SYMBOLS[check.status] ?? pc.dim("·");
+  const symbol = SYMBOLS[check.status] ?? dim("·");
   const label = check.label.padEnd(LABEL_WIDTH);
   const showDetail = verbose || check.status === "fail" || check.status === "warn";
 
@@ -49,21 +49,8 @@ function renderCheckLine(check: CheckResult, verbose: boolean): void {
   if (showDetail && check.detail) {
     // Indent detail to align with the message column: 2 + 1 (symbol) + 2 + LABEL_WIDTH
     const indent = " ".repeat(5 + LABEL_WIDTH);
-    process.stdout.write(`${indent}${pc.dim(check.detail)}\n`);
+    process.stdout.write(`${indent}${dim(check.detail)}\n`);
   }
-}
-
-// ─── Summary line ─────────────────────────────────────────────────────────────
-
-function buildSummaryLine(summary: DoctorReport["summary"]): string {
-  return [
-    pc.green(`${summary.pass} passed`),
-    summary.warn > 0 ? pc.yellow(`${summary.warn} warnings`) : null,
-    summary.fail > 0 ? pc.red(`${summary.fail} failed`) : null,
-    summary.skip > 0 ? pc.dim(`${summary.skip} skipped`) : null,
-  ]
-    .filter(Boolean)
-    .join(pc.dim(" · "));
 }
 
 // ─── Command ─────────────────────────────────────────────────────────────────
@@ -89,14 +76,15 @@ export const doctorCommand: CommandModule = {
         describe: "Prompt for sudo when permission-denied checks are encountered",
         type: "boolean",
         default: true,
-      }),
+      })
+      .option("target-host", TARGET_HOST_OPTION),
   handler: async (argv) => {
     const verbose = argv.verbose as boolean;
     const format = argv.format as "text" | "json" | "yaml";
     const interactive = argv.interactive as boolean;
     const targetHostArg = argv["target-host"] as string | undefined;
 
-    p.intro(`xinity doctor${targetHostArg ? pc.dim(` → ${targetHostArg}`) : ""}`);
+    intro(`xinity doctor${targetHostArg ? dim(` → ${targetHostArg}`) : ""}`);
 
     let host;
     try {
@@ -119,7 +107,7 @@ export const doctorCommand: CommandModule = {
         process.stdout.write(Bun.YAML.stringify(report, null, 2));
       } else {
         renderReport(report, verbose);
-        p.outro(buildSummaryLine(report.summary));
+        outro(buildSummaryLine(report.summary));
       }
       process.exit(1);
       return;
@@ -127,7 +115,7 @@ export const doctorCommand: CommandModule = {
 
     let hasFailures = false;
     try {
-      const clackSpinner = p.spinner();
+      const clackSpinner = spinner();
       clackSpinner.start("Collecting diagnostics…");
 
       const report = await runDoctor({
@@ -147,7 +135,7 @@ export const doctorCommand: CommandModule = {
         process.stdout.write(Bun.YAML.stringify(report, null, 2));
       } else {
         renderReport(report, verbose);
-        p.outro(buildSummaryLine(report.summary));
+        outro(buildSummaryLine(report.summary));
       }
       hasFailures = report.summary.fail > 0;
     } finally {

--- a/packages/xinity-cli/src/commands/doctor.ts
+++ b/packages/xinity-cli/src/commands/doctor.ts
@@ -2,8 +2,7 @@ import type { CommandModule } from "yargs";
 import * as p from "../lib/clack.ts";
 import pc from "picocolors";
 import { runDoctor, type CheckResult, type ComponentReport, type DoctorReport } from "../lib/doctor.ts";
-import { createLocalHost } from "../lib/host.ts";
-import { connectRemoteHost } from "../lib/remote-host.ts";
+import { connectHost } from "../lib/remote-host.ts";
 
 // ─── Status symbols ──────────────────────────────────────────────────────────
 
@@ -99,7 +98,32 @@ export const doctorCommand: CommandModule = {
 
     p.intro(`xinity doctor${targetHostArg ? pc.dim(` → ${targetHostArg}`) : ""}`);
 
-    const host = targetHostArg ? await connectRemoteHost(targetHostArg) : createLocalHost();
+    let host;
+    try {
+      host = await connectHost(targetHostArg);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      const report: DoctorReport = {
+        timestamp: new Date().toISOString(),
+        components: [{
+          component: "connection",
+          installed: false,
+          version: null,
+          checks: [{ label: "SSH", status: "fail", message: `Cannot connect to target host: ${msg}` }],
+        }],
+        summary: { pass: 0, warn: 0, fail: 1, skip: 0 },
+      };
+      if (format === "json") {
+        process.stdout.write(JSON.stringify(report, null, 2) + "\n");
+      } else if (format === "yaml") {
+        process.stdout.write(Bun.YAML.stringify(report, null, 2));
+      } else {
+        renderReport(report, verbose);
+        p.outro(buildSummaryLine(report.summary));
+      }
+      process.exit(1);
+      return;
+    }
 
     let hasFailures = false;
     try {

--- a/packages/xinity-cli/src/commands/rm.ts
+++ b/packages/xinity-cli/src/commands/rm.ts
@@ -56,6 +56,11 @@ export const rmCommand: CommandModule = {
         return;
       }
 
+      if (!(await host.prepareElevation())) {
+        p.outro("Aborted");
+        return;
+      }
+
       if (component === "all") {
         await removeAll(purge, host);
         p.outro("Done");

--- a/packages/xinity-cli/src/commands/rm.ts
+++ b/packages/xinity-cli/src/commands/rm.ts
@@ -5,8 +5,7 @@ import { removeComponent, removeAll } from "../lib/install-remove.ts";
 import { runSteps } from "../lib/step-runner.ts";
 import type { Component } from "../lib/component-meta.ts";
 import { logErrors } from "../lib/output.ts";
-import { createLocalHost } from "../lib/host.ts";
-import { connectRemoteHost } from "../lib/remote-host.ts";
+import { connectHost } from "../lib/remote-host.ts";
 
 const COMPONENTS = ["gateway", "dashboard", "daemon", "infoserver", "all"] as const;
 
@@ -44,7 +43,7 @@ export const rmCommand: CommandModule = {
 
     p.intro(`xinity rm ${pc.cyan(component)}${purge ? pc.yellow(" --purge") : ""}${targetHostArg ? pc.dim(` → ${targetHostArg}`) : ""}`);
 
-    const host = targetHostArg ? await connectRemoteHost(targetHostArg) : createLocalHost();
+    const host = await connectHost(targetHostArg);
 
     try {
       const target = targetHostArg ? pc.cyan(targetHostArg) : "this machine";

--- a/packages/xinity-cli/src/commands/rm.ts
+++ b/packages/xinity-cli/src/commands/rm.ts
@@ -2,6 +2,7 @@ import type { CommandModule } from "yargs";
 import * as p from "../lib/clack.ts";
 import pc from "picocolors";
 import { removeComponent, removeAll } from "../lib/install-remove.ts";
+import { runSteps } from "../lib/step-runner.ts";
 import type { Component } from "../lib/component-meta.ts";
 import { logErrors } from "../lib/output.ts";
 import { createLocalHost } from "../lib/host.ts";
@@ -62,11 +63,11 @@ export const rmCommand: CommandModule = {
         return;
       }
 
-      const result = await removeComponent({
+      const result = await runSteps(removeComponent({
         component: component as Component,
         purge,
         host,
-      });
+      }));
 
       logErrors(result);
       p.outro("Done");

--- a/packages/xinity-cli/src/commands/rm.ts
+++ b/packages/xinity-cli/src/commands/rm.ts
@@ -1,11 +1,10 @@
 import type { CommandModule } from "yargs";
-import * as p from "../lib/clack.ts";
-import pc from "picocolors";
-import { removeComponent, removeAll } from "../lib/install-remove.ts";
-import { runSteps } from "../lib/step-runner.ts";
+import { cancel, confirm, intro, isCancel, outro } from "../lib/clack.ts";
+import { cyan, dim, yellow } from "picocolors";
+import { removeComponentCollapsed, removeAll } from "../lib/install-remove.ts";
 import type { Component } from "../lib/component-meta.ts";
 import { logErrors } from "../lib/output.ts";
-import { connectHost } from "../lib/remote-host.ts";
+import { connectHost, TARGET_HOST_OPTION } from "../lib/remote-host.ts";
 
 const COMPONENTS = ["gateway", "dashboard", "daemon", "infoserver", "all"] as const;
 
@@ -16,8 +15,8 @@ function buildRemovalConfirmMessage(component: string, purge: boolean, target: s
       : `Remove ALL Xinity components on ${target}?`;
   }
   return purge
-    ? `Remove ${pc.cyan(component)} and permanently delete its state data on ${target}?`
-    : `Remove ${pc.cyan(component)} on ${target}?`;
+    ? `Remove ${cyan(component)} and permanently delete its state data on ${target}?`
+    : `Remove ${cyan(component)} on ${target}?`;
 }
 
 export const rmCommand: CommandModule = {
@@ -35,46 +34,43 @@ export const rmCommand: CommandModule = {
         describe: "Also remove state data (logs, runtime files)",
         type: "boolean",
         default: false,
-      }),
+      })
+      .option("target-host", TARGET_HOST_OPTION),
   handler: async (argv) => {
     const component = argv.component as string;
     const purge = argv.purge as boolean;
     const targetHostArg = argv["target-host"] as string | undefined;
 
-    p.intro(`xinity rm ${pc.cyan(component)}${purge ? pc.yellow(" --purge") : ""}${targetHostArg ? pc.dim(` → ${targetHostArg}`) : ""}`);
+    intro(`xinity rm ${cyan(component)}${purge ? yellow(" --purge") : ""}${targetHostArg ? dim(` → ${targetHostArg}`) : ""}`);
 
     const host = await connectHost(targetHostArg);
 
     try {
-      const target = targetHostArg ? pc.cyan(targetHostArg) : "this machine";
-      const confirmed = await p.confirm({
+      const target = targetHostArg ? cyan(targetHostArg) : "this machine";
+      const confirmed = await confirm({
         message: buildRemovalConfirmMessage(component, purge, target),
         initialValue: false,
       });
-      if (p.isCancel(confirmed) || !confirmed) {
-        p.cancel("Cancelled.");
+      if (isCancel(confirmed) || !confirmed) {
+        cancel("Cancelled.");
         return;
       }
 
       if (!(await host.prepareElevation())) {
-        p.outro("Aborted");
+        outro("Aborted");
         return;
       }
 
       if (component === "all") {
         await removeAll(purge, host);
-        p.outro("Done");
+        outro("Done");
         return;
       }
 
-      const result = await runSteps(removeComponent({
-        component: component as Component,
-        purge,
-        host,
-      }));
+      const result = await removeComponentCollapsed({ component: component as Component, purge, host });
 
       logErrors(result);
-      p.outro("Done");
+      outro("Done");
     } finally {
       await host.dispose();
     }

--- a/packages/xinity-cli/src/commands/stack.ts
+++ b/packages/xinity-cli/src/commands/stack.ts
@@ -14,14 +14,13 @@ import {
   listStacks,
   validateStackName,
   getFleet,
-  getHost,
   getFleetForHost,
   hostLabel,
   claimFleetHosts,
   pruneFleetMembership,
 } from "../lib/stack.ts";
 import { editSharedLayer, editComponentLayer, editFleetLayer } from "../lib/stack-layers.ts";
-import { searchSelect, searchMultiselect, listSelect } from "../lib/search-list.ts";
+import { searchSelect, searchMultiselect, listSelect, type SearchListOption } from "../lib/search-list.ts";
 import { runStackFlow } from "../lib/stack-plan.ts";
 import { runDoctor, buildSummaryLine, type DoctorReport } from "../lib/doctor.ts";
 import { fetchRelease, listReleases, type ReleaseListEntry } from "../lib/github.ts";
@@ -268,14 +267,15 @@ async function editPinnedVersion(stack: StackDefinition, releasesPromise: Promis
       prerelease ? yellow("(prerelease)") : "",
       tag === stack.pinnedVersion ? green("(pinned)") : "",
     ].filter(Boolean);
-    const options = releases.map((r) => ({
+    // The manual-entry option is an object so it can never collide with a tag.
+    const options: SearchListOption<string | { manual: true }>[] = releases.map((r) => ({
       value: r.tagName,
       label: [r.tagName, ...markers(r.tagName, r.prerelease)].join(" "),
     }));
     if (!releases.some((r) => r.tagName === stack.pinnedVersion)) {
       options.push({ value: stack.pinnedVersion, label: `${stack.pinnedVersion} ${green("(pinned)")}` });
     }
-    options.push({ value: "__other__", label: dim("Enter a version manually") });
+    options.push({ value: { manual: true }, label: dim("Enter a version manually") });
 
     const choice = await promptOrUndefined(searchSelect({
       message: "Stack release version",
@@ -285,7 +285,7 @@ async function editPinnedVersion(stack: StackDefinition, releasesPromise: Promis
     if (choice === undefined) {
       return;
     }
-    version = choice === "__other__" ? await promptManualVersion(stack) : choice;
+    version = typeof choice === "string" ? choice : await promptManualVersion(stack);
   }
   if (version && version !== stack.pinnedVersion) {
     stack.pinnedVersion = version;
@@ -341,31 +341,30 @@ function claimFleetHostsLogged(stack: StackDefinition, fleet: FleetDefinition, m
 
 async function hostsMenu(stack: StackDefinition): Promise<void> {
   while (true) {
-    const choice = await promptOrUndefined(searchSelect({
+    // Hosts are the option values themselves, so the add/back entries can
+    // never collide with an address.
+    const choice = await promptOrUndefined(searchSelect<StackHost | "add" | "back">({
       message: "Hosts",
       transient: true,
       options: [
         ...stack.hosts.map((h) => ({
-          value: h.address,
+          value: h,
           label: hostLabel(h),
           hint: h.components.join(", "),
         })),
-        { value: "__add__", label: cyan("+ Add a host") },
-        { value: "__back__", label: dim("Back") },
+        { value: "add", label: cyan("+ Add a host") },
+        { value: "back", label: dim("Back") },
       ],
     }));
 
-    if (choice === undefined || choice === "__back__") {
+    if (choice === undefined || choice === "back") {
       return;
     }
-    if (choice === "__add__") {
+    if (choice === "add") {
       await addHostInteractive(stack);
       continue;
     }
-    const host = getHost(stack, choice);
-    if (host) {
-      await hostMenu(stack, host);
-    }
+    await hostMenu(stack, choice);
   }
 }
 
@@ -472,24 +471,26 @@ async function addHostInteractive(stack: StackDefinition): Promise<void> {
 
 async function fleetsMenu(stack: StackDefinition): Promise<void> {
   while (true) {
-    const choice = await promptOrUndefined(listSelect({
+    // Fleets are the option values themselves, so the add/back entries can
+    // never collide with a fleet name.
+    const choice = await promptOrUndefined(listSelect<FleetDefinition | "add" | "back">({
       message: "Fleets",
       transient: true,
       options: [
         ...stack.fleets.map((f) => ({
-          value: f.name,
+          value: f,
           label: f.name,
           hint: f.hosts.join(", "),
         })),
-        { value: "__add__", label: cyan("+ Add a fleet") },
-        { value: "__back__", label: dim("Back") },
+        { value: "add", label: cyan("+ Add a fleet") },
+        { value: "back", label: dim("Back") },
       ],
     }));
 
-    if (choice === undefined || choice === "__back__") {
+    if (choice === undefined || choice === "back") {
       return;
     }
-    if (choice === "__add__") {
+    if (choice === "add") {
       const fleet = await addFleetInteractive(stack);
       if (fleet) {
         // A fleet's daemon settings belong to the moment it is created;
@@ -498,10 +499,7 @@ async function fleetsMenu(stack: StackDefinition): Promise<void> {
       }
       continue;
     }
-    const fleet = getFleet(stack, choice);
-    if (fleet) {
-      await fleetMenu(stack, fleet);
-    }
+    await fleetMenu(stack, choice);
   }
 }
 

--- a/packages/xinity-cli/src/commands/stack.ts
+++ b/packages/xinity-cli/src/commands/stack.ts
@@ -1,0 +1,861 @@
+import type { CommandModule } from "yargs";
+import { intro, outro, cancel, note, log, select, confirm, text, multiselect } from "../lib/clack.ts";
+import { bold, cyan, dim, green, red, yellow } from "picocolors";
+import { promptOrExit, promptOrUndefined, fail, warn, heading } from "../lib/output.ts";
+import { type Component } from "../lib/component-meta.ts";
+import {
+  type StackDefinition,
+  type StackHost,
+  type FleetDefinition,
+  createStack,
+  loadStack,
+  saveStack,
+  deleteStack,
+  listStacks,
+  validateStack,
+  getFleet,
+  getHost,
+  hostLabel,
+} from "../lib/stack.ts";
+import { editSharedLayer, editComponentLayer, editFleetLayer } from "../lib/stack-layers.ts";
+import { searchSelect, searchMultiselect } from "../lib/search-list.ts";
+import { runStackFlow } from "../lib/stack-plan.ts";
+import { runDoctor, buildSummaryLine } from "../lib/doctor.ts";
+import { fetchRelease } from "../lib/github.ts";
+import { removeComponentCollapsed } from "../lib/install-remove.ts";
+import { connectHosts, forEachHost, disposeAll } from "../lib/multi-host.ts";
+
+const AVAILABLE_COMPONENTS: Component[] = ["gateway", "dashboard", "daemon", "infoserver"];
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+function requireStack(name: string): StackDefinition {
+  const stack = loadStack(name);
+  if (!stack) {
+    log.error(`Stack "${name}" not found`);
+    process.exit(1);
+  }
+  return stack;
+}
+
+function requireFleet(stack: StackDefinition, fleetName: string): FleetDefinition {
+  const fleet = getFleet(stack, fleetName);
+  if (!fleet) {
+    log.error(`Fleet "${fleetName}" not found in stack "${stack.name}"`);
+    process.exit(1);
+  }
+  return fleet;
+}
+
+async function resolveLatestTag(): Promise<string | null> {
+  try {
+    return (await fetchRelease("latest")).tagName;
+  } catch {
+    log.warn("Could not reach the release registry to check for updates");
+    return null;
+  }
+}
+
+/** Sets stack.pinnedVersion interactively. Returns false when no version could be determined. */
+async function promptPinnedVersion(stack: StackDefinition): Promise<boolean> {
+  const latest = await resolveLatestTag();
+  const version = await promptOrExit(text({
+    message: "Stack release version (every component is held at this version)",
+    defaultValue: latest ?? undefined,
+    placeholder: latest ?? "vX.Y.Z",
+    validate: (v) => (!v && !latest ? "A version is required" : undefined),
+  }));
+  const chosen = version || latest;
+  if (!chosen) {
+    return false;
+  }
+  stack.pinnedVersion = chosen;
+  return true;
+}
+
+function printStackSummary(stack: StackDefinition): void {
+  log.step(bold(`Stack: ${stack.name}`));
+
+  const envKeys = Object.keys(stack.env);
+  const secretKeys = Object.keys(stack.secrets);
+  if (envKeys.length > 0 || secretKeys.length > 0) {
+    log.info(bold("Shared"));
+    for (const key of envKeys) {
+      log.info(`  ${key} = ${cyan(stack.env[key])}`);
+    }
+    for (const key of secretKeys) {
+      log.info(`  ${key} = ${dim("••••••")}`);
+    }
+  }
+
+  for (const [component, values] of Object.entries(stack.componentEnv)) {
+    if (!values || Object.keys(values).length === 0) continue;
+    log.info(bold(component));
+    for (const [k, v] of Object.entries(values)) {
+      log.info(`  ${k} = ${cyan(v)}`);
+    }
+  }
+
+  const printOverrides = (overrides?: Record<string, string>) => {
+    for (const [k, v] of Object.entries(overrides ?? {})) {
+      log.info(`    ${dim(`${k} = ${v}`)}`);
+    }
+  };
+
+  if (stack.hosts.length > 0) {
+    log.info(bold("Hosts"));
+    for (const host of stack.hosts) {
+      log.info(`  ${hostLabel(host)}: ${host.components.map((c) => cyan(c)).join(", ")}`);
+      printOverrides(host.envOverrides);
+    }
+  }
+
+  if (stack.fleets.length > 0) {
+    log.info(bold("Fleets"));
+    for (const fleet of stack.fleets) {
+      log.info(`  ${fleet.name}: ${fleet.hosts.join(", ")}`);
+      printOverrides(fleet.envOverrides);
+    }
+  }
+}
+
+// ── Init ─────────────────────────────────────────────────────────────────
+
+async function handleInit(name: string): Promise<void> {
+  if (loadStack(name)) {
+    log.error(`Stack "${name}" already exists`);
+    process.exit(1);
+  }
+
+  const stack = createStack(name);
+  const nameError = validateStack(stack).find((e) => e.field === "name");
+  if (nameError) {
+    log.error(`Invalid stack name: ${nameError.message}`);
+    process.exit(1);
+  }
+
+  intro(`xinity stack init ${cyan(name)}`);
+
+  if (!(await promptPinnedVersion(stack))) {
+    cancel("Cancelled, stack not created.");
+    return;
+  }
+
+  const hostsOwnInfoserver = await promptOrExit(confirm({
+    message: "Will this stack host its own infoserver? (rarely needed; its URL is derived at deploy time)",
+    initialValue: false,
+  }));
+
+  // Daemon settings are deliberately absent here: they describe hardware
+  // pools and live on fleets (with an optional stack-wide baseline under
+  // `stack edit` → Component settings).
+  const components: Component[] = hostsOwnInfoserver
+    ? ["infoserver", "gateway", "dashboard"]
+    : ["gateway", "dashboard"];
+  if (hostsOwnInfoserver) {
+    // Marks the infoserver as stack-hosted, which hides INFOSERVER_URL from
+    // the shared editor; the URL is derived from its host at deploy time.
+    stack.componentEnv.infoserver = {};
+  } else {
+    stack.env.INFOSERVER_URL = "https://sysinfo.xinity.ai";
+  }
+
+  if (!(await editSharedLayer(stack))) {
+    cancel("Cancelled, stack not created.");
+    return;
+  }
+
+  for (const component of components) {
+    heading(component);
+    if (!(await editComponentLayer(stack, component))) {
+      cancel("Cancelled, stack not created.");
+      return;
+    }
+  }
+
+  saveStack(stack);
+  log.success("Stack saved and fully configured");
+  note(
+    [
+      `1. Add hosts and fleets:   ${cyan(`xinity stack edit ${name}`)}`,
+      `2. Deploy the stack:       ${cyan(`xinity stack up ${name}`)}`,
+      `3. Check health any time:  ${cyan(`xinity stack doctor ${name}`)}`,
+    ].join("\n"),
+    "Next steps",
+  );
+  outro("Done");
+}
+
+// ── Edit ─────────────────────────────────────────────────────────────────
+
+async function handleEdit(name: string, fleetName?: string): Promise<void> {
+  const stack = requireStack(name);
+  intro(`xinity stack edit ${cyan(name)}${fleetName ? ` · fleet ${cyan(fleetName)}` : ""}`);
+
+  if (fleetName) {
+    await editFleetLayer(stack, requireFleet(stack, fleetName));
+  } else {
+    // Escape at the top level behaves like Save & exit: submenu edits are
+    // already applied in memory and must not be discarded silently.
+    while (true) {
+      const choice = await promptOrUndefined(select({
+        message: "What would you like to edit?",
+        options: [
+          { value: "shared", label: `Shared settings (${Object.keys(stack.env).length + Object.keys(stack.secrets).length} set)` },
+          { value: "component", label: "Component settings (stack-wide per type)" },
+          { value: "version", label: `Release version (${stack.pinnedVersion ?? yellow("not set")})` },
+          { value: "hosts", label: `Hosts (${stack.hosts.length})` },
+          { value: "fleets", label: `Fleets (${stack.fleets.length})` },
+          { value: "save", label: green("Save & exit") },
+        ],
+      })) as string | undefined;
+
+      if (choice === undefined || choice === "save") {
+        break;
+      }
+      if (choice === "shared") {
+        await editSharedLayer(stack);
+      } else if (choice === "component") {
+        await editComponentSettings(stack);
+      } else if (choice === "version") {
+        await editPinnedVersion(stack);
+      } else if (choice === "hosts") {
+        await hostsMenu(stack);
+      } else if (choice === "fleets") {
+        await fleetsMenu(stack);
+      }
+    }
+  }
+
+  saveStack(stack);
+  log.success("Stack saved");
+  log.info(dim(`Apply changes to the hosts with: xinity stack up ${name}`));
+  outro("Done");
+}
+
+async function editPinnedVersion(stack: StackDefinition): Promise<void> {
+  const latest = await resolveLatestTag();
+  if (latest && stack.pinnedVersion && latest !== stack.pinnedVersion) {
+    log.info(`Latest available: ${cyan(latest)} (currently pinned to ${stack.pinnedVersion})`);
+  }
+  const version = await promptOrUndefined(text({
+    message: "Stack release version",
+    defaultValue: stack.pinnedVersion ?? latest ?? undefined,
+    placeholder: latest ?? "vX.Y.Z",
+  }));
+  if (version) {
+    stack.pinnedVersion = version;
+  }
+}
+
+async function editComponentSettings(stack: StackDefinition): Promise<void> {
+  const component = await promptOrUndefined(select({
+    message: "Which component type?",
+    options: AVAILABLE_COMPONENTS.map((c) => {
+      const count = Object.keys(stack.componentEnv[c] ?? {}).length;
+      return { value: c, label: `${c}${count > 0 ? dim(` (${count} set)`) : ""}` };
+    }),
+  })) as Component | undefined;
+  if (component) {
+    await editComponentLayer(stack, component);
+  }
+}
+
+/**
+ * Fleet membership is exclusive: hosts already in another fleet sort to the
+ * bottom, dimmed and marked; selecting one moves it into this fleet.
+ */
+function fleetHostOptions(stack: StackDefinition, fleet: FleetDefinition | null) {
+  const ownerOf = new Map<string, FleetDefinition>();
+  for (const other of stack.fleets) {
+    if (other === fleet) continue;
+    for (const addr of other.hosts) {
+      ownerOf.set(addr, other);
+    }
+  }
+
+  const free: { value: string; label: string; hint?: string }[] = [];
+  const taken: { value: string; label: string; hint?: string }[] = [];
+  for (const host of stack.hosts) {
+    if (!host.components.includes("daemon")) continue;
+    const owner = ownerOf.get(host.address);
+    if (owner) {
+      taken.push({
+        value: host.address,
+        label: dim(hostLabel(host)),
+        hint: `in fleet "${owner.name}"; selecting moves it here`,
+      });
+    } else {
+      free.push({ value: host.address, label: hostLabel(host) });
+    }
+  }
+
+  return [...free, ...taken];
+}
+
+/** Assign members to a fleet, pulling any that belonged to other fleets. */
+function claimFleetHosts(stack: StackDefinition, fleet: FleetDefinition, members: string[]): void {
+  const claimed = new Set(members);
+  fleet.hosts = members;
+  for (const other of stack.fleets) {
+    if (other === fleet) continue;
+    const remaining = other.hosts.filter((a) => !claimed.has(a));
+    if (remaining.length === 0 && other.hosts.length > 0) {
+      log.warn(`Fleet "${other.name}" lost its last host and was removed`);
+    }
+    other.hosts = remaining;
+  }
+  stack.fleets = stack.fleets.filter((f) => f.hosts.length > 0);
+}
+
+/** Hosts no longer running a daemon can't stay fleet members. */
+function pruneFleetMembership(stack: StackDefinition, address: string): void {
+  for (const fleet of stack.fleets) {
+    fleet.hosts = fleet.hosts.filter((a) => a !== address);
+  }
+  stack.fleets = stack.fleets.filter((f) => f.hosts.length > 0);
+}
+
+async function hostsMenu(stack: StackDefinition): Promise<void> {
+  while (true) {
+    const choice = await promptOrUndefined(searchSelect({
+      message: "Hosts",
+      options: [
+        ...stack.hosts.map((h) => ({
+          value: h.address,
+          label: hostLabel(h),
+          hint: h.components.join(", "),
+        })),
+        { value: "__add__", label: cyan("+ Add a host") },
+        { value: "__back__", label: dim("Back") },
+      ],
+    }));
+
+    if (choice === undefined || choice === "__back__") {
+      return;
+    }
+    if (choice === "__add__") {
+      await addHostInteractive(stack);
+      continue;
+    }
+    const host = getHost(stack, choice);
+    if (host) {
+      await hostMenu(stack, host);
+    }
+  }
+}
+
+async function hostMenu(stack: StackDefinition, host: StackHost): Promise<void> {
+  while (true) {
+    const choice = await promptOrUndefined(select({
+      message: hostLabel(host),
+      options: [
+        { value: "components", label: `Components (${host.components.join(", ") || yellow("none")})` },
+        { value: "alias", label: `Alias (${host.alias ?? "not set"})` },
+        { value: "remove", label: red("Remove this host from the stack") },
+        { value: "back", label: dim("Back") },
+      ],
+    })) as string | undefined;
+
+    if (choice === undefined || choice === "back") {
+      return;
+    }
+
+    if (choice === "components") {
+      const components = await promptOrUndefined(multiselect({
+        message: `Components for ${host.address}`,
+        options: AVAILABLE_COMPONENTS.map((c) => ({ value: c, label: c })),
+        initialValues: host.components,
+        required: true,
+      })) as Component[] | undefined;
+      if (!components) {
+        continue;
+      }
+      host.components = components;
+      if (!components.includes("daemon")) {
+        pruneFleetMembership(stack, host.address);
+      }
+      continue;
+    }
+
+    if (choice === "alias") {
+      const alias = await promptOrUndefined(text({
+        message: "Alias (leave empty to remove)",
+        placeholder: host.alias ?? "friendly-name",
+      }));
+      if (alias === undefined) {
+        continue;
+      }
+      if (alias) {
+        host.alias = alias;
+      } else {
+        delete host.alias;
+      }
+      continue;
+    }
+
+    if (choice === "remove") {
+      const confirmed = await promptOrUndefined(confirm({
+        message: `Remove ${hostLabel(host)} from the stack? (nothing is uninstalled)`,
+        initialValue: false,
+      }));
+      if (confirmed) {
+        stack.hosts = stack.hosts.filter((h) => h.address !== host.address);
+        pruneFleetMembership(stack, host.address);
+        log.success(`Removed ${host.address}`);
+        return;
+      }
+    }
+  }
+}
+
+async function addHostInteractive(stack: StackDefinition): Promise<void> {
+  const address = await promptOrUndefined(text({
+    message: "SSH address (or 'local')",
+    placeholder: "user@hostname",
+  }));
+  if (!address) {
+    return;
+  }
+  if (stack.hosts.some((h) => h.address === address)) {
+    log.warn(`Host ${address} already exists in this stack`);
+    return;
+  }
+
+  const components = await promptOrUndefined(multiselect({
+    message: `Components for ${address}`,
+    options: AVAILABLE_COMPONENTS.map((c) => ({ value: c, label: c })),
+    required: true,
+  })) as Component[] | undefined;
+  if (!components) {
+    return;
+  }
+
+  const host: StackHost = { address, components };
+
+  const setAlias = await promptOrUndefined(confirm({ message: "Set an alias?", initialValue: false }));
+  if (setAlias) {
+    const alias = await promptOrUndefined(text({ message: "Alias" }));
+    if (alias) {
+      host.alias = alias;
+    }
+  }
+
+  stack.hosts.push(host);
+  log.success(`Added ${address}`);
+}
+
+async function fleetsMenu(stack: StackDefinition): Promise<void> {
+  while (true) {
+    const choice = await promptOrUndefined(select({
+      message: "Fleets",
+      options: [
+        ...stack.fleets.map((f) => ({
+          value: f.name,
+          label: f.name,
+          hint: f.hosts.join(", "),
+        })),
+        { value: "__add__", label: cyan("+ Add a fleet") },
+        { value: "__back__", label: dim("Back") },
+      ],
+    })) as string | undefined;
+
+    if (choice === undefined || choice === "__back__") {
+      return;
+    }
+    if (choice === "__add__") {
+      const fleet = await addFleetInteractive(stack);
+      if (fleet) {
+        // A fleet's daemon settings belong to the moment it is created;
+        // saving the editor untouched keeps the stack-wide baseline.
+        await editFleetLayer(stack, fleet);
+      }
+      continue;
+    }
+    const fleet = getFleet(stack, choice);
+    if (fleet) {
+      await fleetMenu(stack, fleet);
+    }
+  }
+}
+
+async function fleetMenu(stack: StackDefinition, fleet: FleetDefinition): Promise<void> {
+  while (true) {
+    const choice = await promptOrUndefined(select({
+      message: `Fleet "${fleet.name}"`,
+      options: [
+        { value: "settings", label: `Daemon settings (${Object.keys(fleet.envOverrides ?? {}).length} override(s))` },
+        { value: "hosts", label: `Hosts (${fleet.hosts.join(", ") || yellow("none")})` },
+        { value: "remove", label: red("Remove this fleet") },
+        { value: "back", label: dim("Back") },
+      ],
+    })) as string | undefined;
+
+    if (choice === undefined || choice === "back") {
+      return;
+    }
+
+    if (choice === "settings") {
+      await editFleetLayer(stack, fleet);
+      continue;
+    }
+
+    if (choice === "hosts") {
+      if (!stack.hosts.some((h) => h.components.includes("daemon"))) {
+        log.warn("No hosts with the daemon component in this stack");
+        continue;
+      }
+      const members = await promptOrUndefined(searchMultiselect({
+        message: `Daemon hosts in "${fleet.name}"`,
+        options: fleetHostOptions(stack, fleet),
+        initialValues: fleet.hosts,
+        required: true,
+      }));
+      if (members) {
+        claimFleetHosts(stack, fleet, members);
+      }
+      continue;
+    }
+
+    if (choice === "remove") {
+      const confirmed = await promptOrUndefined(confirm({
+        message: `Remove fleet "${fleet.name}"? (hosts and their daemons stay)`,
+        initialValue: false,
+      }));
+      if (confirmed) {
+        stack.fleets = stack.fleets.filter((f) => f.name !== fleet.name);
+        log.success(`Fleet "${fleet.name}" removed`);
+        return;
+      }
+    }
+  }
+}
+
+async function addFleetInteractive(stack: StackDefinition): Promise<FleetDefinition | null> {
+  const daemonHosts = stack.hosts.filter((h) => h.components.includes("daemon"));
+  if (daemonHosts.length === 0) {
+    log.warn("No hosts with the daemon component to form a fleet");
+    return null;
+  }
+
+  const fleetName = await promptOrUndefined(text({ message: "Fleet name", placeholder: "e.g. gpu-pool" }));
+  if (!fleetName) {
+    return null;
+  }
+  if (stack.fleets.some((f) => f.name === fleetName)) {
+    log.warn(`Fleet "${fleetName}" already exists`);
+    return null;
+  }
+
+  const members = await promptOrUndefined(searchMultiselect({
+    message: "Select daemon hosts",
+    options: fleetHostOptions(stack, null),
+    required: true,
+  }));
+  if (!members) {
+    return null;
+  }
+
+  const fleet: FleetDefinition = { name: fleetName, hosts: [] };
+  stack.fleets.push(fleet);
+  claimFleetHosts(stack, fleet, members);
+  log.success(`Fleet "${fleetName}" created with ${members.length} host(s)`);
+  return fleet;
+}
+
+// ── Up ───────────────────────────────────────────────────────────────────
+
+async function handleUp(name: string, versionFlag?: string): Promise<void> {
+  const stack = requireStack(name);
+  intro(`xinity stack up ${cyan(name)}`);
+
+  // The stack is held at its pinned version; updates only on express intent
+  // (the --target-version flag, or saying yes to the update offer).
+  if (versionFlag) {
+    try {
+      stack.pinnedVersion = (await fetchRelease(versionFlag)).tagName;
+    } catch (err) {
+      log.error(`Could not resolve version ${versionFlag}: ${(err as Error).message}`);
+      outro("Failed");
+      process.exit(1);
+    }
+    saveStack(stack);
+  } else if (!stack.pinnedVersion) {
+    if (!(await promptPinnedVersion(stack))) {
+      outro("Aborted");
+      return;
+    }
+    saveStack(stack);
+  } else {
+    const latest = await resolveLatestTag();
+    if (latest && latest !== stack.pinnedVersion) {
+      const update = await promptOrExit(confirm({
+        message: `A newer release is available. Update the stack from ${stack.pinnedVersion} to ${latest}?`,
+        initialValue: false,
+      }));
+      if (update) {
+        stack.pinnedVersion = latest;
+        saveStack(stack);
+      }
+    }
+  }
+  log.info(`Stack version: ${cyan(stack.pinnedVersion!)}`);
+
+  const ok = await runStackFlow(stack, { targetVersion: stack.pinnedVersion! });
+  outro(ok ? "Done" : "Failed");
+  if (!ok) {
+    process.exit(1);
+  }
+}
+
+// ── Doctor ────────────────────────────────────────────────────────────────
+
+async function handleDoctor(name: string, fleetName?: string): Promise<void> {
+  const stack = requireStack(name);
+  const addresses = fleetName
+    ? requireFleet(stack, fleetName).hosts
+    : stack.hosts.map((h) => h.address);
+  intro(`xinity stack doctor ${cyan(name)}${fleetName ? ` · fleet ${cyan(fleetName)}` : ""}`);
+
+  if (addresses.length === 0) {
+    log.warn("No hosts to check");
+    outro("Nothing to do");
+    return;
+  }
+
+  const hosts = await connectHosts(addresses);
+  if (!hosts) {
+    outro("Failed");
+    process.exit(1);
+  }
+
+  let totalFailed = 0;
+  try {
+    await forEachHost(hosts, async (host) => {
+      const report = await runDoctor({ host, interactive: false });
+      totalFailed += report.summary.fail;
+
+      for (const component of report.components) {
+        for (const check of component.checks) {
+          if (check.status === "fail") {
+            fail(`${component.component} · ${check.label}`, check.message);
+          } else if (check.status === "warn") {
+            warn(`${component.component} · ${check.label}`, check.message);
+          }
+        }
+      }
+
+      log.info(buildSummaryLine(report.summary));
+    });
+  } finally {
+    await disposeAll(hosts);
+  }
+
+  outro(totalFailed > 0 ? red("Some checks failed") : green("All checks passed"));
+  if (totalFailed > 0) {
+    process.exit(1);
+  }
+}
+
+async function handleRm(name: string): Promise<void> {
+  const stack = requireStack(name);
+  intro(`xinity stack rm ${cyan(name)}`);
+
+  if (stack.hosts.length === 0) {
+    const confirmed = await promptOrExit(confirm({
+      message: `Delete stack "${name}"?`,
+      initialValue: false,
+    }));
+    if (!confirmed) {
+      outro("Aborted");
+      return;
+    }
+    deleteStack(name);
+    log.success(`Stack "${name}" deleted`);
+    outro("Done");
+    return;
+  }
+
+  log.info(bold("Tracked hosts:"));
+  for (const host of stack.hosts) {
+    log.info(`  ${host.address}: ${host.components.join(", ")}`);
+  }
+
+  const choice = await promptOrExit(select({
+    message: `How should "${name}" be removed?`,
+    options: [
+      { value: "local", label: "Remove the local stack definition only", hint: "hosts stay untouched" },
+      { value: "teardown", label: `Uninstall all tracked components from ${stack.hosts.length} host(s), then remove the definition`, hint: "best effort" },
+      { value: "abort", label: "Abort" },
+    ],
+  })) as string;
+
+  if (choice === "abort") {
+    outro("Aborted");
+    return;
+  }
+
+  if (choice === "teardown") {
+    const done = await teardownHosts(
+      stack.hosts.map((h) => h.address),
+      (address) => getHost(stack, address)?.components ?? [],
+    );
+    if (!done) {
+      log.error("Could not reach all hosts; nothing was removed and the stack definition was kept.");
+      outro("Failed");
+      process.exit(1);
+    }
+  }
+
+  deleteStack(name);
+  log.success(`Stack "${name}" deleted`);
+  outro("Done");
+}
+
+/** Best-effort removal across hosts; failures are reported and treated as removed. */
+async function teardownHosts(
+  addresses: string[],
+  componentsFor: (address: string) => Component[],
+): Promise<boolean> {
+  const hosts = await connectHosts(addresses);
+  if (!hosts) {
+    return false;
+  }
+  try {
+    await forEachHost(hosts, async (host, address) => {
+      for (const component of componentsFor(address)) {
+        const result = await removeComponentCollapsed({ component, host });
+        if (!result.success) {
+          warn(component, `Not fully removed (${result.errors.join(", ")}); treating it as deleted`);
+        }
+      }
+    });
+    return true;
+  } finally {
+    await disposeAll(hosts);
+  }
+}
+
+/** `stack rm <name> --fleet <fleet>`: remove the fleet concept, or tear its daemons down too. */
+async function handleRmFleet(name: string, fleetName: string): Promise<void> {
+  const stack = requireStack(name);
+  const fleet = requireFleet(stack, fleetName);
+  intro(`xinity stack rm ${cyan(name)} · fleet ${cyan(fleetName)}`);
+
+  let choice = "concept";
+  if (fleet.hosts.length > 0) {
+    log.info(bold("Fleet hosts:"));
+    for (const addr of fleet.hosts) {
+      log.info(`  ${addr}`);
+    }
+
+    choice = await promptOrExit(select({
+      message: `How should fleet "${fleetName}" be removed?`,
+      options: [
+        { value: "concept", label: "Remove the fleet definition only", hint: "hosts and their daemons stay untouched" },
+        { value: "teardown", label: `Uninstall the daemon from ${fleet.hosts.length} host(s), then remove the fleet`, hint: "best effort" },
+        { value: "abort", label: "Abort" },
+      ],
+    })) as string;
+  } else {
+    const confirmed = await promptOrExit(confirm({
+      message: `Remove fleet "${fleetName}"?`,
+      initialValue: false,
+    }));
+    if (!confirmed) {
+      choice = "abort";
+    }
+  }
+
+  if (choice === "abort") {
+    outro("Aborted");
+    return;
+  }
+
+  if (choice === "teardown") {
+    if (!(await teardownHosts(fleet.hosts, () => ["daemon"]))) {
+      log.error("Could not reach all hosts; nothing was removed and the fleet was kept.");
+      outro("Failed");
+      process.exit(1);
+    }
+
+    // The stack must stop expecting daemons here, or the next `stack up`
+    // would simply reinstall what was just torn down.
+    for (const addr of fleet.hosts) {
+      const stackHost = getHost(stack, addr);
+      if (stackHost) {
+        stackHost.components = stackHost.components.filter((c) => c !== "daemon");
+      }
+    }
+    stack.hosts = stack.hosts.filter((h) => h.components.length > 0);
+  }
+
+  stack.fleets = stack.fleets.filter((f) => f.name !== fleetName);
+  saveStack(stack);
+  log.success(`Fleet "${fleetName}" removed`);
+  outro("Done");
+}
+
+// ── Command module ───────────────────────────────────────────────────────
+
+export const stackCommand: CommandModule = {
+  command: "stack <action>",
+  describe: "Manage deployment stacks",
+  builder: (yargs) =>
+    yargs
+      .command("init <name>", "Create a new stack (shared settings only)", (y) =>
+        y.positional("name", { type: "string", demandOption: true, describe: "Stack name" }),
+      (argv) => handleInit(argv.name as string))
+      .command("ls", "List all stacks", {}, () => {
+        const names = listStacks();
+        if (names.length === 0) {
+          log.info("No stacks defined");
+          return;
+        }
+        for (const name of names) {
+          const stack = loadStack(name);
+          if (stack) {
+            const hostCount = stack.hosts.length;
+            const fleetCount = stack.fleets.length;
+            log.info(`  ${cyan(name)}  ${dim(`${hostCount} host(s), ${fleetCount} fleet(s)`)}`);
+          }
+        }
+      })
+      .command("show <name>", "Display stack details", (y) =>
+        y.positional("name", { type: "string", demandOption: true, describe: "Stack name" }),
+      (argv) => {
+        const stack = requireStack(argv.name as string);
+        printStackSummary(stack);
+      })
+      .command("edit <name>", "Edit a stack", (y) =>
+        y
+          .positional("name", { type: "string", demandOption: true, describe: "Stack name" })
+          .option("fleet", { type: "string", describe: "Jump straight to a fleet's daemon settings" }),
+      (argv) => handleEdit(argv.name as string, argv.fleet as string | undefined))
+      .command("rm <name>", "Delete a stack, or remove the daemon from a fleet's hosts (--fleet)", (y) =>
+        y
+          .positional("name", { type: "string", demandOption: true, describe: "Stack name" })
+          .option("fleet", { type: "string", describe: "Remove the daemon from this fleet's hosts instead of deleting the stack" }),
+      (argv) => {
+        const fleetName = argv.fleet as string | undefined;
+        return fleetName
+          ? handleRmFleet(argv.name as string, fleetName)
+          : handleRm(argv.name as string);
+      })
+      .command("up <name>", "Plan and apply the whole stack at its pinned version", (y) =>
+        y
+          .positional("name", { type: "string", demandOption: true, describe: "Stack name" })
+          .option("target-version", {
+            describe: "Pin the stack to this release and deploy it (defaults to the stack's pinned version)",
+            type: "string",
+          }),
+      (argv) => handleUp(argv.name as string, argv["target-version"] as string | undefined))
+      .command(["doctor <name>", "status <name>"], "Health check the stack's hosts", (y) =>
+        y
+          .positional("name", { type: "string", demandOption: true, describe: "Stack name" })
+          .option("fleet", { type: "string", describe: "Only check this fleet's hosts" }),
+      (argv) => handleDoctor(argv.name as string, argv.fleet as string | undefined))
+      .demandCommand(1, "Specify a stack action")
+      .strict(),
+  handler: () => {},
+};

--- a/packages/xinity-cli/src/commands/stack.ts
+++ b/packages/xinity-cli/src/commands/stack.ts
@@ -571,43 +571,52 @@ async function addFleetInteractive(stack: StackDefinition): Promise<FleetDefinit
 
 // ── Up ───────────────────────────────────────────────────────────────────
 
-async function handleUp(name: string, versionFlag?: string): Promise<void> {
+async function handleUp(name: string, versionFlag: string | undefined, dryRun: boolean): Promise<void> {
   const stack = requireStack(name);
-  intro(`xinity stack up ${cyan(name)}`);
+  intro(`xinity stack up ${cyan(name)}${dryRun ? yellow(" (dry run)") : ""}`);
 
   // The stack is held at its pinned version; updates only on express intent
-  // (the --target-version flag, or saying yes to the update offer).
+  // (the --target-version flag, or saying yes to the update offer). A dry
+  // run never moves the pin and skips the update offer.
+  let targetVersion: string;
   if (versionFlag) {
     try {
-      stack.pinnedVersion = (await fetchRelease(versionFlag)).tagName;
+      targetVersion = (await fetchRelease(versionFlag)).tagName;
     } catch (err) {
       log.error(`Could not resolve version ${versionFlag}: ${(err as Error).message}`);
       outro("Failed");
       process.exit(1);
     }
-    saveStack(stack);
+    if (!dryRun) {
+      stack.pinnedVersion = targetVersion;
+      saveStack(stack);
+    }
   } else if (!stack.pinnedVersion) {
     if (!(await promptPinnedVersion(stack))) {
       outro("Aborted");
       return;
     }
     saveStack(stack);
+    targetVersion = stack.pinnedVersion!;
   } else {
-    const latest = await resolveLatestTag();
-    if (latest && latest !== stack.pinnedVersion) {
-      const update = await promptOrExit(confirm({
-        message: `A newer release is available. Update the stack from ${stack.pinnedVersion} to ${latest}?`,
-        initialValue: false,
-      }));
-      if (update) {
-        stack.pinnedVersion = latest;
-        saveStack(stack);
+    if (!dryRun) {
+      const latest = await resolveLatestTag();
+      if (latest && latest !== stack.pinnedVersion) {
+        const update = await promptOrExit(confirm({
+          message: `A newer release is available. Update the stack from ${stack.pinnedVersion} to ${latest}?`,
+          initialValue: false,
+        }));
+        if (update) {
+          stack.pinnedVersion = latest;
+          saveStack(stack);
+        }
       }
     }
+    targetVersion = stack.pinnedVersion;
   }
-  log.info(`Stack version: ${cyan(stack.pinnedVersion!)}`);
+  log.info(`Stack version: ${cyan(targetVersion)}`);
 
-  const ok = await runStackFlow(stack, { targetVersion: stack.pinnedVersion! });
+  const ok = await runStackFlow(stack, { targetVersion, dryRun });
   outro(ok ? "Done" : "Failed");
   if (!ok) {
     process.exit(1);
@@ -754,8 +763,13 @@ export const stackCommand: CommandModule = {
           .option("target-version", {
             describe: "Pin the stack to this release and deploy it (defaults to the stack's pinned version)",
             type: "string",
+          })
+          .option("dry-run", {
+            describe: "Show the planned actions without applying them",
+            type: "boolean",
+            default: false,
           }),
-      (argv) => handleUp(argv.name as string, argv["target-version"] as string | undefined))
+      (argv) => handleUp(argv.name as string, argv["target-version"] as string | undefined, argv["dry-run"] as boolean))
       .command(["doctor <name>", "status <name>"], "Health check the stack's hosts", (y) =>
         y
           .positional("name", { type: "string", demandOption: true, describe: "Stack name", ...stackNameChoices() })

--- a/packages/xinity-cli/src/commands/stack.ts
+++ b/packages/xinity-cli/src/commands/stack.ts
@@ -12,7 +12,7 @@ import {
   saveStack,
   deleteStack,
   listStacks,
-  validateStack,
+  validateStackName,
   getFleet,
   getHost,
   getFleetForHost,
@@ -24,7 +24,7 @@ import { editSharedLayer, editComponentLayer, editFleetLayer } from "../lib/stac
 import { searchSelect, searchMultiselect, listSelect } from "../lib/search-list.ts";
 import { runStackFlow } from "../lib/stack-plan.ts";
 import { runDoctor, buildSummaryLine, type DoctorReport } from "../lib/doctor.ts";
-import { fetchRelease } from "../lib/github.ts";
+import { fetchRelease, listReleases, type ReleaseListEntry } from "../lib/github.ts";
 import { loadStackState, findOrphanHosts } from "../lib/stack-state.ts";
 import { connectHosts, disposeAll } from "../lib/multi-host.ts";
 
@@ -72,26 +72,9 @@ async function resolveLatestTag(): Promise<string | null> {
   try {
     return (await fetchRelease("latest")).tagName;
   } catch {
-    log.warn("Could not reach the release registry to check for updates");
+    log.warn("Could not reach the release registry");
     return null;
   }
-}
-
-/** Sets stack.pinnedVersion interactively. Returns false when no version could be determined. */
-async function promptPinnedVersion(stack: StackDefinition): Promise<boolean> {
-  const latest = await resolveLatestTag();
-  const version = await promptOrExit(text({
-    message: "Stack release version (every component is held at this version)",
-    defaultValue: latest ?? undefined,
-    placeholder: latest ?? "vX.Y.Z",
-    validate: (v) => (!v && !latest ? "A version is required" : undefined),
-  }));
-  const chosen = version || latest;
-  if (!chosen) {
-    return false;
-  }
-  stack.pinnedVersion = chosen;
-  return true;
 }
 
 function printStackSummary(stack: StackDefinition): void {
@@ -150,19 +133,23 @@ async function handleInit(name: string): Promise<void> {
     process.exit(1);
   }
 
-  const stack = createStack(name);
-  const nameError = validateStack(stack).find((e) => e.field === "name");
+  const nameError = validateStackName(name);
   if (nameError) {
-    log.error(`Invalid stack name: ${nameError.message}`);
+    log.error(`Invalid stack name: ${nameError}`);
     process.exit(1);
   }
 
   intro(`xinity stack init ${cyan(name)}`);
 
-  if (!(await promptPinnedVersion(stack))) {
-    cancel("Cancelled, stack not created.");
-    return;
+  // New stacks pin the latest release; re-pinning happens in stack edit.
+  const latest = await resolveLatestTag();
+  if (!latest) {
+    log.error("A release version is required to create a stack");
+    outro("Failed");
+    process.exit(1);
   }
+  const stack = createStack(name, latest);
+  log.info(`Release version: ${cyan(latest)} (every component is held at this version)`);
 
   const hostsOwnInfoserver = await promptOrExit(confirm({
     message: "Will this stack host its own infoserver? (rarely needed; its URL is derived at deploy time)",
@@ -218,6 +205,9 @@ async function handleEdit(name: string, fleetName?: string): Promise<void> {
   if (fleetName) {
     await editFleetLayer(stack, requireFleet(stack, fleetName));
   } else {
+    // Fetched in the background so the version menu opens without waiting.
+    const releasesPromise: Promise<ReleaseListEntry[]> = listReleases().catch(() => []);
+
     // Escape at the top level behaves like Save & exit: submenu edits are
     // already applied in memory and must not be discarded silently.
     while (true) {
@@ -227,7 +217,7 @@ async function handleEdit(name: string, fleetName?: string): Promise<void> {
         options: [
           { value: "shared", label: `Shared settings (${Object.keys(stack.env).length + Object.keys(stack.secrets).length} set)` },
           { value: "component", label: "Component settings (stack-wide per type)" },
-          { value: "version", label: `Release version (${stack.pinnedVersion ?? yellow("not set")})` },
+          { value: "version", label: `Release version (${stack.pinnedVersion})` },
           { value: "hosts", label: `Hosts (${stack.hosts.length})` },
           { value: "fleets", label: `Fleets (${stack.fleets.length})` },
           { value: "save", label: green("Save & exit") },
@@ -242,7 +232,7 @@ async function handleEdit(name: string, fleetName?: string): Promise<void> {
       } else if (choice === "component") {
         await editComponentSettings(stack);
       } else if (choice === "version") {
-        await editPinnedVersion(stack);
+        await editPinnedVersion(stack, releasesPromise);
       } else if (choice === "hosts") {
         await hostsMenu(stack);
       } else if (choice === "fleets") {
@@ -257,18 +247,49 @@ async function handleEdit(name: string, fleetName?: string): Promise<void> {
   outro("Done");
 }
 
-async function editPinnedVersion(stack: StackDefinition): Promise<void> {
-  const latest = await resolveLatestTag();
-  if (latest && stack.pinnedVersion && latest !== stack.pinnedVersion) {
-    log.info(`Latest available: ${cyan(latest)} (currently pinned to ${stack.pinnedVersion})`);
-  }
-  const version = await promptOrUndefined(text({
+function promptManualVersion(stack: StackDefinition): Promise<string | undefined> {
+  return promptOrUndefined(text({
     message: "Stack release version",
-    defaultValue: stack.pinnedVersion ?? latest ?? undefined,
-    placeholder: latest ?? "vX.Y.Z",
+    defaultValue: stack.pinnedVersion,
+    placeholder: "vX.Y.Z",
   }));
-  if (version) {
+}
+
+async function editPinnedVersion(stack: StackDefinition, releasesPromise: Promise<ReleaseListEntry[]>): Promise<void> {
+  const releases = await releasesPromise;
+  let version: string | undefined;
+  if (releases.length === 0) {
+    // Registry unreachable (or no releases yet): manual entry is all we have.
+    version = await promptManualVersion(stack);
+  } else {
+    const latestStable = releases.find((r) => !r.prerelease)?.tagName;
+    const markers = (tag: string, prerelease: boolean) => [
+      tag === latestStable ? cyan("(latest)") : "",
+      prerelease ? yellow("(prerelease)") : "",
+      tag === stack.pinnedVersion ? green("(pinned)") : "",
+    ].filter(Boolean);
+    const options = releases.map((r) => ({
+      value: r.tagName,
+      label: [r.tagName, ...markers(r.tagName, r.prerelease)].join(" "),
+    }));
+    if (!releases.some((r) => r.tagName === stack.pinnedVersion)) {
+      options.push({ value: stack.pinnedVersion, label: `${stack.pinnedVersion} ${green("(pinned)")}` });
+    }
+    options.push({ value: "__other__", label: dim("Enter a version manually") });
+
+    const choice = await promptOrUndefined(searchSelect({
+      message: "Stack release version",
+      transient: true,
+      options,
+    }));
+    if (choice === undefined) {
+      return;
+    }
+    version = choice === "__other__" ? await promptManualVersion(stack) : choice;
+  }
+  if (version && version !== stack.pinnedVersion) {
     stack.pinnedVersion = version;
+    log.success(`Pinned version set to ${cyan(version)}`);
   }
 }
 
@@ -576,8 +597,7 @@ async function handleUp(name: string, versionFlag: string | undefined, dryRun: b
   intro(`xinity stack up ${cyan(name)}${dryRun ? yellow(" (dry run)") : ""}`);
 
   // The stack is held at its pinned version; updates only on express intent
-  // (the --target-version flag, or saying yes to the update offer). A dry
-  // run never moves the pin and skips the update offer.
+  // (the --target-version flag, or re-pinning in stack edit).
   let targetVersion: string;
   if (versionFlag) {
     try {
@@ -591,27 +611,7 @@ async function handleUp(name: string, versionFlag: string | undefined, dryRun: b
       stack.pinnedVersion = targetVersion;
       saveStack(stack);
     }
-  } else if (!stack.pinnedVersion) {
-    if (!(await promptPinnedVersion(stack))) {
-      outro("Aborted");
-      return;
-    }
-    saveStack(stack);
-    targetVersion = stack.pinnedVersion!;
   } else {
-    if (!dryRun) {
-      const latest = await resolveLatestTag();
-      if (latest && latest !== stack.pinnedVersion) {
-        const update = await promptOrExit(confirm({
-          message: `A newer release is available. Update the stack from ${stack.pinnedVersion} to ${latest}?`,
-          initialValue: false,
-        }));
-        if (update) {
-          stack.pinnedVersion = latest;
-          saveStack(stack);
-        }
-      }
-    }
     targetVersion = stack.pinnedVersion;
   }
   log.info(`Stack version: ${cyan(targetVersion)}`);

--- a/packages/xinity-cli/src/commands/stack.ts
+++ b/packages/xinity-cli/src/commands/stack.ts
@@ -25,7 +25,7 @@ import { runStackFlow } from "../lib/stack-plan.ts";
 import { runDoctor, buildSummaryLine, type DoctorReport } from "../lib/doctor.ts";
 import { fetchRelease, listReleases, type ReleaseListEntry } from "../lib/github.ts";
 import { loadStackState, findOrphanHosts } from "../lib/stack-state.ts";
-import { connectHosts, disposeAll } from "../lib/multi-host.ts";
+import { connectHosts, disposeAll, mapBounded, HOST_CONCURRENCY } from "../lib/multi-host.ts";
 
 const AVAILABLE_COMPONENTS: Component[] = ["gateway", "dashboard", "daemon", "infoserver"];
 
@@ -647,13 +647,13 @@ async function handleDoctor(name: string, fleetName?: string): Promise<void> {
     // Checks are collected on all hosts at once (runDoctor stays silent when
     // non-interactive) and rendered afterwards in host order.
     type DoctorEntry = { address: string; report: DoctorReport } | { address: string; error: string };
-    const reports = await Promise.all([...hosts.entries()].map(async ([address, host]): Promise<DoctorEntry> => {
+    const reports = await mapBounded([...hosts.entries()], HOST_CONCURRENCY, async ([address, host]): Promise<DoctorEntry> => {
       try {
         return { address, report: await runDoctor({ host, interactive: false }) };
       } catch (err) {
         return { address, error: err instanceof Error ? err.message : String(err) };
       }
-    }));
+    });
 
     for (const entry of reports) {
       heading(entry.address);

--- a/packages/xinity-cli/src/commands/stack.ts
+++ b/packages/xinity-cli/src/commands/stack.ts
@@ -1,5 +1,5 @@
 import type { CommandModule } from "yargs";
-import { intro, outro, cancel, note, log, select, confirm, text, multiselect } from "../lib/clack.ts";
+import { intro, outro, cancel, note, log, confirm, text, multiselect } from "../lib/clack.ts";
 import { bold, cyan, dim, green, red, yellow } from "picocolors";
 import { promptOrExit, promptOrUndefined, fail, warn, heading } from "../lib/output.ts";
 import { type Component } from "../lib/component-meta.ts";
@@ -15,19 +15,40 @@ import {
   validateStack,
   getFleet,
   getHost,
+  getFleetForHost,
   hostLabel,
+  claimFleetHosts,
+  pruneFleetMembership,
 } from "../lib/stack.ts";
 import { editSharedLayer, editComponentLayer, editFleetLayer } from "../lib/stack-layers.ts";
-import { searchSelect, searchMultiselect } from "../lib/search-list.ts";
+import { searchSelect, searchMultiselect, listSelect } from "../lib/search-list.ts";
 import { runStackFlow } from "../lib/stack-plan.ts";
-import { runDoctor, buildSummaryLine } from "../lib/doctor.ts";
+import { runDoctor, buildSummaryLine, type DoctorReport } from "../lib/doctor.ts";
 import { fetchRelease } from "../lib/github.ts";
-import { removeComponentCollapsed } from "../lib/install-remove.ts";
-import { connectHosts, forEachHost, disposeAll } from "../lib/multi-host.ts";
+import { loadStackState, findOrphanHosts } from "../lib/stack-state.ts";
+import { connectHosts, disposeAll } from "../lib/multi-host.ts";
 
 const AVAILABLE_COMPONENTS: Component[] = ["gateway", "dashboard", "daemon", "infoserver"];
 
 // ── Helpers ──────────────────────────────────────────────────────────────
+
+// Shell completion runs the yargs builder with these choices; outside of it
+// they stay off so unknown names hit our own error messages, and `init`
+// keeps accepting fresh names.
+const completing = process.argv.includes("--get-yargs-completions");
+
+function stackNameChoices(): { choices?: string[] } {
+  return completing ? { choices: listStacks() } : {};
+}
+
+function fleetNameChoices(): { choices?: string[] } {
+  if (!completing) {
+    return {};
+  }
+  const words = process.argv.slice(process.argv.indexOf("stack") + 1).filter((w) => w && !w.startsWith("-"));
+  const stack = words[1] ? loadStack(words[1]) : null;
+  return stack ? { choices: stack.fleets.map((f) => f.name) } : {};
+}
 
 function requireStack(name: string): StackDefinition {
   const stack = loadStack(name);
@@ -89,7 +110,9 @@ function printStackSummary(stack: StackDefinition): void {
   }
 
   for (const [component, values] of Object.entries(stack.componentEnv)) {
-    if (!values || Object.keys(values).length === 0) continue;
+    if (!values || Object.keys(values).length === 0) {
+      continue;
+    }
     log.info(bold(component));
     for (const [k, v] of Object.entries(values)) {
       log.info(`  ${k} = ${cyan(v)}`);
@@ -198,8 +221,9 @@ async function handleEdit(name: string, fleetName?: string): Promise<void> {
     // Escape at the top level behaves like Save & exit: submenu edits are
     // already applied in memory and must not be discarded silently.
     while (true) {
-      const choice = await promptOrUndefined(select({
+      const choice = await promptOrUndefined(listSelect({
         message: "What would you like to edit?",
+        transient: true,
         options: [
           { value: "shared", label: `Shared settings (${Object.keys(stack.env).length + Object.keys(stack.secrets).length} set)` },
           { value: "component", label: "Component settings (stack-wide per type)" },
@@ -208,7 +232,7 @@ async function handleEdit(name: string, fleetName?: string): Promise<void> {
           { value: "fleets", label: `Fleets (${stack.fleets.length})` },
           { value: "save", label: green("Save & exit") },
         ],
-      })) as string | undefined;
+      }));
 
       if (choice === undefined || choice === "save") {
         break;
@@ -249,13 +273,14 @@ async function editPinnedVersion(stack: StackDefinition): Promise<void> {
 }
 
 async function editComponentSettings(stack: StackDefinition): Promise<void> {
-  const component = await promptOrUndefined(select({
+  const component = await promptOrUndefined(listSelect({
     message: "Which component type?",
+    transient: true,
     options: AVAILABLE_COMPONENTS.map((c) => {
       const count = Object.keys(stack.componentEnv[c] ?? {}).length;
       return { value: c, label: `${c}${count > 0 ? dim(` (${count} set)`) : ""}` };
     }),
-  })) as Component | undefined;
+  }));
   if (component) {
     await editComponentLayer(stack, component);
   }
@@ -266,20 +291,14 @@ async function editComponentSettings(stack: StackDefinition): Promise<void> {
  * bottom, dimmed and marked; selecting one moves it into this fleet.
  */
 function fleetHostOptions(stack: StackDefinition, fleet: FleetDefinition | null) {
-  const ownerOf = new Map<string, FleetDefinition>();
-  for (const other of stack.fleets) {
-    if (other === fleet) continue;
-    for (const addr of other.hosts) {
-      ownerOf.set(addr, other);
-    }
-  }
-
   const free: { value: string; label: string; hint?: string }[] = [];
   const taken: { value: string; label: string; hint?: string }[] = [];
   for (const host of stack.hosts) {
-    if (!host.components.includes("daemon")) continue;
-    const owner = ownerOf.get(host.address);
-    if (owner) {
+    if (!host.components.includes("daemon")) {
+      continue;
+    }
+    const owner = getFleetForHost(stack, host.address);
+    if (owner && owner !== fleet) {
       taken.push({
         value: host.address,
         label: dim(hostLabel(host)),
@@ -293,33 +312,17 @@ function fleetHostOptions(stack: StackDefinition, fleet: FleetDefinition | null)
   return [...free, ...taken];
 }
 
-/** Assign members to a fleet, pulling any that belonged to other fleets. */
-function claimFleetHosts(stack: StackDefinition, fleet: FleetDefinition, members: string[]): void {
-  const claimed = new Set(members);
-  fleet.hosts = members;
-  for (const other of stack.fleets) {
-    if (other === fleet) continue;
-    const remaining = other.hosts.filter((a) => !claimed.has(a));
-    if (remaining.length === 0 && other.hosts.length > 0) {
-      log.warn(`Fleet "${other.name}" lost its last host and was removed`);
-    }
-    other.hosts = remaining;
+function claimFleetHostsLogged(stack: StackDefinition, fleet: FleetDefinition, members: string[]): void {
+  for (const emptied of claimFleetHosts(stack, fleet, members)) {
+    log.warn(`Fleet "${emptied}" lost its last host and was removed`);
   }
-  stack.fleets = stack.fleets.filter((f) => f.hosts.length > 0);
-}
-
-/** Hosts no longer running a daemon can't stay fleet members. */
-function pruneFleetMembership(stack: StackDefinition, address: string): void {
-  for (const fleet of stack.fleets) {
-    fleet.hosts = fleet.hosts.filter((a) => a !== address);
-  }
-  stack.fleets = stack.fleets.filter((f) => f.hosts.length > 0);
 }
 
 async function hostsMenu(stack: StackDefinition): Promise<void> {
   while (true) {
     const choice = await promptOrUndefined(searchSelect({
       message: "Hosts",
+      transient: true,
       options: [
         ...stack.hosts.map((h) => ({
           value: h.address,
@@ -347,15 +350,16 @@ async function hostsMenu(stack: StackDefinition): Promise<void> {
 
 async function hostMenu(stack: StackDefinition, host: StackHost): Promise<void> {
   while (true) {
-    const choice = await promptOrUndefined(select({
-      message: hostLabel(host),
+    const choice = await promptOrUndefined(listSelect({
+      message: `Hosts > ${hostLabel(host)}`,
+      transient: true,
       options: [
         { value: "components", label: `Components (${host.components.join(", ") || yellow("none")})` },
         { value: "alias", label: `Alias (${host.alias ?? "not set"})` },
         { value: "remove", label: red("Remove this host from the stack") },
         { value: "back", label: dim("Back") },
       ],
-    })) as string | undefined;
+    }));
 
     if (choice === undefined || choice === "back") {
       return;
@@ -396,7 +400,7 @@ async function hostMenu(stack: StackDefinition, host: StackHost): Promise<void> 
 
     if (choice === "remove") {
       const confirmed = await promptOrUndefined(confirm({
-        message: `Remove ${hostLabel(host)} from the stack? (nothing is uninstalled)`,
+        message: `Remove ${hostLabel(host)} from the stack? (the next stack up uninstalls its components)`,
         initialValue: false,
       }));
       if (confirmed) {
@@ -447,8 +451,9 @@ async function addHostInteractive(stack: StackDefinition): Promise<void> {
 
 async function fleetsMenu(stack: StackDefinition): Promise<void> {
   while (true) {
-    const choice = await promptOrUndefined(select({
+    const choice = await promptOrUndefined(listSelect({
       message: "Fleets",
+      transient: true,
       options: [
         ...stack.fleets.map((f) => ({
           value: f.name,
@@ -458,7 +463,7 @@ async function fleetsMenu(stack: StackDefinition): Promise<void> {
         { value: "__add__", label: cyan("+ Add a fleet") },
         { value: "__back__", label: dim("Back") },
       ],
-    })) as string | undefined;
+    }));
 
     if (choice === undefined || choice === "__back__") {
       return;
@@ -481,15 +486,16 @@ async function fleetsMenu(stack: StackDefinition): Promise<void> {
 
 async function fleetMenu(stack: StackDefinition, fleet: FleetDefinition): Promise<void> {
   while (true) {
-    const choice = await promptOrUndefined(select({
-      message: `Fleet "${fleet.name}"`,
+    const choice = await promptOrUndefined(listSelect({
+      message: `Fleets > ${fleet.name}`,
+      transient: true,
       options: [
         { value: "settings", label: `Daemon settings (${Object.keys(fleet.envOverrides ?? {}).length} override(s))` },
         { value: "hosts", label: `Hosts (${fleet.hosts.join(", ") || yellow("none")})` },
         { value: "remove", label: red("Remove this fleet") },
         { value: "back", label: dim("Back") },
       ],
-    })) as string | undefined;
+    }));
 
     if (choice === undefined || choice === "back") {
       return;
@@ -512,7 +518,7 @@ async function fleetMenu(stack: StackDefinition, fleet: FleetDefinition): Promis
         required: true,
       }));
       if (members) {
-        claimFleetHosts(stack, fleet, members);
+        claimFleetHostsLogged(stack, fleet, members);
       }
       continue;
     }
@@ -558,7 +564,7 @@ async function addFleetInteractive(stack: StackDefinition): Promise<FleetDefinit
 
   const fleet: FleetDefinition = { name: fleetName, hosts: [] };
   stack.fleets.push(fleet);
-  claimFleetHosts(stack, fleet, members);
+  claimFleetHostsLogged(stack, fleet, members);
   log.success(`Fleet "${fleetName}" created with ${members.length} host(s)`);
   return fleet;
 }
@@ -631,11 +637,26 @@ async function handleDoctor(name: string, fleetName?: string): Promise<void> {
 
   let totalFailed = 0;
   try {
-    await forEachHost(hosts, async (host) => {
-      const report = await runDoctor({ host, interactive: false });
-      totalFailed += report.summary.fail;
+    // Checks are collected on all hosts at once (runDoctor stays silent when
+    // non-interactive) and rendered afterwards in host order.
+    type DoctorEntry = { address: string; report: DoctorReport } | { address: string; error: string };
+    const reports = await Promise.all([...hosts.entries()].map(async ([address, host]): Promise<DoctorEntry> => {
+      try {
+        return { address, report: await runDoctor({ host, interactive: false }) };
+      } catch (err) {
+        return { address, error: err instanceof Error ? err.message : String(err) };
+      }
+    }));
 
-      for (const component of report.components) {
+    for (const entry of reports) {
+      heading(entry.address);
+      if ("error" in entry) {
+        log.error(entry.error);
+        totalFailed++;
+        continue;
+      }
+      totalFailed += entry.report.summary.fail;
+      for (const component of entry.report.components) {
         for (const check of component.checks) {
           if (check.status === "fail") {
             fail(`${component.component} · ${check.label}`, check.message);
@@ -644,9 +665,8 @@ async function handleDoctor(name: string, fleetName?: string): Promise<void> {
           }
         }
       }
-
-      log.info(buildSummaryLine(report.summary));
-    });
+      log.info(buildSummaryLine(entry.report.summary));
+    }
   } finally {
     await disposeAll(hosts);
   }
@@ -661,138 +681,30 @@ async function handleRm(name: string): Promise<void> {
   const stack = requireStack(name);
   intro(`xinity stack rm ${cyan(name)}`);
 
-  if (stack.hosts.length === 0) {
-    const confirmed = await promptOrExit(confirm({
-      message: `Delete stack "${name}"?`,
-      initialValue: false,
-    }));
-    if (!confirmed) {
-      outro("Aborted");
-      return;
+  // Deleting the definition also deletes the state, so hosts not yet
+  // evacuated by an up run would be forgotten; the listing makes that visible.
+  const orphans = findOrphanHosts(loadStackState(name), stack);
+  if (stack.hosts.length > 0 || orphans.length > 0) {
+    log.info(bold("Tracked hosts:"));
+    for (const host of stack.hosts) {
+      log.info(`  ${host.address}: ${host.components.join(", ")}`);
     }
-    deleteStack(name);
-    log.success(`Stack "${name}" deleted`);
-    outro("Done");
-    return;
+    for (const address of orphans) {
+      log.info(`  ${address}: ${dim("removed from the definition, not yet evacuated")}`);
+    }
+    log.info("Hosts stay untouched. To uninstall components first, remove the hosts from the stack and run stack up before deleting it.");
   }
 
-  log.info(bold("Tracked hosts:"));
-  for (const host of stack.hosts) {
-    log.info(`  ${host.address}: ${host.components.join(", ")}`);
-  }
-
-  const choice = await promptOrExit(select({
-    message: `How should "${name}" be removed?`,
-    options: [
-      { value: "local", label: "Remove the local stack definition only", hint: "hosts stay untouched" },
-      { value: "teardown", label: `Uninstall all tracked components from ${stack.hosts.length} host(s), then remove the definition`, hint: "best effort" },
-      { value: "abort", label: "Abort" },
-    ],
-  })) as string;
-
-  if (choice === "abort") {
+  const confirmed = await promptOrExit(confirm({
+    message: `Delete stack "${name}"?`,
+    initialValue: false,
+  }));
+  if (!confirmed) {
     outro("Aborted");
     return;
   }
-
-  if (choice === "teardown") {
-    const done = await teardownHosts(
-      stack.hosts.map((h) => h.address),
-      (address) => getHost(stack, address)?.components ?? [],
-    );
-    if (!done) {
-      log.error("Could not reach all hosts; nothing was removed and the stack definition was kept.");
-      outro("Failed");
-      process.exit(1);
-    }
-  }
-
   deleteStack(name);
   log.success(`Stack "${name}" deleted`);
-  outro("Done");
-}
-
-/** Best-effort removal across hosts; failures are reported and treated as removed. */
-async function teardownHosts(
-  addresses: string[],
-  componentsFor: (address: string) => Component[],
-): Promise<boolean> {
-  const hosts = await connectHosts(addresses);
-  if (!hosts) {
-    return false;
-  }
-  try {
-    await forEachHost(hosts, async (host, address) => {
-      for (const component of componentsFor(address)) {
-        const result = await removeComponentCollapsed({ component, host });
-        if (!result.success) {
-          warn(component, `Not fully removed (${result.errors.join(", ")}); treating it as deleted`);
-        }
-      }
-    });
-    return true;
-  } finally {
-    await disposeAll(hosts);
-  }
-}
-
-/** `stack rm <name> --fleet <fleet>`: remove the fleet concept, or tear its daemons down too. */
-async function handleRmFleet(name: string, fleetName: string): Promise<void> {
-  const stack = requireStack(name);
-  const fleet = requireFleet(stack, fleetName);
-  intro(`xinity stack rm ${cyan(name)} · fleet ${cyan(fleetName)}`);
-
-  let choice = "concept";
-  if (fleet.hosts.length > 0) {
-    log.info(bold("Fleet hosts:"));
-    for (const addr of fleet.hosts) {
-      log.info(`  ${addr}`);
-    }
-
-    choice = await promptOrExit(select({
-      message: `How should fleet "${fleetName}" be removed?`,
-      options: [
-        { value: "concept", label: "Remove the fleet definition only", hint: "hosts and their daemons stay untouched" },
-        { value: "teardown", label: `Uninstall the daemon from ${fleet.hosts.length} host(s), then remove the fleet`, hint: "best effort" },
-        { value: "abort", label: "Abort" },
-      ],
-    })) as string;
-  } else {
-    const confirmed = await promptOrExit(confirm({
-      message: `Remove fleet "${fleetName}"?`,
-      initialValue: false,
-    }));
-    if (!confirmed) {
-      choice = "abort";
-    }
-  }
-
-  if (choice === "abort") {
-    outro("Aborted");
-    return;
-  }
-
-  if (choice === "teardown") {
-    if (!(await teardownHosts(fleet.hosts, () => ["daemon"]))) {
-      log.error("Could not reach all hosts; nothing was removed and the fleet was kept.");
-      outro("Failed");
-      process.exit(1);
-    }
-
-    // The stack must stop expecting daemons here, or the next `stack up`
-    // would simply reinstall what was just torn down.
-    for (const addr of fleet.hosts) {
-      const stackHost = getHost(stack, addr);
-      if (stackHost) {
-        stackHost.components = stackHost.components.filter((c) => c !== "daemon");
-      }
-    }
-    stack.hosts = stack.hosts.filter((h) => h.components.length > 0);
-  }
-
-  stack.fleets = stack.fleets.filter((f) => f.name !== fleetName);
-  saveStack(stack);
-  log.success(`Fleet "${fleetName}" removed`);
   outro("Done");
 }
 
@@ -822,29 +734,23 @@ export const stackCommand: CommandModule = {
         }
       })
       .command("show <name>", "Display stack details", (y) =>
-        y.positional("name", { type: "string", demandOption: true, describe: "Stack name" }),
+        y.positional("name", { type: "string", demandOption: true, describe: "Stack name", ...stackNameChoices() }),
       (argv) => {
         const stack = requireStack(argv.name as string);
         printStackSummary(stack);
       })
       .command("edit <name>", "Edit a stack", (y) =>
         y
-          .positional("name", { type: "string", demandOption: true, describe: "Stack name" })
-          .option("fleet", { type: "string", describe: "Jump straight to a fleet's daemon settings" }),
+          .positional("name", { type: "string", demandOption: true, describe: "Stack name", ...stackNameChoices() })
+          .option("fleet", { type: "string", describe: "Jump straight to a fleet's daemon settings", ...fleetNameChoices() }),
       (argv) => handleEdit(argv.name as string, argv.fleet as string | undefined))
-      .command("rm <name>", "Delete a stack, or remove the daemon from a fleet's hosts (--fleet)", (y) =>
+      .command("rm <name>", "Delete a stack definition", (y) =>
         y
-          .positional("name", { type: "string", demandOption: true, describe: "Stack name" })
-          .option("fleet", { type: "string", describe: "Remove the daemon from this fleet's hosts instead of deleting the stack" }),
-      (argv) => {
-        const fleetName = argv.fleet as string | undefined;
-        return fleetName
-          ? handleRmFleet(argv.name as string, fleetName)
-          : handleRm(argv.name as string);
-      })
+          .positional("name", { type: "string", demandOption: true, describe: "Stack name", ...stackNameChoices() }),
+      (argv) => handleRm(argv.name as string))
       .command("up <name>", "Plan and apply the whole stack at its pinned version", (y) =>
         y
-          .positional("name", { type: "string", demandOption: true, describe: "Stack name" })
+          .positional("name", { type: "string", demandOption: true, describe: "Stack name", ...stackNameChoices() })
           .option("target-version", {
             describe: "Pin the stack to this release and deploy it (defaults to the stack's pinned version)",
             type: "string",
@@ -852,8 +758,8 @@ export const stackCommand: CommandModule = {
       (argv) => handleUp(argv.name as string, argv["target-version"] as string | undefined))
       .command(["doctor <name>", "status <name>"], "Health check the stack's hosts", (y) =>
         y
-          .positional("name", { type: "string", demandOption: true, describe: "Stack name" })
-          .option("fleet", { type: "string", describe: "Only check this fleet's hosts" }),
+          .positional("name", { type: "string", demandOption: true, describe: "Stack name", ...stackNameChoices() })
+          .option("fleet", { type: "string", describe: "Only check this fleet's hosts", ...fleetNameChoices() }),
       (argv) => handleDoctor(argv.name as string, argv.fleet as string | undefined))
       .demandCommand(1, "Specify a stack action")
       .strict(),

--- a/packages/xinity-cli/src/commands/stack.ts
+++ b/packages/xinity-cli/src/commands/stack.ts
@@ -9,10 +9,12 @@ import {
   type FleetDefinition,
   createStack,
   loadStack,
+  stackExists,
   saveStack,
   deleteStack,
   listStacks,
   validateStackName,
+  validateStack,
   getFleet,
   getFleetForHost,
   hostLabel,
@@ -52,7 +54,17 @@ function fleetNameChoices(): { choices?: string[] } {
 function requireStack(name: string): StackDefinition {
   const stack = loadStack(name);
   if (!stack) {
-    log.error(`Stack "${name}" not found`);
+    if (!stackExists(name)) {
+      log.error(`Stack "${name}" not found`);
+    }
+    process.exit(1);
+  }
+  const errors = validateStack(stack);
+  if (errors.length > 0) {
+    for (const error of errors) {
+      fail(error.field, error.message);
+    }
+    fail("Stack", `The definition is invalid; fix it with: xinity stack edit ${name}`);
     process.exit(1);
   }
   return stack;
@@ -685,21 +697,26 @@ async function handleDoctor(name: string, fleetName?: string): Promise<void> {
 }
 
 async function handleRm(name: string): Promise<void> {
-  const stack = requireStack(name);
+  if (!stackExists(name)) {
+    log.error(`Stack "${name}" not found`);
+    process.exit(1);
+  }
+
   intro(`xinity stack rm ${cyan(name)}`);
 
-  // Deleting the definition also deletes the state, so hosts not yet
-  // evacuated by an up run would be forgotten; the listing makes that visible.
-  const orphans = findOrphanHosts(loadStackState(name), stack);
-  if (stack.hosts.length > 0 || orphans.length > 0) {
-    log.info(bold("Tracked hosts:"));
-    for (const host of stack.hosts) {
-      log.info(`  ${host.address}: ${host.components.join(", ")}`);
+  const stack = loadStack(name);
+  if (stack) {
+    const orphans = findOrphanHosts(loadStackState(name), stack);
+    if (stack.hosts.length > 0 || orphans.length > 0) {
+      log.info(bold("Tracked hosts:"));
+      for (const host of stack.hosts) {
+        log.info(`  ${host.address}: ${host.components.join(", ")}`);
+      }
+      for (const address of orphans) {
+        log.info(`  ${address}: ${dim("removed from the definition, not yet evacuated")}`);
+      }
+      log.info("Hosts stay untouched. To uninstall components first, remove the hosts from the stack and run stack up before deleting it.");
     }
-    for (const address of orphans) {
-      log.info(`  ${address}: ${dim("removed from the definition, not yet evacuated")}`);
-    }
-    log.info("Hosts stay untouched. To uninstall components first, remove the hosts from the stack and run stack up before deleting it.");
   }
 
   const confirmed = await promptOrExit(confirm({

--- a/packages/xinity-cli/src/commands/up.ts
+++ b/packages/xinity-cli/src/commands/up.ts
@@ -1,10 +1,18 @@
 import type { CommandModule } from "yargs";
 import * as p from "../lib/clack.ts";
 import pc from "picocolors";
-import { installComponent, installAll, preflightCheck, showDashboardHints } from "../lib/installer.ts";
 import type { Component } from "../lib/component-meta.ts";
-import { runMigrations } from "../lib/migrator.ts";
-import { logErrors, warn } from "../lib/output.ts";
+import { preflightCheck, showDashboardHints } from "../lib/installer.ts";
+import { discoverConnectionUrl, dbHint, runMigrations } from "../lib/migrator.ts";
+import {
+  planUp,
+  renderUpPlan,
+  renderUpPlanScript,
+  reviewGate,
+  applyUpPlan,
+  printPostInstallSummary,
+} from "../lib/up-plan.ts";
+import { warn, heading } from "../lib/output.ts";
 import { connectHost } from "../lib/remote-host.ts";
 import { seaweedfsSetup } from "../lib/seaweedfs-setup.ts";
 import { infraRedis } from "../lib/redis-setup.ts";
@@ -21,6 +29,90 @@ const COMPONENTS = [
   // Meta
   "cli", "all",
 ] as const;
+
+/** `up db`: plan (discover the URL), review, then provision/migrate and wire Redis. */
+async function runDbFlow(opts: { targetVersion: string; dryRun: boolean }, host: import("../lib/host.ts").Host): Promise<boolean> {
+  const dbPlan = await discoverConnectionUrl(host);
+  if (!dbPlan) return false;
+
+  p.log.step(pc.bold("Planned actions"));
+  let step = 1;
+  if (dbPlan.provision) {
+    const { describePostgresProvision } = await import("../lib/postgres-setup.ts");
+    p.log.info(`${step++}. ${describePostgresProvision(dbPlan.provision)}`);
+  }
+  p.log.info(`${step}. Apply database migrations from release ${opts.targetVersion} to ${dbHint(dbPlan.connectionUrl)}`);
+
+  if (opts.dryRun) {
+    p.log.info(pc.yellow("Dry run, stopping before apply."));
+    return true;
+  }
+  if (!(await reviewGate())) return true;
+
+  if (dbPlan.provision) {
+    const { applyPostgresProvision } = await import("../lib/postgres-setup.ts");
+    if (!(await applyPostgresProvision(dbPlan.provision, host))) return false;
+  }
+
+  const result = await runMigrations({ connectionUrl: dbPlan.connectionUrl, targetVersion: opts.targetVersion, dryRun: false, host });
+  if (!result.success) {
+    for (const err of result.errors) p.log.error(err);
+    return false;
+  }
+
+  // Redis is a shared infrastructure dependency; non-fatal when skipped.
+  heading("redis");
+  const { planRedis, applyRedisPlan } = await import("../lib/redis-setup.ts");
+  const redisPlan = await planRedis(host);
+  if (redisPlan && (await applyRedisPlan(redisPlan, host))) {
+    p.log.success("Redis - Connection configured");
+  } else {
+    warn("Redis", "No Redis URL configured (can be set up later with xinity up infra-redis)");
+  }
+  return true;
+}
+
+/** Service components and `all`: collect, review, gate, apply. */
+async function runPlannedFlow(
+  component: string,
+  opts: { targetVersion: string; dryRun: boolean; hardReset: boolean },
+  host: import("../lib/host.ts").Host,
+): Promise<boolean> {
+  const isAll = component === "all";
+  if (isAll && opts.targetVersion.startsWith("local:")) {
+    p.log.error("'xinity up all' does not support local: builds. Run 'xinity up <component>' for each component individually.");
+    return false;
+  }
+
+  const plan = await planUp(
+    isAll ? [] : [component as Component],
+    { targetVersion: opts.targetVersion, hardReset: opts.hardReset, dryRun: opts.dryRun, withInfra: isAll },
+    host,
+  );
+  if (!plan) return true;
+
+  renderUpPlan(plan);
+
+  if (opts.dryRun) {
+    p.log.info(pc.yellow("Dry run, stopping before apply."));
+    return true;
+  }
+
+  if (!(await reviewGate(() => renderUpPlanScript(plan)))) return true;
+
+  const result = await applyUpPlan(plan, host);
+  if (!result.success) {
+    for (const err of result.errors) p.log.error(err);
+    return false;
+  }
+
+  if (isAll) {
+    await printPostInstallSummary(host);
+  } else if (component === "dashboard") {
+    await showDashboardHints(host);
+  }
+  return true;
+}
 
 export const upCommand: CommandModule = {
   command: "up <component>",
@@ -39,7 +131,7 @@ export const upCommand: CommandModule = {
         default: "latest",
       })
       .option("dry-run", {
-        describe: "Show what would be done without making changes",
+        describe: "Show the planned actions without applying them",
         type: "boolean",
         default: false,
       })
@@ -55,12 +147,22 @@ export const upCommand: CommandModule = {
     const hardReset = argv["hard-reset"] as boolean;
     const targetHostArg = argv["target-host"] as string | undefined;
 
+    if (component === "cli") {
+      await runUpdateFlow({ checkOnly: false, targetVersion });
+      return;
+    }
+
     p.intro(`xinity up ${pc.cyan(component)}${dryRun ? pc.yellow(" (dry run)") : ""}${targetHostArg ? pc.dim(` → ${targetHostArg}`) : ""}`);
 
     const host = await connectHost(targetHostArg);
 
     let hasFailure = false;
     try {
+      if (!(await host.prepareElevation())) {
+        p.outro("Aborted");
+        return;
+      }
+
       // ── Upfront pre-flight checks ──────────────────────────────────────
       const issues = await preflightCheck([component], host);
       if (issues.length > 0) {
@@ -79,16 +181,10 @@ export const upCommand: CommandModule = {
         }
       }
 
-      if (component === "cli") {
-        await runUpdateFlow({ checkOnly: false, targetVersion });
-        return;
-      }
-
       if (component === "db") {
-        const result = await runMigrations({ targetVersion, dryRun, host });
-        logErrors(result);
-        p.outro(result.success ? "Done" : "Failed");
-        hasFailure = !result.success;
+        const ok = await runDbFlow({ targetVersion, dryRun }, host);
+        p.outro(ok ? "Done" : "Failed");
+        hasFailure = !ok;
         return;
       }
 
@@ -139,28 +235,9 @@ export const upCommand: CommandModule = {
         return;
       }
 
-      if (component === "all") {
-        await installAll(targetVersion, dryRun, hardReset, host);
-        p.outro("Done");
-        return;
-      }
-
-      const result = await installComponent({
-        component: component as Component,
-        targetVersion,
-        dryRun,
-        hardReset,
-        host,
-      });
-
-      logErrors(result);
-
-      if (component === "dashboard" && result.success && !dryRun) {
-        await showDashboardHints(host);
-      }
-
-      p.outro(result.success ? "Done" : "Failed");
-      hasFailure = !result.success;
+      const ok = await runPlannedFlow(component, { targetVersion, dryRun, hardReset }, host);
+      p.outro(ok ? "Done" : "Failed");
+      hasFailure = !ok;
     } finally {
       await host.dispose();
     }

--- a/packages/xinity-cli/src/commands/up.ts
+++ b/packages/xinity-cli/src/commands/up.ts
@@ -1,6 +1,6 @@
 import type { CommandModule } from "yargs";
-import * as p from "../lib/clack.ts";
-import pc from "picocolors";
+import { confirm, intro, isCancel, log, outro } from "../lib/clack.ts";
+import { bold, cyan, dim, yellow } from "picocolors";
 import type { Component } from "../lib/component-meta.ts";
 import { preflightCheck, showDashboardHints } from "../lib/installer.ts";
 import { discoverConnectionUrl, dbHint, runMigrations } from "../lib/migrator.ts";
@@ -13,7 +13,7 @@ import {
   printPostInstallSummary,
 } from "../lib/up-plan.ts";
 import { warn, heading } from "../lib/output.ts";
-import { connectHost } from "../lib/remote-host.ts";
+import { connectHost, TARGET_HOST_OPTION } from "../lib/remote-host.ts";
 import { seaweedfsSetup } from "../lib/seaweedfs-setup.ts";
 import { infraRedis } from "../lib/redis-setup.ts";
 import { runUpdateFlow } from "./update.ts";
@@ -35,16 +35,16 @@ async function runDbFlow(opts: { targetVersion: string; dryRun: boolean }, host:
   const dbPlan = await discoverConnectionUrl(host);
   if (!dbPlan) return false;
 
-  p.log.step(pc.bold("Planned actions"));
+  log.step(bold("Planned actions"));
   let step = 1;
   if (dbPlan.provision) {
     const { describePostgresProvision } = await import("../lib/postgres-setup.ts");
-    p.log.info(`${step++}. ${describePostgresProvision(dbPlan.provision)}`);
+    log.info(`${step++}. ${describePostgresProvision(dbPlan.provision)}`);
   }
-  p.log.info(`${step}. Apply database migrations from release ${opts.targetVersion} to ${dbHint(dbPlan.connectionUrl)}`);
+  log.info(`${step}. Apply database migrations from release ${opts.targetVersion} to ${dbHint(dbPlan.connectionUrl)}`);
 
   if (opts.dryRun) {
-    p.log.info(pc.yellow("Dry run, stopping before apply."));
+    log.info(yellow("Dry run, stopping before apply."));
     return true;
   }
   if (!(await reviewGate())) return true;
@@ -56,7 +56,7 @@ async function runDbFlow(opts: { targetVersion: string; dryRun: boolean }, host:
 
   const result = await runMigrations({ connectionUrl: dbPlan.connectionUrl, targetVersion: opts.targetVersion, dryRun: false, host });
   if (!result.success) {
-    for (const err of result.errors) p.log.error(err);
+    for (const err of result.errors) log.error(err);
     return false;
   }
 
@@ -65,7 +65,7 @@ async function runDbFlow(opts: { targetVersion: string; dryRun: boolean }, host:
   const { planRedis, applyRedisPlan } = await import("../lib/redis-setup.ts");
   const redisPlan = await planRedis(host);
   if (redisPlan && (await applyRedisPlan(redisPlan, host))) {
-    p.log.success("Redis - Connection configured");
+    log.success("Redis - Connection configured");
   } else {
     warn("Redis", "No Redis URL configured (can be set up later with xinity up infra-redis)");
   }
@@ -80,7 +80,7 @@ async function runPlannedFlow(
 ): Promise<boolean> {
   const isAll = component === "all";
   if (isAll && opts.targetVersion.startsWith("local:")) {
-    p.log.error("'xinity up all' does not support local: builds. Run 'xinity up <component>' for each component individually.");
+    log.error("'xinity up all' does not support local: builds. Run 'xinity up <component>' for each component individually.");
     return false;
   }
 
@@ -94,7 +94,7 @@ async function runPlannedFlow(
   renderUpPlan(plan);
 
   if (opts.dryRun) {
-    p.log.info(pc.yellow("Dry run, stopping before apply."));
+    log.info(yellow("Dry run, stopping before apply."));
     return true;
   }
 
@@ -102,7 +102,7 @@ async function runPlannedFlow(
 
   const result = await applyUpPlan(plan, host);
   if (!result.success) {
-    for (const err of result.errors) p.log.error(err);
+    for (const err of result.errors) log.error(err);
     return false;
   }
 
@@ -139,7 +139,8 @@ export const upCommand: CommandModule = {
         describe: "Fully reset component state during reinstall (systemctl clean --what=state)",
         type: "boolean",
         default: false,
-      }),
+      })
+      .option("target-host", TARGET_HOST_OPTION),
   handler: async (argv) => {
     const component = argv.component as string;
     const targetVersion = argv["target-version"] as string;
@@ -152,38 +153,38 @@ export const upCommand: CommandModule = {
       return;
     }
 
-    p.intro(`xinity up ${pc.cyan(component)}${dryRun ? pc.yellow(" (dry run)") : ""}${targetHostArg ? pc.dim(` → ${targetHostArg}`) : ""}`);
+    intro(`xinity up ${cyan(component)}${dryRun ? yellow(" (dry run)") : ""}${targetHostArg ? dim(` → ${targetHostArg}`) : ""}`);
 
     const host = await connectHost(targetHostArg);
 
     let hasFailure = false;
     try {
       if (!(await host.prepareElevation())) {
-        p.outro("Aborted");
+        outro("Aborted");
         return;
       }
 
       // ── Upfront pre-flight checks ──────────────────────────────────────
       const issues = await preflightCheck([component], host);
       if (issues.length > 0) {
-        p.log.step(pc.bold("Pre-flight checks"));
+        log.step(bold("Pre-flight checks"));
         for (const issue of issues) {
           warn(issue.tool, issue.reason);
-          if (issue.hint) p.log.info(`  ${pc.dim("Install:")} ${pc.cyan(issue.hint)}`);
+          if (issue.hint) log.info(`  ${dim("Install:")} ${cyan(issue.hint)}`);
         }
-        const cont = await p.confirm({
+        const cont = await confirm({
           message: "Some requirements are missing. Continue anyway?",
           initialValue: false,
         });
-        if (p.isCancel(cont) || !cont) {
-          p.outro("Aborted");
+        if (isCancel(cont) || !cont) {
+          outro("Aborted");
           return;
         }
       }
 
       if (component === "db") {
         const ok = await runDbFlow({ targetVersion, dryRun }, host);
-        p.outro(ok ? "Done" : "Failed");
+        outro(ok ? "Done" : "Failed");
         hasFailure = !ok;
         return;
       }
@@ -191,38 +192,38 @@ export const upCommand: CommandModule = {
       if (component === "infra-redis") {
         const url = await infraRedis(host, dryRun);
         if (url) {
-          p.log.success("Redis connection configured.");
+          log.success("Redis connection configured.");
         } else {
           warn("Redis", "No Redis URL configured");
         }
-        p.outro("Done");
+        outro("Done");
         return;
       }
 
       if (component === "infra-seaweedfs") {
         await seaweedfsSetup(host, dryRun);
-        p.outro("Done");
+        outro("Done");
         return;
       }
 
       if (component === "infra-prometheus") {
         const { prometheusSetup } = await import("../lib/prometheus-setup.ts");
         await prometheusSetup(host, dryRun);
-        p.outro("Done");
+        outro("Done");
         return;
       }
 
       if (component === "infra-postgres") {
         const { postgresSetup } = await import("../lib/postgres-setup.ts");
         await postgresSetup(host, dryRun);
-        p.outro("Done");
+        outro("Done");
         return;
       }
 
       if (component === "infra-ollama") {
         const { ollamaSetup } = await import("../lib/ollama-setup.ts");
         await ollamaSetup(host, dryRun);
-        p.outro("Done");
+        outro("Done");
         return;
       }
 
@@ -230,13 +231,13 @@ export const upCommand: CommandModule = {
         component === "infra-vllm" ||
         component === "infra-searxng"
       ) {
-        p.log.warn(`${pc.cyan(component)} is not yet implemented.`);
-        p.outro("Coming soon");
+        log.warn(`${cyan(component)} is not yet implemented.`);
+        outro("Coming soon");
         return;
       }
 
       const ok = await runPlannedFlow(component, { targetVersion, dryRun, hardReset }, host);
-      p.outro(ok ? "Done" : "Failed");
+      outro(ok ? "Done" : "Failed");
       hasFailure = !ok;
     } finally {
       await host.dispose();

--- a/packages/xinity-cli/src/commands/up.ts
+++ b/packages/xinity-cli/src/commands/up.ts
@@ -5,8 +5,7 @@ import { installComponent, installAll, preflightCheck, showDashboardHints } from
 import type { Component } from "../lib/component-meta.ts";
 import { runMigrations } from "../lib/migrator.ts";
 import { logErrors, warn } from "../lib/output.ts";
-import { createLocalHost } from "../lib/host.ts";
-import { connectRemoteHost } from "../lib/remote-host.ts";
+import { connectHost } from "../lib/remote-host.ts";
 import { seaweedfsSetup } from "../lib/seaweedfs-setup.ts";
 import { infraRedis } from "../lib/redis-setup.ts";
 import { runUpdateFlow } from "./update.ts";
@@ -58,7 +57,7 @@ export const upCommand: CommandModule = {
 
     p.intro(`xinity up ${pc.cyan(component)}${dryRun ? pc.yellow(" (dry run)") : ""}${targetHostArg ? pc.dim(` → ${targetHostArg}`) : ""}`);
 
-    const host = targetHostArg ? await connectRemoteHost(targetHostArg) : createLocalHost();
+    const host = await connectHost(targetHostArg);
 
     let hasFailure = false;
     try {

--- a/packages/xinity-cli/src/commands/up.ts
+++ b/packages/xinity-cli/src/commands/up.ts
@@ -3,7 +3,7 @@ import { confirm, intro, isCancel, log, outro } from "../lib/clack.ts";
 import { bold, cyan, dim, yellow } from "picocolors";
 import type { Component } from "../lib/component-meta.ts";
 import { preflightCheck, showDashboardHints } from "../lib/installer.ts";
-import { discoverConnectionUrl, dbHint, runMigrations } from "../lib/migrator.ts";
+import { discoverConnectionUrl, describeMigrationStep, runMigrations } from "../lib/migrator.ts";
 import {
   planUp,
   renderUpPlan,
@@ -41,7 +41,7 @@ async function runDbFlow(opts: { targetVersion: string; dryRun: boolean }, host:
     const { describePostgresProvision } = await import("../lib/postgres-setup.ts");
     log.info(`${step++}. ${describePostgresProvision(dbPlan.provision)}`);
   }
-  log.info(`${step}. Apply database migrations from release ${opts.targetVersion} to ${dbHint(dbPlan.connectionUrl)}`);
+  log.info(`${step}. ${describeMigrationStep(opts.targetVersion, dbPlan.connectionUrl)}`);
 
   if (opts.dryRun) {
     log.info(yellow("Dry run, stopping before apply."));

--- a/packages/xinity-cli/src/commands/up.ts
+++ b/packages/xinity-cli/src/commands/up.ts
@@ -157,7 +157,6 @@ export const upCommand: CommandModule = {
 
     const host = await connectHost(targetHostArg);
 
-    let hasFailure = false;
     try {
       if (!(await host.prepareElevation())) {
         outro("Aborted");
@@ -185,7 +184,9 @@ export const upCommand: CommandModule = {
       if (component === "db") {
         const ok = await runDbFlow({ targetVersion, dryRun }, host);
         outro(ok ? "Done" : "Failed");
-        hasFailure = !ok;
+        if (!ok) {
+          process.exit(1);
+        }
         return;
       }
 
@@ -238,10 +239,11 @@ export const upCommand: CommandModule = {
 
       const ok = await runPlannedFlow(component, { targetVersion, dryRun, hardReset }, host);
       outro(ok ? "Done" : "Failed");
-      hasFailure = !ok;
+      if (!ok) {
+        process.exit(1);
+      }
     } finally {
       await host.dispose();
     }
-    if (hasFailure) process.exit(1);
   },
 };

--- a/packages/xinity-cli/src/commands/update.ts
+++ b/packages/xinity-cli/src/commands/update.ts
@@ -2,8 +2,8 @@ import type { CommandModule } from "yargs";
 import { join } from "path";
 import { tmpdir, homedir } from "os";
 import { mkdirSync, copyFileSync, renameSync, unlinkSync, chmodSync, existsSync } from "fs";
-import * as p from "../lib/clack.ts";
-import pc from "picocolors";
+import { cancel, confirm, intro, isCancel, log, outro, spinner as clackSpinner } from "../lib/clack.ts";
+import { cyan, green, yellow } from "picocolors";
 
 import { version } from "../../../../package.json";
 const CLI_VERSION = `v${version}`;
@@ -45,7 +45,7 @@ async function selfUpdate(release: Release): Promise<boolean> {
     fail(
       "Self-update",
       `Could not locate the xinity binary to replace.\n` +
-      `Expected it at ${pc.cyan(fallbackPath)} (conventional install location).\n` +
+      `Expected it at ${cyan(fallbackPath)} (conventional install location).\n` +
       `If you installed it elsewhere, replace the binary manually with the downloaded file.`,
     );
     return false;
@@ -54,7 +54,7 @@ async function selfUpdate(release: Release): Promise<boolean> {
   const newBinary = join(extractDir, "xinity");
   const backupPath = currentPath + ".bak";
 
-  const replaceSpinner = p.spinner();
+  const replaceSpinner = clackSpinner();
   replaceSpinner.start("Replacing binary…");
 
   try {
@@ -99,10 +99,10 @@ function locateRunningBinary(fallbackPath: string): string | null {
 export async function runUpdateFlow(opts: { checkOnly: boolean; targetVersion: string }): Promise<void> {
   const { checkOnly, targetVersion } = opts;
 
-  p.intro(`xinity update${checkOnly ? pc.yellow(" (check only)") : ""}`);
+  intro(`xinity update${checkOnly ? yellow(" (check only)") : ""}`);
 
   // Fetch latest release
-  const spinner = p.spinner();
+  const spinner = clackSpinner();
   spinner.start("Checking for updates…");
 
   let release: Release;
@@ -111,7 +111,7 @@ export async function runUpdateFlow(opts: { checkOnly: boolean; targetVersion: s
   } catch (err) {
     spinner.stop("Failed");
     fail("GitHub API", (err as Error).message);
-    p.outro("Done");
+    outro("Done");
     return;
   }
   spinner.stop(`Latest release: ${release.tagName}`);
@@ -119,33 +119,33 @@ export async function runUpdateFlow(opts: { checkOnly: boolean; targetVersion: s
   // Compare versions
   const needsUpdate = CLI_VERSION !== release.tagName;
   const status = needsUpdate
-    ? pc.yellow(`${CLI_VERSION} → ${release.tagName}`)
-    : pc.green(`${CLI_VERSION} (up to date)`);
-  p.log.info(`  ${pc.cyan("cli")}  ${status}`);
+    ? yellow(`${CLI_VERSION} → ${release.tagName}`)
+    : green(`${CLI_VERSION} (up to date)`);
+  log.info(`  ${cyan("cli")}  ${status}`);
 
   if (!needsUpdate) {
-    p.log.success("Already up to date");
-    p.outro("Done");
+    log.success("Already up to date");
+    outro("Done");
     return;
   }
 
   if (checkOnly) {
-    p.outro("Run " + pc.cyan("xinity update") + " to apply the update");
+    outro("Run " + cyan("xinity update") + " to apply the update");
     return;
   }
 
   // Confirm
-  const proceed = await p.confirm({
+  const proceed = await confirm({
     message: `Update CLI to ${release.tagName}?`,
     initialValue: true,
   });
-  if (p.isCancel(proceed) || !proceed) {
-    p.cancel("Cancelled.");
+  if (isCancel(proceed) || !proceed) {
+    cancel("Cancelled.");
     return;
   }
 
   await selfUpdate(release);
-  p.outro("Done");
+  outro("Done");
 }
 
 // ─── Command ────────────────────────────────────────────────────────────────

--- a/packages/xinity-cli/src/commands/update.ts
+++ b/packages/xinity-cli/src/commands/update.ts
@@ -9,6 +9,7 @@ import { version } from "../../../../package.json";
 const CLI_VERSION = `v${version}`;
 import { fetchRelease, pickReleaseAsset, type Release } from "../lib/github.ts";
 import { downloadAndVerify, extractCommandArgv } from "../lib/install-download.ts";
+import { runSteps } from "../lib/step-runner.ts";
 import { pass, fail } from "../lib/output.ts";
 import { createLocalHost } from "../lib/host.ts";
 
@@ -26,7 +27,7 @@ async function selfUpdate(release: Release): Promise<boolean> {
   const tmpDir = join(tmpdir(), `xinity-cli-update-${Date.now()}`);
   mkdirSync(tmpDir, { recursive: true });
 
-  const filePath = await downloadAndVerify(release, assetName, tmpDir);
+  const filePath = await runSteps(downloadAndVerify(release, assetName, tmpDir));
   if (!filePath) return false;
 
   const extractDir = join(tmpDir, "extracted");

--- a/packages/xinity-cli/src/commands/update.ts
+++ b/packages/xinity-cli/src/commands/update.ts
@@ -144,7 +144,10 @@ export async function runUpdateFlow(opts: { checkOnly: boolean; targetVersion: s
     return;
   }
 
-  await selfUpdate(release);
+  const ok = await selfUpdate(release);
+  if (!ok) {
+    process.exit(1);
+  }
   outro("Done");
 }
 

--- a/packages/xinity-cli/src/commands/update.ts
+++ b/packages/xinity-cli/src/commands/update.ts
@@ -11,7 +11,7 @@ import { fetchRelease, pickReleaseAsset, type Release } from "../lib/github.ts";
 import { downloadAndVerify, extractCommandArgv } from "../lib/install-download.ts";
 import { runSteps } from "../lib/step-runner.ts";
 import { pass, fail } from "../lib/output.ts";
-import { createLocalHost } from "../lib/host.ts";
+import { localRun } from "../lib/host.ts";
 
 // ─── Self-update ────────────────────────────────────────────────────────────
 
@@ -32,8 +32,7 @@ async function selfUpdate(release: Release): Promise<boolean> {
 
   const extractDir = join(tmpDir, "extracted");
   mkdirSync(extractDir, { recursive: true });
-  const local = createLocalHost();
-  const extracted = await local.run(extractCommandArgv(filePath, extractDir));
+  const extracted = await localRun(extractCommandArgv(filePath, extractDir));
   if (!extracted.ok) {
     fail("Extract", "Failed to extract archive");
     return false;

--- a/packages/xinity-cli/src/index.ts
+++ b/packages/xinity-cli/src/index.ts
@@ -9,6 +9,7 @@ import { actCommand, preloadActChoices } from "./commands/act.ts";
 import { configureCommand } from "./commands/configure.ts";
 import { rmCommand } from "./commands/rm.ts";
 import { completionCommand } from "./commands/completion.ts";
+import { stackCommand } from "./commands/stack.ts";
 
 // Wrapped in an async function to avoid top-level await, which Bun.build()
 // transforms into an internal `awaitPromise` call that breaks the two-step
@@ -22,17 +23,13 @@ async function main() {
   await yargs(hideBin(process.argv))
     .scriptName("xinity")
     .version(`v${version}`)
-    .option("target-host", {
-      describe: "SSH host to operate on (any valid ssh bind_address or host alias)",
-      type: "string",
-      global: true,
-    })
     .command(doctorCommand)
     .command(upCommand)
     .command(rmCommand)
     .command(updateCommand)
     .command(actCommand)
     .command(configureCommand)
+    .command(stackCommand)
     .command(completionCommand)
     .completion("__completions", false)
     .demandCommand(1, "Run xinity --help for available commands")

--- a/packages/xinity-cli/src/lib/clack.ts
+++ b/packages/xinity-cli/src/lib/clack.ts
@@ -4,7 +4,7 @@
  * All UI chrome (spinner, intro, outro, logs, prompts) goes to stderr so that
  * stdout stays clean for pipeable content (`xinity doctor --json | jq`).
  *
- * Usage: `import * as p from "./clack.ts"`, same API as @clack/prompts.
+ * Import the wrappers by name, same API as @clack/prompts.
  */
 import * as clack from "@clack/prompts";
 export { isCancel } from "@clack/prompts";
@@ -43,6 +43,9 @@ export const log = {
 
 export const select = <Value>(opts: clack.SelectOptions<Value>) =>
   clack.select({ output: OUT, ...opts });
+
+export const multiselect = <Value>(opts: clack.MultiSelectOptions<Value>) =>
+  clack.multiselect({ output: OUT, ...opts });
 
 export const confirm = (opts: clack.ConfirmOptions) =>
   clack.confirm({ output: OUT, ...opts });

--- a/packages/xinity-cli/src/lib/component-meta.ts
+++ b/packages/xinity-cli/src/lib/component-meta.ts
@@ -23,6 +23,10 @@ export const ENV_SCHEMAS: Record<Component, z.ZodObject<any>> = {
   infoserver: infoserverEnvSchema,
 };
 
+/** Listen ports assumed when PORT is not configured, taken from the env schemas. */
+export const GATEWAY_DEFAULT_PORT = String(gatewayEnvSchema.shape.PORT.parse(undefined));
+export const INFOSERVER_DEFAULT_PORT = String(infoserverEnvSchema.shape.PORT.parse(undefined));
+
 export const ENV_DIR = "/etc/xinity-ai";
 export const SECRETS_DIR = "/etc/xinity-ai/secrets";
 export const BIN_DIR = "/opt/xinity/bin";

--- a/packages/xinity-cli/src/lib/config.ts
+++ b/packages/xinity-cli/src/lib/config.ts
@@ -62,16 +62,12 @@ export function configPath(): string {
   return join(xinityConfigDir(), "config.json");
 }
 
-/** Returns null when the file is missing or not valid JSON. */
+/** Returns null when the file is missing. Throws on corrupt JSON. */
 export function loadPrivateJson<T>(path: string): T | null {
   if (!existsSync(path)) {
     return null;
   }
-  try {
-    return JSON.parse(readFileSync(path, "utf-8")) as T;
-  } catch {
-    return null;
-  }
+  return JSON.parse(readFileSync(path, "utf-8")) as T;
 }
 
 /** Write JSON readable only by the user (0700 directory, 0600 file). */
@@ -82,9 +78,13 @@ export function savePrivateJson(path: string, value: unknown): void {
   chmodSync(path, 0o600);
 }
 
-/** Read the config file, returning an empty object if it doesn't exist. */
+/** Read the config file, returning an empty object if it doesn't exist or is corrupt. */
 export function loadConfig(): CliConfig {
-  return loadPrivateJson<CliConfig>(configPath()) ?? {};
+  try {
+    return loadPrivateJson<CliConfig>(configPath()) ?? {};
+  } catch {
+    return {};
+  }
 }
 
 /** Write the full config object to disk, creating the directory if needed. */

--- a/packages/xinity-cli/src/lib/config.ts
+++ b/packages/xinity-cli/src/lib/config.ts
@@ -1,8 +1,9 @@
 /**
- * Persistent CLI configuration stored at ~/.config/xinity/config.json.
+ * Persistent CLI configuration stored at config.json under the xinity config
+ * dir ($XDG_CONFIG_HOME/xinity).
  */
 import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
-import { join } from "path";
+import { dirname, join } from "path";
 import { homedir } from "os";
 import * as p from "./clack.ts";
 import pc from "picocolors";
@@ -51,25 +52,44 @@ const CLI_FIELDS: ConfigField[] = [
   { key: "githubToken", label: "GitHub token (for private repo access)", isSecret: true },
 ];
 
-const CONFIG_DIR = join(homedir(), ".config", "xinity");
-export const CONFIG_PATH = join(CONFIG_DIR, "config.json");
+export function xinityConfigDir(): string {
+  return process.env.XDG_CONFIG_HOME
+    ? join(process.env.XDG_CONFIG_HOME, "xinity")
+    : join(homedir(), ".config", "xinity");
+}
+
+export function configPath(): string {
+  return join(xinityConfigDir(), "config.json");
+}
+
+/** Returns null when the file is missing or not valid JSON. */
+export function loadPrivateJson<T>(path: string): T | null {
+  if (!existsSync(path)) {
+    return null;
+  }
+  try {
+    return JSON.parse(readFileSync(path, "utf-8")) as T;
+  } catch {
+    return null;
+  }
+}
+
+/** Write JSON readable only by the user (0700 directory, 0600 file). */
+export function savePrivateJson(path: string, value: unknown): void {
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  chmodSync(dirname(path), 0o700);
+  writeFileSync(path, JSON.stringify(value, null, 2) + "\n", { mode: 0o600 });
+  chmodSync(path, 0o600);
+}
 
 /** Read the config file, returning an empty object if it doesn't exist. */
 export function loadConfig(): CliConfig {
-  if (!existsSync(CONFIG_PATH)) return {};
-  try {
-    return JSON.parse(readFileSync(CONFIG_PATH, "utf-8")) as CliConfig;
-  } catch {
-    return {};
-  }
+  return loadPrivateJson<CliConfig>(configPath()) ?? {};
 }
 
 /** Write the full config object to disk, creating the directory if needed. */
 export function saveConfig(config: CliConfig): void {
-  mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 });
-  chmodSync(CONFIG_DIR, 0o700);
-  writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2) + "\n", { mode: 0o600 });
-  chmodSync(CONFIG_PATH, 0o600);
+  savePrivateJson(configPath(), config);
 }
 
 /** Merge partial updates into the existing config and persist. */
@@ -139,6 +159,6 @@ export async function menuConfigureCli(): Promise<void> {
   }
 
   saveConfig(config);
-  p.log.success(`Config saved to ${pc.dim(CONFIG_PATH)}`);
+  p.log.success(`Config saved to ${pc.dim(configPath())}`);
   p.outro("Done");
 }

--- a/packages/xinity-cli/src/lib/connectivity.ts
+++ b/packages/xinity-cli/src/lib/connectivity.ts
@@ -1,63 +1,40 @@
-/**
- * Lightweight connectivity probes for Postgres and Redis.
- *
- * Used during `xinity up` to validate user-provided URLs before
- * persisting them. Reuses the Host tunnel abstraction so the same
- * code works for both local and remote (SSH) hosts.
- */
 import postgres from "postgres";
-import * as p from "./clack.ts";
-import pc from "picocolors";
 import type { Host } from "./host.ts";
 
-const okMark = (message: string) => `${pc.green("✓")}  ${message}`;
-const failMark = (message: string) => `${pc.red("✗")}  ${message}`;
+export interface ConnectionResult {
+  success: boolean;
+  error?: string;
+}
 
 const POSTGRES_CONNECT_TIMEOUT_SECONDS = 5;
 const REDIS_PING_TIMEOUT_MS = 5000;
 
-/**
- * Test PostgreSQL connectivity with a `SELECT 1`.
- * Shows a spinner while connecting. Returns true on success.
- */
-export async function testPostgresConnection(url: string, host: Host): Promise<boolean> {
+export async function testPostgresConnection(url: string, host: Host): Promise<ConnectionResult> {
   const tunnel = await host.openTunnel(url);
-  const spinner = p.spinner();
-  spinner.start("Testing database connection…");
   let sql: postgres.Sql | undefined;
   try {
     sql = postgres(tunnel.localUrl, { max: 1, connect_timeout: POSTGRES_CONNECT_TIMEOUT_SECONDS });
     await sql`SELECT 1`;
-    spinner.stop(okMark("Database connection successful"));
-    return true;
+    return { success: true };
   } catch (err) {
-    spinner.stop(failMark("Database connection failed"));
-    p.log.error(pc.dim(String(err)));
-    return false;
+    return { success: false, error: String(err) };
   } finally {
-    if (sql) await sql.end().catch(() => {});
+    if (sql) {
+      await sql.end().catch(() => {});
+    }
     await tunnel.close();
   }
 }
 
-/**
- * Test Redis connectivity with AUTH (if password set) + PING.
- * Shows a spinner while connecting. Returns true on +PONG or +OK.
- */
-export async function testRedisConnection(url: string, host: Host): Promise<boolean> {
+export async function testRedisConnection(url: string, host: Host): Promise<ConnectionResult> {
   const tunnel = await host.openTunnel(url);
-  const spinner = p.spinner();
-  spinner.start("Testing Redis connection…");
   let client: import("bun").RedisClient | undefined;
   try {
     client = new Bun.RedisClient(tunnel.localUrl, { connectionTimeout: REDIS_PING_TIMEOUT_MS });
     await client.ping();
-    spinner.stop(okMark("Redis connection successful"));
-    return true;
+    return { success: true };
   } catch (err) {
-    spinner.stop(failMark("Redis connection failed"));
-    p.log.error(pc.dim(String(err)));
-    return false;
+    return { success: false, error: String(err) };
   } finally {
     client?.close();
     await tunnel.close();

--- a/packages/xinity-cli/src/lib/connectivity.ts
+++ b/packages/xinity-cli/src/lib/connectivity.ts
@@ -11,6 +11,9 @@ const REDIS_PING_TIMEOUT_MS = 5000;
 
 export async function testPostgresConnection(url: string, host: Host): Promise<ConnectionResult> {
   const tunnel = await host.openTunnel(url);
+  if (!tunnel.ok) {
+    return { success: false, error: tunnel.error };
+  }
   let sql: postgres.Sql | undefined;
   try {
     sql = postgres(tunnel.localUrl, { max: 1, connect_timeout: POSTGRES_CONNECT_TIMEOUT_SECONDS });
@@ -28,6 +31,9 @@ export async function testPostgresConnection(url: string, host: Host): Promise<C
 
 export async function testRedisConnection(url: string, host: Host): Promise<ConnectionResult> {
   const tunnel = await host.openTunnel(url);
+  if (!tunnel.ok) {
+    return { success: false, error: tunnel.error };
+  }
   let client: import("bun").RedisClient | undefined;
   try {
     client = new Bun.RedisClient(tunnel.localUrl, { connectionTimeout: REDIS_PING_TIMEOUT_MS });

--- a/packages/xinity-cli/src/lib/doctor-probes.ts
+++ b/packages/xinity-cli/src/lib/doctor-probes.ts
@@ -47,6 +47,10 @@ export async function probeMigrationState(sql: postgres.Sql): Promise<CheckResul
 export async function checkPostgresAndMigrations(url: string, host: Host): Promise<CheckResult[]> {
   const results: CheckResult[] = [];
   const tunnel = await host.openTunnel(url);
+  if (!tunnel.ok) {
+    results.push({ label: "PostgreSQL", status: "fail", message: "Could not open tunnel", detail: tunnel.error });
+    return results;
+  }
   let sql: postgres.Sql | undefined;
   try {
     sql = postgres(tunnel.localUrl, { max: 1, connect_timeout: 5 });
@@ -118,6 +122,9 @@ export function probeTcpService(opts: TcpProbeOptions): Promise<CheckResult> {
 
 export async function checkRedis(url: string, host: Host): Promise<CheckResult> {
   const tunnel = await host.openTunnel(url);
+  if (!tunnel.ok) {
+    return { label: "Redis", status: "fail", message: "Could not open tunnel", detail: tunnel.error };
+  }
   let client: import("bun").RedisClient | undefined;
   try {
     client = new Bun.RedisClient(tunnel.localUrl);
@@ -175,6 +182,9 @@ export function isLocalUrl(url: string, expectedPort: string): boolean {
 
 export async function checkSmtp(url: string, host: Host): Promise<CheckResult> {
   const tunnel = await host.openTunnel(url);
+  if (!tunnel.ok) {
+    return { label: "SMTP", status: "warn", message: "Could not open tunnel", detail: tunnel.error };
+  }
   try {
     const parsed = new URL(tunnel.localUrl);
     const hostname = parsed.hostname;

--- a/packages/xinity-cli/src/lib/doctor.ts
+++ b/packages/xinity-cli/src/lib/doctor.ts
@@ -1,3 +1,4 @@
+import { green, yellow, red, dim } from "picocolors";
 import { readManifest, type ComponentEntry } from "./manifest.ts";
 import { commandExistsOn, isUnitActiveOn, readSecrets, type Host } from "./host.ts";
 import { isOllamaRunning } from "./ollama-setup.ts";
@@ -40,6 +41,17 @@ export interface DoctorReport {
   timestamp: string;
   components: ComponentReport[];
   summary: { pass: number; warn: number; fail: number; skip: number };
+}
+
+export function buildSummaryLine(summary: DoctorReport["summary"]): string {
+  return [
+    green(`${summary.pass} passed`),
+    summary.warn > 0 ? yellow(`${summary.warn} warnings`) : null,
+    summary.fail > 0 ? red(`${summary.fail} failed`) : null,
+    summary.skip > 0 ? dim(`${summary.skip} skipped`) : null,
+  ]
+    .filter(Boolean)
+    .join(dim(" · "));
 }
 
 function notInstalledReport(component: string, message = "Not installed"): ComponentReport {

--- a/packages/xinity-cli/src/lib/doctor.ts
+++ b/packages/xinity-cli/src/lib/doctor.ts
@@ -61,25 +61,21 @@ async function readFileWithElevation(
   path: string,
   description: string,
   opts: DoctorRunOptions,
-): Promise<{ content: string | null; permissionDenied: boolean; skipped: boolean }> {
+): Promise<{ content: string | null; permissionDenied: boolean }> {
   const host = opts.host;
   const content = await host.readFile(path);
   if (content !== null) {
-    return { content, permissionDenied: false, skipped: false };
+    return { content, permissionDenied: false };
   }
   // File not found or inaccessible, try elevated read if interactive
   if (opts.interactive) {
     opts.spinner?.stop();
-    const result = await host.withElevation(`cat '${path}'`, description, { sensitive: true });
+    const result = await host.withElevation(`cat '${path}'`, description);
     if (result.success) {
-      return { content: result.output, permissionDenied: false, skipped: false };
+      return { content: result.output, permissionDenied: false };
     }
-    if (result.skipped) {
-      return { content: null, permissionDenied: false, skipped: true };
-    }
-    return { content: null, permissionDenied: true, skipped: false };
   }
-  return { content: null, permissionDenied: true, skipped: false };
+  return { content: null, permissionDenied: true };
 }
 
 async function checkSystem(host: Host): Promise<ComponentReport> {
@@ -194,15 +190,6 @@ async function checkConfiguration(
     opts,
   );
 
-  if (envRead.skipped) {
-    checks.push({
-      label: "Env file",
-      status: "skip",
-      message: "Skipped",
-    });
-    return { checks, values: {}, permissionDenied: false };
-  }
-
   if (envRead.permissionDenied) {
     checks.push({
       label: "Env file",
@@ -224,7 +211,6 @@ async function checkConfiguration(
 
   // Read all secrets, elevating if needed
   let secretsPermDenied = false;
-  let secretsSkipped = false;
   let secrets: Record<string, string> = {};
 
   if (secretFields.length > 0) {
@@ -233,7 +219,6 @@ async function checkConfiguration(
       const sr = await readSecrets(host, SECRETS_DIR, secretFields.map((f) => f.key), `Read ${component} secrets`);
       secrets = sr.secrets;
       secretsPermDenied = sr.permissionDenied;
-      secretsSkipped = sr.skipped;
     } else {
       // Non-interactive: only try unelevated reads
       for (const field of secretFields) {
@@ -249,8 +234,6 @@ async function checkConfiguration(
 
   if (secretsPermDenied) {
     checks.push({ label: "Secrets", status: "skip", message: "Permission denied, rerun with sudo for full checks" });
-  } else if (secretsSkipped) {
-    checks.push({ label: "Secrets", status: "skip", message: "Skipped by user" });
   } else {
     checks.push(requiredFieldsPresenceCheck("Secrets", "All required secrets set", secretFields, values));
   }
@@ -321,42 +304,6 @@ async function checkGatewayConnectivity(
     checks.push(await checkServiceHealth(host, "Health endpoint", `http://${checkHost}:${port}/healthCheck`));
   }
   return checks;
-}
-
-async function checkSeaweedFSComponent(host: Host): Promise<ComponentReport> {
-  const checks: CheckResult[] = [];
-  const weedBin = `${BIN_DIR}/weed`;
-  const unitFile = `${UNIT_DIR}/xinity-ai-seaweedfs.service`;
-  const hasSystemd = await commandExistsOn(host, "systemctl");
-
-  // Binary
-  if (await host.fileExists(weedBin)) {
-    checks.push({ label: "Binary", status: "pass", message: weedBin });
-  } else if (await commandExistsOn(host, "weed")) {
-    checks.push({ label: "Binary", status: "pass", message: "weed found in PATH" });
-  } else {
-    checks.push({
-      label: "Binary",
-      status: "fail",
-      message: `Not found at ${weedBin}`,
-      detail: 'Run "xinity up seaweedfs" to install',
-    });
-  }
-
-  // Systemd unit
-  if (await host.fileExists(unitFile)) {
-    checks.push({ label: "Systemd unit", status: "pass", message: "xinity-ai-seaweedfs.service" });
-  } else {
-    checks.push({ label: "Systemd unit", status: "fail", message: "Unit file not found" });
-  }
-
-  checks.push(await serviceActiveCheck(host, "xinity-ai-seaweedfs.service", hasSystemd));
-
-  // S3 endpoint reachability
-  checks.push(await checkServiceHealth(host, "S3 endpoint", "http://127.0.0.1:8333/"));
-
-  const installed = await host.fileExists(weedBin) || await commandExistsOn(host, "weed");
-  return { component: "seaweedfs", installed, version: null, checks };
 }
 
 async function checkDashboardConnectivity(
@@ -654,16 +601,6 @@ export async function runDoctor(opts: DoctorRunOptions): Promise<DoctorReport> {
   // 3. Each installable component
   const checkedInfoserverUrls = new Set<string>();
   const remoteInfoserverChecks: CheckResult[] = [];
-
-  // 3a. SeaweedFS (checked independently, not in manifest)
-  opts.spinner?.message("Checking SeaweedFS…");
-  const seaweedBin = "/opt/xinity/bin/weed";
-  const seaweedInstalled = await host.fileExists(seaweedBin) || await commandExistsOn(host, "weed");
-  if (seaweedInstalled) {
-    components.push(await checkSeaweedFSComponent(host));
-  } else {
-    components.push(notInstalledReport("seaweedfs", "Not installed (optional, required for multimodal image storage)"));
-  }
 
   for (const comp of ["gateway", "dashboard", "daemon", "infoserver"] as const) {
     const entry = manifest.components[comp];

--- a/packages/xinity-cli/src/lib/doctor.ts
+++ b/packages/xinity-cli/src/lib/doctor.ts
@@ -611,7 +611,7 @@ export async function runDoctor(opts: DoctorRunOptions): Promise<DoctorReport> {
   components.push(await checkSystem(host));
 
   // 3. Each installable component
-  const checkedInfoserverUrls = new Set<string>();
+  const discoveredInfoserverUrls = new Map<string, string[]>();
   const remoteInfoserverChecks: CheckResult[] = [];
 
   for (const comp of ["gateway", "dashboard", "daemon", "infoserver"] as const) {
@@ -625,17 +625,26 @@ export async function runDoctor(opts: DoctorRunOptions): Promise<DoctorReport> {
       continue;
     }
     opts.spinner?.message(`Checking ${comp}…`);
+
+    const infoserverUrls = comp === "infoserver"
+      ? [...discoveredInfoserverUrls.entries()].map(([url, comps]) => ({ url, components: comps }))
+      : [];
+
     const { report, values } = await checkComponent(comp, entry, {
       ...opts,
       host,
-      infoserverUrls: [],
+      infoserverUrls,
     });
     components.push(report);
 
-    // Check each component's infoserver URL (skip duplicates)
-    if (comp !== "infoserver" && values.INFOSERVER_URL && !checkedInfoserverUrls.has(values.INFOSERVER_URL)) {
-      checkedInfoserverUrls.add(values.INFOSERVER_URL);
-      remoteInfoserverChecks.push(...await checkInfoserverUrl(values.INFOSERVER_URL, host, comp));
+    if (comp !== "infoserver" && values.INFOSERVER_URL) {
+      const existing = discoveredInfoserverUrls.get(values.INFOSERVER_URL);
+      if (existing) {
+        existing.push(comp);
+      } else {
+        discoveredInfoserverUrls.set(values.INFOSERVER_URL, [comp]);
+        remoteInfoserverChecks.push(...await checkInfoserverUrl(values.INFOSERVER_URL, host, comp));
+      }
     }
   }
 

--- a/packages/xinity-cli/src/lib/doctor.ts
+++ b/packages/xinity-cli/src/lib/doctor.ts
@@ -596,6 +596,7 @@ async function checkComponent(
 
 
 export async function runDoctor(opts: DoctorRunOptions): Promise<DoctorReport> {
+  infoserverCheckCache.clear();
   const components: ComponentReport[] = [];
 
   // 2. Read manifest (needed before probe to know which components to check)

--- a/packages/xinity-cli/src/lib/doctor.ts
+++ b/packages/xinity-cli/src/lib/doctor.ts
@@ -1,5 +1,5 @@
 import { readManifest, type ComponentEntry } from "./manifest.ts";
-import { commandExistsOn, isUnitActiveOn, readSecrets, type Host, createLocalHost } from "./host.ts";
+import { commandExistsOn, isUnitActiveOn, readSecrets, type Host } from "./host.ts";
 import { isOllamaRunning } from "./ollama-setup.ts";
 import { analyzeEnvSchema, categorizeFields, type EnvField } from "./env-prompt.ts";
 import { parseEnvString } from "./env-file.ts";
@@ -25,8 +25,8 @@ export interface DoctorRunOptions {
   interactive?: boolean;
   /** Spinner instance for progress updates during collection. */
   spinner?: DoctorSpinner;
-  /** Host to run diagnostics on. Defaults to local if not provided. */
-  host?: Host;
+  /** Host to run diagnostics on. */
+  host: Host;
 }
 
 export interface ComponentReport {
@@ -62,7 +62,7 @@ async function readFileWithElevation(
   description: string,
   opts: DoctorRunOptions,
 ): Promise<{ content: string | null; permissionDenied: boolean; skipped: boolean }> {
-  const host = opts.host ?? createLocalHost();
+  const host = opts.host;
   const content = await host.readFile(path);
   if (content !== null) {
     return { content, permissionDenied: false, skipped: false };
@@ -175,7 +175,7 @@ async function checkConfiguration(
   const checks: CheckResult[] = [];
   const envPath = `${ENV_DIR}/${component}.env`;
 
-  const host = opts.host ?? createLocalHost();
+  const host = opts.host;
 
   // Env file exists
   if (!(await host.fileExists(envPath))) {
@@ -581,7 +581,7 @@ async function checkComponent(
   entry: ComponentEntry,
   opts: DoctorRunOptions & { infoserverUrls?: { url: string; components: string[] }[] },
 ): Promise<{ report: ComponentReport; values: Record<string, string> }> {
-  const host = opts.host ?? createLocalHost();
+  const host = opts.host;
   const checks: CheckResult[] = [];
 
   // Installation
@@ -636,20 +636,16 @@ async function checkComponent(
 }
 
 
-export async function runDoctor(opts: DoctorRunOptions = {}): Promise<DoctorReport> {
-  let host = opts.host ?? createLocalHost();
+export async function runDoctor(opts: DoctorRunOptions): Promise<DoctorReport> {
   const components: ComponentReport[] = [];
 
   // 2. Read manifest (needed before probe to know which components to check)
-  const manifest = await readManifest(host);
+  const manifest = await readManifest(opts.host);
 
-  // For remote hosts, collect all state in a single SSH call to avoid
-  // dozens of individual round-trips (file checks, command checks, unit status).
-  if (host.isRemote) {
-    opts.spinner?.message("Collecting remote state…");
-    const state = await collectRemoteState(host, manifest);
-    host = createCachedHost(host, state);
-  }
+  // Collect all state in a single SSH call to avoid dozens of individual round-trips.
+  opts.spinner?.message("Collecting host state…");
+  const state = await collectRemoteState(opts.host, manifest);
+  const host = createCachedHost(opts.host, state);
 
   // 1. System checks
   opts.spinner?.message("Checking system…");

--- a/packages/xinity-cli/src/lib/doctor.ts
+++ b/packages/xinity-cli/src/lib/doctor.ts
@@ -5,7 +5,7 @@ import { isOllamaRunning } from "./ollama-setup.ts";
 import { analyzeEnvSchema, categorizeFields, type EnvField } from "./env-prompt.ts";
 import { parseEnvString } from "./env-file.ts";
 import { unitName } from "./systemd.ts";
-import { type Component, ENV_SCHEMAS, ENV_DIR, SECRETS_DIR, BIN_DIR, UNIT_DIR } from "./component-meta.ts";
+import { type Component, ENV_SCHEMAS, ENV_DIR, SECRETS_DIR, BIN_DIR, UNIT_DIR, GATEWAY_DEFAULT_PORT, INFOSERVER_DEFAULT_PORT } from "./component-meta.ts";
 import { collectRemoteState, createCachedHost } from "./remote-probe.ts";
 import {
   type CheckResult, type CheckStatus,
@@ -311,7 +311,7 @@ async function checkGatewayConnectivity(
   }
   if (serviceActive) {
     const bindHost = values.HOST || "localhost";
-    const port = values.PORT || "4010";
+    const port = values.PORT || GATEWAY_DEFAULT_PORT;
     const checkHost = bindHost === "0.0.0.0" ? "localhost" : bindHost;
     checks.push(await checkServiceHealth(host, "Health endpoint", `http://${checkHost}:${port}/healthCheck`));
   }
@@ -358,7 +358,7 @@ async function checkInfoserverConnectivity(
   host: Host,
 ): Promise<CheckResult[]> {
   const checks: CheckResult[] = [];
-  const localPort = values.PORT || "8090";
+  const localPort = values.PORT || INFOSERVER_DEFAULT_PORT;
 
   // Check configured INFOSERVER_URL(s) from other components
   for (const { url, components } of discoveredUrls) {

--- a/packages/xinity-cli/src/lib/env-file.ts
+++ b/packages/xinity-cli/src/lib/env-file.ts
@@ -15,7 +15,9 @@ export function parseEnvString(content: string): Record<string, string> {
     if (eq === -1) continue;
     const key = trimmed.slice(0, eq).trim();
     let value = trimmed.slice(eq + 1).trim();
-    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+    if (value.startsWith('"') && value.endsWith('"')) {
+      value = value.slice(1, -1).replace(/\\"/g, '"');
+    } else if (value.startsWith("'") && value.endsWith("'")) {
       value = value.slice(1, -1);
     }
     result[key] = value;

--- a/packages/xinity-cli/src/lib/env-prompt.ts
+++ b/packages/xinity-cli/src/lib/env-prompt.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
-import * as p from "./clack.ts";
-import pc from "picocolors";
+import { select, confirm, text, password, log, isCancel } from "./clack.ts";
+import { bold, cyan, dim, yellow, green } from "picocolors";
 import { promptOrExit, cancelAndExit } from "./output.ts";
 import { parseEnvString } from "./env-file.ts";
 import { type Component, ENV_SCHEMAS, ENV_DIR, SECRETS_DIR } from "./component-meta.ts";
@@ -48,10 +48,16 @@ function resolveJsonSchemaType(prop: JsonSchemaProp): string | undefined {
   return nonNull?.type ?? "string";
 }
 
-/** Analyze a Zod env schema into structured field metadata. */
+const schemaFieldCache = new WeakMap<z.ZodObject<any>, EnvField[]>();
+
+/** Analyze a Zod env schema into structured field metadata. Cached per schema object. */
 export function analyzeEnvSchema(
   schema: z.ZodObject<any>,
 ): EnvField[] {
+  const cached = schemaFieldCache.get(schema);
+  if (cached) {
+    return cached;
+  }
   const jsonSchema = z.toJSONSchema(schema) as {
     properties: Record<string, JsonSchemaProp>;
     required?: string[];
@@ -80,7 +86,17 @@ export function analyzeEnvSchema(
     });
   }
 
+  schemaFieldCache.set(schema, fields);
   return fields;
+}
+
+/** The single definition of "the config is invalid without this field". */
+export function isRequiredUnset(field: EnvField, values: Record<string, string | undefined>): boolean {
+  return !field.isOptional && !field.hasDefault && !values[field.key];
+}
+
+export function missingRequiredFields(fields: EnvField[], values: Record<string, string | undefined>): EnvField[] {
+  return fields.filter((f) => isRequiredUnset(f, values));
 }
 
 export function categorizeFields(fields: EnvField[]): {
@@ -120,6 +136,10 @@ export function splitValuesByCategory(
 export interface EnvBundle {
   config: Record<string, string>;
   secrets: Record<string, string>;
+}
+
+export function flattenBundle(bundle: EnvBundle): Record<string, string> {
+  return { ...bundle.config, ...bundle.secrets };
 }
 
 export interface EnvChange {
@@ -197,7 +217,7 @@ export async function promptForEnv(
   await promptFieldsUnderHeading(visibleSecrets, "Secrets", existingValues, config, secrets);
 
   if (expertFields.length > 0) {
-    const showAdvanced = await promptOrExit(p.confirm({
+    const showAdvanced = await promptOrExit(confirm({
       message: "Configure advanced settings?",
       initialValue: false,
     }));
@@ -218,32 +238,50 @@ async function promptFieldsUnderHeading(
   secrets: Record<string, string>,
 ): Promise<void> {
   if (fields.length === 0) return;
-  p.log.step(pc.bold(heading));
+  log.step(bold(heading));
   for (const field of fields) {
     const value = await promptField(field, existingValues?.[field.key]);
-    if (value !== undefined) assignByCategory(field, value, config, secrets);
+    if (value !== undefined && value !== FIELD_CANCELLED) assignByCategory(field, value, config, secrets);
   }
 }
 
-/** Prompt for a single field value. Returns undefined if skipped. */
+/** Distinguishes an Escape (back out, change nothing) from a skipped/cleared field. */
+const FIELD_CANCELLED: unique symbol = Symbol("field-cancelled");
+
+/**
+ * Prompt for a single field value. Returns undefined if skipped. When
+ * `cancelable`, Escape returns FIELD_CANCELLED instead of exiting the CLI
+ * (menu editors treat it as backing out to the menu).
+ */
 async function promptField(
   field: EnvField,
   existingValue?: string,
-): Promise<string | undefined> {
-  const hint = field.description ? pc.dim(` (${field.description})`) : "";
-  const optTag = field.isOptional ? pc.dim(" [optional]") : "";
+  cancelable = false,
+): Promise<string | undefined | typeof FIELD_CANCELLED> {
+  const resolve = async <T>(prompt: Promise<T | symbol>): Promise<T | typeof FIELD_CANCELLED> => {
+    const value = await prompt;
+    if (isCancel(value)) {
+      if (cancelable) return FIELD_CANCELLED;
+      cancelAndExit();
+    }
+    return value as T;
+  };
+
+  const hint = field.description ? dim(` (${field.description})`) : "";
+  const optTag = field.isOptional ? dim(" [optional]") : "";
   const existing = existingValue ?? (field.hasDefault ? String(field.defaultValue) : undefined);
 
   // Secret → masked password input
   if (field.isSecret) {
-    const keepHint = existing ? pc.dim(" [Enter to keep current]") : "";
-    const value = await promptOrExit(p.password({
+    const keepHint = existing ? dim(" [Enter to keep current]") : "";
+    const value = await resolve(password({
       message: `${field.key}${hint}${optTag}${keepHint}`,
       validate: (val) => {
         if (!val && !existing && !field.isOptional && !field.hasDefault) return "This field is required";
         return undefined;
       },
     }));
+    if (value === FIELD_CANCELLED) return value;
     return value || existing || undefined;
   }
 
@@ -251,29 +289,31 @@ async function promptField(
   if (field.enumValues) {
     const options = field.enumValues.map((v) => ({ value: v, label: v }));
     if (field.isOptional) {
-      options.unshift({ value: "__skip__", label: pc.dim("skip") });
+      options.unshift({ value: "__skip__", label: dim("skip") });
     }
-    const value = await promptOrExit(p.select({
+    const value = await resolve(select({
       message: `${field.key}${hint}${optTag}`,
       options,
       initialValue: existing,
     }));
+    if (value === FIELD_CANCELLED) return value;
     return value === "__skip__" ? undefined : value;
   }
 
   // Boolean → confirm
   if (field.isBoolean) {
-    const value = await promptOrExit(p.confirm({
+    const value = await resolve(confirm({
       message: `${field.key}${hint}`,
       initialValue: existingValue !== undefined
         ? existingValue === "true" || existingValue === "1"
         : field.hasDefault && field.defaultValue === true,
     }));
+    if (value === FIELD_CANCELLED) return value;
     return String(value);
   }
 
   // Number or string → text input
-  const value = await promptOrExit(p.text({
+  const value = await resolve(text({
     message: `${field.key}${hint}${optTag}`,
     placeholder: existing ?? undefined,
     defaultValue: existing ?? undefined,
@@ -283,23 +323,26 @@ async function promptField(
       return undefined;
     },
   }));
+  if (value === FIELD_CANCELLED) return value;
   return value || undefined;
 }
 
 /** Format a field's current value for display in the menu. */
 function displayValue(field: EnvField, value: string | undefined): string {
   if (value !== undefined && value !== "") {
-    if (field.isSecret) return pc.dim("••••••");
-    return pc.cyan(value);
+    if (field.isSecret) return dim("••••••");
+    return cyan(value);
   }
-  if (field.hasDefault) return pc.dim(`(default: ${field.defaultValue})`);
-  if (field.isOptional) return pc.dim("(not set)");
-  return pc.yellow("(not set)");
+  if (field.hasDefault) return dim(`(default: ${field.defaultValue})`);
+  if (field.isOptional) return dim("(not set)");
+  return yellow("(not set)");
 }
 
 export interface MenuEditOptions {
-  /** Keys flagged as "new", highlighted in label and required to be set before save. */
-  newKeys?: Set<string>;
+  /** Keys highlighted for review: values worth a deliberate look, not enforced. */
+  attentionKeys?: Set<string>;
+  /** Keys owned by another layer (e.g. stack shared settings): not shown, not editable; their seeded values pass through. */
+  hiddenKeys?: Set<string>;
   /** Message displayed above the menu. */
   message?: string;
 }
@@ -307,6 +350,10 @@ export interface MenuEditOptions {
 /**
  * Menu-based env editor. Returns the merged { config, secrets } without
  * persisting anything. Returns null if the user cancels.
+ *
+ * Required fields are marked and block saving while unset. Expert fields
+ * are hidden behind an "advanced settings" toggle unless they already
+ * carry a value or need attention.
  */
 export async function menuEditEnv(
   schema: z.ZodObject<any>,
@@ -314,48 +361,66 @@ export async function menuEditEnv(
   opts?: MenuEditOptions,
 ): Promise<{ config: Record<string, string>; secrets: Record<string, string> } | null> {
   const fields = analyzeEnvSchema(schema);
-  const newKeys = opts?.newKeys ?? new Set<string>();
+  const attentionKeys = opts?.attentionKeys ?? new Set<string>();
+  const hiddenKeys = opts?.hiddenKeys ?? new Set<string>();
+  const editable = fields.filter((f) => !hiddenKeys.has(f.key));
   const values: Record<string, string | undefined> = { ...existing };
+  let showExpert = false;
 
-  const newMarker = pc.yellow("● new ");
+  const isUnset = (f: EnvField) => values[f.key] === undefined || values[f.key] === "";
+  const requiredUnset = (f: EnvField) => isRequiredUnset(f, values);
+  const isVisible = (f: EnvField) =>
+    !f.isExpert || showExpert || !isUnset(f) || requiredUnset(f) || attentionKeys.has(f.key);
 
   while (true) {
-    const options = fields.map((field) => {
-      const marker = newKeys.has(field.key) ? newMarker : "";
+    const hiddenCount = editable.filter((f) => !isVisible(f)).length;
+
+    const options = editable.filter(isVisible).map((field) => {
+      const marker = requiredUnset(field)
+        ? yellow("● required ")
+        : attentionKeys.has(field.key) ? cyan("● review ") : "";
+      const key = field.isExpert ? dim(field.key) : field.key;
       return {
         value: field.key,
-        label: `${marker}${field.key}  ${displayValue(field, values[field.key])}`,
+        label: `${marker}${key}  ${displayValue(field, values[field.key])}`,
         hint: field.description,
       };
     });
-    options.push({ value: "__save__", label: pc.green("Save & exit"), hint: undefined });
+    if (hiddenCount > 0) {
+      options.push({ value: "__expert__", label: dim(`Show advanced settings (${hiddenCount} more)…`), hint: undefined });
+    } else if (showExpert && editable.some((f) => f.isExpert)) {
+      options.push({ value: "__expert__", label: dim("Hide advanced settings"), hint: undefined });
+    }
+    options.push({ value: "__save__", label: green("Save & exit"), hint: undefined });
 
-    const choice = await p.select({
+    const choice = await select({
       message: opts?.message ?? "Select a value to update",
       options,
     });
 
-    if (p.isCancel(choice)) return null;
+    if (isCancel(choice)) return null;
+
+    if (choice === "__expert__") {
+      showExpert = !showExpert;
+      continue;
+    }
 
     if (choice === "__save__") {
-      const unsetRequiredNew = fields.filter(
-        (f) =>
-          newKeys.has(f.key) &&
-          !f.isOptional &&
-          !f.hasDefault &&
-          (values[f.key] === undefined || values[f.key] === ""),
-      );
-      if (unsetRequiredNew.length > 0) {
-        p.log.warn(
-          `These new variables are required and not set: ${unsetRequiredNew.map((f) => f.key).join(", ")}`,
+      const blocking = missingRequiredFields(editable, values);
+      if (blocking.length > 0) {
+        log.warn(
+          `These variables are required and not set: ${blocking.map((f) => f.key).join(", ")}`,
         );
         continue;
       }
       break;
     }
 
-    const field = fields.find((f) => f.key === choice)!;
-    const newValue = await promptField(field, values[field.key]);
+    const field = editable.find((f) => f.key === choice)!;
+    const newValue = await promptField(field, values[field.key], true);
+    if (newValue === FIELD_CANCELLED) {
+      continue;
+    }
     if (newValue !== undefined) {
       values[field.key] = newValue;
     } else {
@@ -376,16 +441,17 @@ export async function readExistingEnvState(component: Component, host: Host): Pr
   const { secretFields } = categorizeFields(analyzeEnvSchema(ENV_SCHEMAS[component]));
   const secretKeys = secretFields.map((f) => f.key);
 
-  const envContent = await host.readFile(`${ENV_DIR}/${component}.env`);
-  const existingConfig = envContent ? parseEnvString(envContent) : {};
+  const [envContent, secretsResult] = await Promise.all([
+    host.readFile(`${ENV_DIR}/${component}.env`),
+    secretKeys.length > 0
+      ? readSecrets(host, SECRETS_DIR, secretKeys, "Read existing secrets")
+      : Promise.resolve({ secrets: {} as Record<string, string>, permissionDenied: false }),
+  ]);
 
-  let existingSecrets: Record<string, string> = {};
-  if (secretKeys.length > 0) {
-    const sr = await readSecrets(host, SECRETS_DIR, secretKeys, "Read existing secrets");
-    existingSecrets = sr.secrets;
-  }
-
-  return { existingConfig, existingSecrets };
+  return {
+    existingConfig: envContent ? parseEnvString(envContent) : {},
+    existingSecrets: secretsResult.secrets,
+  };
 }
 
 export interface CollectedEnv extends EnvBundle {
@@ -414,9 +480,7 @@ export async function collectEnv(
   const hasExistingConfig = Object.keys(existingConfig).length > 0;
   const existing = { ...autoDefaults, ...existingConfig, ...existingSecrets };
 
-  const missingRequired = fields.filter(
-    (f) => !f.isOptional && !f.hasDefault && !existing[f.key],
-  );
+  const missingRequired = missingRequiredFields(fields, existing);
 
   const withChanges = (result: EnvBundle): CollectedEnv => ({
     ...result,
@@ -428,7 +492,7 @@ export async function collectEnv(
 
   if (isInstalled && hasExistingConfig) {
     if (missingRequired.length === 0) {
-      const action = await promptOrExit(p.select({
+      const action = await promptOrExit(select({
         message: "All configuration variables are already set.",
         options: [
           { value: "skip", label: "Keep current configuration" },
@@ -439,17 +503,16 @@ export async function collectEnv(
       const result = await menuEditEnv(schema, existing);
       return result ? withChanges(result) : useExisting();
     } else {
-      p.log.info(
+      log.info(
         `${missingRequired.length} new variable(s) need to be set. Edit any other values too if you like.`,
       );
-      const newKeys = new Set(missingRequired.map((f) => f.key));
-      const result = await menuEditEnv(schema, existing, { newKeys });
+      const result = await menuEditEnv(schema, existing);
       if (result === null) cancelAndExit();
       return withChanges(result);
     }
   } else if (hasExistingConfig && missingRequired.length === 0) {
     // Not in manifest but has existing config, preserve original behavior
-    const reconfigure = await promptOrExit(p.confirm({
+    const reconfigure = await promptOrExit(confirm({
       message: "Existing configuration found. Reconfigure?",
       initialValue: false,
     }));

--- a/packages/xinity-cli/src/lib/env-prompt.ts
+++ b/packages/xinity-cli/src/lib/env-prompt.ts
@@ -6,7 +6,7 @@ import { parseEnvString } from "./env-file.ts";
 import { type Component, ENV_SCHEMAS, ENV_DIR, SECRETS_DIR, getAutoDefaults } from "./component-meta.ts";
 import { writeEnvConfig, writeSystemdUnit, restartService } from "./service.ts";
 import { runSteps } from "./step-runner.ts";
-import { createLocalHost, readSecrets, type Host } from "./host.ts";
+import { readSecrets, type Host } from "./host.ts";
 
 export interface EnvField {
   key: string;
@@ -350,9 +350,8 @@ export async function menuEditEnv(
  */
 export async function menuConfigureEnv(
   component: Component,
-  host?: Host,
+  host: Host,
 ): Promise<void> {
-  const h = host ?? createLocalHost();
   const schema = ENV_SCHEMAS[component];
   const fields = analyzeEnvSchema(schema);
   const { secretFields } = categorizeFields(fields);
@@ -361,12 +360,12 @@ export async function menuConfigureEnv(
   p.intro(`xinity configure ${pc.cyan(component)}`);
 
   const envPath = `${ENV_DIR}/${component}.env`;
-  const envContent = await h.readFile(envPath);
+  const envContent = await host.readFile(envPath);
   const existingConfig = envContent ? parseEnvString(envContent) : {};
   let secretsLocked = false;
   let existingSecrets: Record<string, string> = {};
   if (secretKeys.length > 0) {
-    const sr = await readSecrets(h, SECRETS_DIR, secretKeys, "Read existing secrets");
+    const sr = await readSecrets(host, SECRETS_DIR, secretKeys, "Read existing secrets");
     existingSecrets = sr.secrets;
     secretsLocked = sr.skipped;
   }
@@ -379,11 +378,11 @@ export async function menuConfigureEnv(
     return;
   }
 
-  const configResult = await writeEnvConfig(component, result.config, result.secrets, h);
+  const configResult = await writeEnvConfig(component, result.config, result.secrets, host);
   if (configResult.success) {
     p.log.success("Config – Environment configured");
-    await writeSystemdUnit(component, Object.keys(result.secrets), h);
-    await runSteps(restartService(component, h));
+    await writeSystemdUnit(component, Object.keys(result.secrets), host);
+    await runSteps(restartService(component, host));
   } else if (configResult.error) {
     p.log.error(`Config – ${configResult.error}`);
   }

--- a/packages/xinity-cli/src/lib/env-prompt.ts
+++ b/packages/xinity-cli/src/lib/env-prompt.ts
@@ -343,6 +343,8 @@ export interface MenuEditOptions {
   attentionKeys?: Set<string>;
   /** Keys owned by another layer (e.g. stack shared settings): not shown, not editable; their seeded values pass through. */
   hiddenKeys?: Set<string>;
+  /** Values the edited layer inherits; expert fields still matching them stay behind the advanced toggle. */
+  inherited?: Record<string, string>;
   /** Message displayed above the menu. */
   message?: string;
 }
@@ -352,8 +354,8 @@ export interface MenuEditOptions {
  * persisting anything. Returns null if the user cancels.
  *
  * Required fields are marked and block saving while unset. Expert fields
- * are hidden behind an "advanced settings" toggle unless they already
- * carry a value or need attention.
+ * are hidden behind an "advanced settings" toggle unless they carry a
+ * value beyond the inherited baseline or need attention.
  */
 export async function menuEditEnv(
   schema: z.ZodObject<any>,
@@ -363,14 +365,16 @@ export async function menuEditEnv(
   const fields = analyzeEnvSchema(schema);
   const attentionKeys = opts?.attentionKeys ?? new Set<string>();
   const hiddenKeys = opts?.hiddenKeys ?? new Set<string>();
+  const inherited = opts?.inherited ?? {};
   const editable = fields.filter((f) => !hiddenKeys.has(f.key));
   const values: Record<string, string | undefined> = { ...existing };
   let showExpert = false;
 
   const isUnset = (f: EnvField) => values[f.key] === undefined || values[f.key] === "";
   const requiredUnset = (f: EnvField) => isRequiredUnset(f, values);
+  const isInherited = (f: EnvField) => inherited[f.key] !== undefined && values[f.key] === inherited[f.key];
   const isVisible = (f: EnvField) =>
-    !f.isExpert || showExpert || !isUnset(f) || requiredUnset(f) || attentionKeys.has(f.key);
+    !f.isExpert || showExpert || (!isUnset(f) && !isInherited(f)) || requiredUnset(f) || attentionKeys.has(f.key);
 
   while (true) {
     const hiddenCount = editable.filter((f) => !isVisible(f)).length;

--- a/packages/xinity-cli/src/lib/env-prompt.ts
+++ b/packages/xinity-cli/src/lib/env-prompt.ts
@@ -1,12 +1,11 @@
 import { z } from "zod";
 import * as p from "./clack.ts";
 import pc from "picocolors";
-import { promptOrExit } from "./output.ts";
+import { promptOrExit, cancelAndExit } from "./output.ts";
 import { parseEnvString } from "./env-file.ts";
-import { type Component, ENV_SCHEMAS, ENV_DIR, SECRETS_DIR, getAutoDefaults } from "./component-meta.ts";
-import { writeEnvConfig, writeSystemdUnit, restartService } from "./service.ts";
-import { runSteps } from "./step-runner.ts";
+import { type Component, ENV_SCHEMAS, ENV_DIR, SECRETS_DIR } from "./component-meta.ts";
 import { readSecrets, type Host } from "./host.ts";
+import { readManifest } from "./manifest.ts";
 
 export interface EnvField {
   key: string;
@@ -116,6 +115,39 @@ export function splitValuesByCategory(
     if (val !== undefined) assignByCategory(field, val, config, secrets);
   }
   return { config, secrets };
+}
+
+export interface EnvBundle {
+  config: Record<string, string>;
+  secrets: Record<string, string>;
+}
+
+export interface EnvChange {
+  key: string;
+  kind: "added" | "changed" | "removed";
+  isSecret: boolean;
+  before?: string;
+  after?: string;
+}
+
+/** What applying `after` would change relative to the values currently on the host. */
+export function diffEnv(before: EnvBundle, after: EnvBundle): EnvChange[] {
+  const changes: EnvChange[] = [];
+  const compare = (prev: Record<string, string>, next: Record<string, string>, isSecret: boolean) => {
+    for (const [key, value] of Object.entries(next)) {
+      if (!(key in prev)) {
+        changes.push({ key, kind: "added", isSecret, after: value });
+      } else if (prev[key] !== value) {
+        changes.push({ key, kind: "changed", isSecret, before: prev[key], after: value });
+      }
+    }
+    for (const key of Object.keys(prev)) {
+      if (!(key in next)) changes.push({ key, kind: "removed", isSecret });
+    }
+  };
+  compare(before.config, after.config, false);
+  compare(before.secrets, after.secrets, true);
+  return changes;
 }
 
 function prefillFromExisting(
@@ -255,22 +287,19 @@ async function promptField(
 }
 
 /** Format a field's current value for display in the menu. */
-function displayValue(field: EnvField, value: string | undefined, locked = false): string {
+function displayValue(field: EnvField, value: string | undefined): string {
   if (value !== undefined && value !== "") {
     if (field.isSecret) return pc.dim("••••••");
     return pc.cyan(value);
   }
-  if (locked && field.isSecret) return pc.dim("(locked)");
   if (field.hasDefault) return pc.dim(`(default: ${field.defaultValue})`);
   if (field.isOptional) return pc.dim("(not set)");
   return pc.yellow("(not set)");
 }
 
 export interface MenuEditOptions {
-  /** Keys flagged as "new" — highlighted in label and required to be set before save. */
+  /** Keys flagged as "new", highlighted in label and required to be set before save. */
   newKeys?: Set<string>;
-  /** Secrets we couldn't read because elevation was skipped — shown as (locked). */
-  secretsLocked?: boolean;
   /** Message displayed above the menu. */
   message?: string;
 }
@@ -278,10 +307,6 @@ export interface MenuEditOptions {
 /**
  * Menu-based env editor. Returns the merged { config, secrets } without
  * persisting anything. Returns null if the user cancels.
- *
- * Used by both `xinity configure` (where the caller writes to disk and
- * restarts the service) and the `xinity up` update flow (where the caller
- * passes the result through the installer's existing write path).
  */
 export async function menuEditEnv(
   schema: z.ZodObject<any>,
@@ -290,7 +315,6 @@ export async function menuEditEnv(
 ): Promise<{ config: Record<string, string>; secrets: Record<string, string> } | null> {
   const fields = analyzeEnvSchema(schema);
   const newKeys = opts?.newKeys ?? new Set<string>();
-  const secretsLocked = opts?.secretsLocked ?? false;
   const values: Record<string, string | undefined> = { ...existing };
 
   const newMarker = pc.yellow("● new ");
@@ -300,7 +324,7 @@ export async function menuEditEnv(
       const marker = newKeys.has(field.key) ? newMarker : "";
       return {
         value: field.key,
-        label: `${marker}${field.key}  ${displayValue(field, values[field.key], secretsLocked && field.isSecret)}`,
+        label: `${marker}${field.key}  ${displayValue(field, values[field.key])}`,
         hint: field.description,
       };
     });
@@ -342,50 +366,95 @@ export async function menuEditEnv(
   return splitValuesByCategory(fields, values);
 }
 
-/**
- * Menu-based interactive configuration for a component's env vars.
- *
- * Loads current values from disk, opens the menu editor, and on save
- * persists the result and restarts the service.
- */
-export async function menuConfigureEnv(
-  component: Component,
-  host: Host,
-): Promise<void> {
-  const schema = ENV_SCHEMAS[component];
-  const fields = analyzeEnvSchema(schema);
-  const { secretFields } = categorizeFields(fields);
+/** A component's env values as currently present on the host. */
+export interface ExistingEnvState {
+  existingConfig: Record<string, string>;
+  existingSecrets: Record<string, string>;
+}
+
+export async function readExistingEnvState(component: Component, host: Host): Promise<ExistingEnvState> {
+  const { secretFields } = categorizeFields(analyzeEnvSchema(ENV_SCHEMAS[component]));
   const secretKeys = secretFields.map((f) => f.key);
 
-  p.intro(`xinity configure ${pc.cyan(component)}`);
-
-  const envPath = `${ENV_DIR}/${component}.env`;
-  const envContent = await host.readFile(envPath);
+  const envContent = await host.readFile(`${ENV_DIR}/${component}.env`);
   const existingConfig = envContent ? parseEnvString(envContent) : {};
-  let secretsLocked = false;
+
   let existingSecrets: Record<string, string> = {};
   if (secretKeys.length > 0) {
     const sr = await readSecrets(host, SECRETS_DIR, secretKeys, "Read existing secrets");
     existingSecrets = sr.secrets;
-    secretsLocked = sr.skipped;
-  }
-  const autoDefaults = getAutoDefaults(component);
-  const existing: Record<string, string> = { ...autoDefaults, ...existingConfig, ...existingSecrets };
-
-  const result = await menuEditEnv(schema, existing, { secretsLocked });
-  if (result === null) {
-    p.cancel("Cancelled, no changes saved.");
-    return;
   }
 
-  const configResult = await writeEnvConfig(component, result.config, result.secrets, host);
-  if (configResult.success) {
-    p.log.success("Config – Environment configured");
-    await writeSystemdUnit(component, Object.keys(result.secrets), host);
-    await runSteps(restartService(component, host));
-  } else if (configResult.error) {
-    p.log.error(`Config – ${configResult.error}`);
-  }
-  p.outro("Done");
+  return { existingConfig, existingSecrets };
 }
 
+export interface CollectedEnv extends EnvBundle {
+  changes: EnvChange[];
+}
+
+/**
+ * Planning-phase env collection: load current values from the host, prompt
+ * for whatever is missing (or let the user edit), and report what applying
+ * the result would change. Writes nothing. Returns null on cancel.
+ */
+export async function collectEnv(
+  component: Component,
+  host: Host,
+  autoDefaults: Record<string, string>,
+  skipKeys?: Set<string>,
+): Promise<CollectedEnv | null> {
+  const schema = ENV_SCHEMAS[component];
+  const fields = analyzeEnvSchema(schema);
+  const { existingConfig, existingSecrets } = await readExistingEnvState(component, host);
+
+  // Only the component's own env file marks it as previously configured.
+  // The secrets dir is shared infrastructure: on a fresh install the redis
+  // step already stored REDIS_URL there before any component exists, and
+  // that must not make the first component look like a leftover install.
+  const hasExistingConfig = Object.keys(existingConfig).length > 0;
+  const existing = { ...autoDefaults, ...existingConfig, ...existingSecrets };
+
+  const missingRequired = fields.filter(
+    (f) => !f.isOptional && !f.hasDefault && !existing[f.key],
+  );
+
+  const withChanges = (result: EnvBundle): CollectedEnv => ({
+    ...result,
+    changes: diffEnv({ config: existingConfig, secrets: existingSecrets }, result),
+  });
+  const useExisting = () => withChanges(splitValuesByCategory(fields, existing));
+
+  const isInstalled = !!(await readManifest(host)).components[component];
+
+  if (isInstalled && hasExistingConfig) {
+    if (missingRequired.length === 0) {
+      const action = await promptOrExit(p.select({
+        message: "All configuration variables are already set.",
+        options: [
+          { value: "skip", label: "Keep current configuration" },
+          { value: "edit", label: "Edit configuration" },
+        ],
+      }));
+      if (action === "skip") return useExisting();
+      const result = await menuEditEnv(schema, existing);
+      return result ? withChanges(result) : useExisting();
+    } else {
+      p.log.info(
+        `${missingRequired.length} new variable(s) need to be set. Edit any other values too if you like.`,
+      );
+      const newKeys = new Set(missingRequired.map((f) => f.key));
+      const result = await menuEditEnv(schema, existing, { newKeys });
+      if (result === null) cancelAndExit();
+      return withChanges(result);
+    }
+  } else if (hasExistingConfig && missingRequired.length === 0) {
+    // Not in manifest but has existing config, preserve original behavior
+    const reconfigure = await promptOrExit(p.confirm({
+      message: "Existing configuration found. Reconfigure?",
+      initialValue: false,
+    }));
+    if (!reconfigure) return useExisting();
+  }
+
+  return withChanges(await promptForEnv(component, schema, existing, skipKeys));
+}

--- a/packages/xinity-cli/src/lib/env-prompt.ts
+++ b/packages/xinity-cli/src/lib/env-prompt.ts
@@ -5,6 +5,7 @@ import { promptOrExit } from "./output.ts";
 import { parseEnvString } from "./env-file.ts";
 import { type Component, ENV_SCHEMAS, ENV_DIR, SECRETS_DIR, getAutoDefaults } from "./component-meta.ts";
 import { writeEnvConfig, writeSystemdUnit, restartService } from "./service.ts";
+import { runSteps } from "./step-runner.ts";
 import { createLocalHost, readSecrets, type Host } from "./host.ts";
 
 export interface EnvField {
@@ -378,10 +379,13 @@ export async function menuConfigureEnv(
     return;
   }
 
-  const wrote = await writeEnvConfig(component, result.config, result.secrets, h);
-  if (wrote) {
+  const configResult = await writeEnvConfig(component, result.config, result.secrets, h);
+  if (configResult.success) {
+    p.log.success("Config – Environment configured");
     await writeSystemdUnit(component, Object.keys(result.secrets), h);
-    await restartService(component, h);
+    await runSteps(restartService(component, h));
+  } else if (configResult.error) {
+    p.log.error(`Config – ${configResult.error}`);
   }
   p.outro("Done");
 }

--- a/packages/xinity-cli/src/lib/github.ts
+++ b/packages/xinity-cli/src/lib/github.ts
@@ -67,8 +67,23 @@ async function apiHeaders(accept = "application/vnd.github+json"): Promise<Recor
   return headers;
 }
 
-/** Fetch a release by version tag (or "latest"). */
-export async function fetchRelease(version: string): Promise<Release> {
+const releaseCache = new Map<string, Promise<Release>>();
+
+/**
+ * Fetch a release by version tag (or "latest"). One API call per version
+ * per run: `up all` resolves the same release for every component, and
+ * unauthenticated GitHub rate limits are tight.
+ */
+export function fetchRelease(version: string): Promise<Release> {
+  const cached = releaseCache.get(version);
+  if (cached) return cached;
+  const pending = fetchReleaseFromApi(version);
+  releaseCache.set(version, pending);
+  pending.catch(() => releaseCache.delete(version));
+  return pending;
+}
+
+async function fetchReleaseFromApi(version: string): Promise<Release> {
   const base = getApiBase();
   const url =
     version === "latest"

--- a/packages/xinity-cli/src/lib/github.ts
+++ b/packages/xinity-cli/src/lib/github.ts
@@ -86,6 +86,21 @@ export function fetchRelease(version: string): Promise<Release> {
   return pending;
 }
 
+export interface ReleaseListEntry {
+  tagName: string;
+  prerelease: boolean;
+}
+
+/** List recent release tags, newest first. */
+export async function listReleases(limit = 20): Promise<ReleaseListEntry[]> {
+  const res = await fetch(`${getApiBase()}/releases?per_page=${limit}`, { headers: await apiHeaders() });
+  if (!res.ok) {
+    throw new Error(`GitHub API ${res.status}: ${res.statusText}`);
+  }
+  const data = (await res.json()) as { tag_name: string; prerelease: boolean; draft: boolean }[];
+  return data.filter((r) => !r.draft).map((r) => ({ tagName: r.tag_name, prerelease: r.prerelease }));
+}
+
 async function fetchReleaseFromApi(version: string): Promise<Release> {
   const base = getApiBase();
   const url =

--- a/packages/xinity-cli/src/lib/github.ts
+++ b/packages/xinity-cli/src/lib/github.ts
@@ -79,7 +79,10 @@ export function fetchRelease(version: string): Promise<Release> {
   if (cached) return cached;
   const pending = fetchReleaseFromApi(version);
   releaseCache.set(version, pending);
-  pending.catch(() => releaseCache.delete(version));
+  pending
+    // "latest" and its concrete tag are the same release; share the fetch.
+    .then((release) => releaseCache.set(release.tagName, pending))
+    .catch(() => releaseCache.delete(version));
   return pending;
 }
 

--- a/packages/xinity-cli/src/lib/github.ts
+++ b/packages/xinity-cli/src/lib/github.ts
@@ -6,7 +6,7 @@
  */
 import { join } from "path";
 import { loadConfig } from "./config.ts";
-import { createLocalHost } from "./host.ts";
+import { localRun } from "./host.ts";
 
 const DEFAULT_PROJECT_URL = "https://github.com/xinity-ai/xinity-ai";
 
@@ -42,8 +42,7 @@ async function discoverToken(): Promise<string | undefined> {
   const config = loadConfig();
   if (config.githubToken) return config.githubToken;
   try {
-    const local = createLocalHost();
-    const result = await local.run(["gh", "auth", "token"]);
+    const result = await localRun(["gh", "auth", "token"]);
     if (result.ok && result.output) return result.output;
   } catch { /* gh not installed or not authenticated */ }
   return undefined;

--- a/packages/xinity-cli/src/lib/host.ts
+++ b/packages/xinity-cli/src/lib/host.ts
@@ -4,8 +4,6 @@
  * All operations that touch the filesystem or run commands go through a Host
  * instance. Use `connectHost()` from remote-host.ts to create one.
  */
-import * as p from "./clack.ts";
-
 // ─── Low-level shell primitives ─────────────────────────────────────────────
 
 export interface RunResult {
@@ -60,38 +58,9 @@ function resetStdin(): void {
 
 // ─── Elevation (sudo) ──────────────────────────────────────────────────────
 
-export type ElevationPolicy = "sudo" | "manual" | null;
-
 export interface ElevationResult {
   success: boolean;
   output: string;
-  skipped: boolean;
-}
-
-export function buildElevationMenu(sensitive: boolean): { value: string; label: string }[] {
-  const options: { value: string; label: string }[] = [
-    { value: "sudo-all", label: "Run with sudo (all remaining)" },
-    { value: "sudo-once", label: "Run with sudo (this time only)" },
-  ];
-  if (!sensitive) {
-    options.push(
-      { value: "manual-all", label: "Show me the commands (all remaining)" },
-      { value: "manual-once", label: "Show me the command (this time only)" },
-    );
-  }
-  return options;
-}
-
-export async function confirmManualRun(): Promise<ElevationResult> {
-  const done = await p.confirm({ message: "Have you run the command?", initialValue: true });
-  if (!p.isCancel(done) && done) {
-    return { success: true, output: "", skipped: false };
-  }
-  const abort = await p.confirm({ message: "Abort?", initialValue: false });
-  if (p.isCancel(abort) || abort) {
-    p.cancel("Aborted.");
-  }
-  return { success: false, output: "", skipped: true };
 }
 
 // ─── Host interface ─────────────────────────────────────────────────────────
@@ -107,13 +76,18 @@ export interface Host {
   runShell(command: string): Promise<RunResult>;
 
   /**
-   * Run a shell command that requires root privileges.
-   * May prompt the user for sudo, show the command, or skip.
-   *
-   * When `sensitive` is true the command involves secret values:
-   * - The "show command" option is hidden (prevents printing secrets)
+   * Run a shell command as root. Uses the established sudo session,
+   * prompting for the password once on first need (no-op when root).
    */
-  withElevation(command: string, description: string, options?: { sensitive?: boolean }): Promise<ElevationResult>;
+  withElevation(command: string, description: string): Promise<ElevationResult>;
+
+  /**
+   * Establish root privileges up front: passes silently when already root,
+   * otherwise starts the sudo session (one password prompt) so everything
+   * after runs unattended. Returns false when authentication is cancelled
+   * or fails.
+   */
+  prepareElevation(): Promise<boolean>;
 
   /** Read a file, returning its content or null if not found / not accessible. */
   readFile(path: string): Promise<string | null>;
@@ -159,7 +133,6 @@ export interface Host {
 export interface ReadSecretsResult {
   secrets: Record<string, string>;
   permissionDenied: boolean;
-  skipped: boolean;
 }
 
 /**
@@ -185,20 +158,17 @@ export async function readSecrets(
 
   const missing = keys.filter((k) => !(k in secrets));
   if (missing.length === 0) {
-    return { secrets, permissionDenied: false, skipped: false };
+    return { secrets, permissionDenied: false };
   }
 
   const script = missing
     .map((k) => `[ -f '${dir}/${k}' ] && printf '%s\\0%s\\0' '${k}' "$(cat '${dir}/${k}')"`)
     .join("; ") + "; true";
 
-  const result = await host.withElevation(script, description, { sensitive: true });
+  const result = await host.withElevation(script, description);
 
-  if (result.skipped) {
-    return { secrets, permissionDenied: false, skipped: true };
-  }
   if (!result.success) {
-    return { secrets, permissionDenied: true, skipped: false };
+    return { secrets, permissionDenied: true };
   }
 
   const parts = result.output.split("\0");
@@ -210,7 +180,7 @@ export async function readSecrets(
     }
   }
 
-  return { secrets, permissionDenied: false, skipped: false };
+  return { secrets, permissionDenied: false };
 }
 
 // ─── Convenience helpers ─────────────────────────────────────────────────────

--- a/packages/xinity-cli/src/lib/host.ts
+++ b/packages/xinity-cli/src/lib/host.ts
@@ -1,19 +1,12 @@
 /**
- * Host abstraction for local and remote (SSH) execution.
+ * Host abstraction for command execution via SSH.
  *
  * All operations that touch the filesystem or run commands go through a Host
- * instance, enabling transparent remote execution with --target-host.
- *
- * The raw `localRun` / `localRunInteractive` helpers are exported for use by
- * RemoteHost (which executes SSH commands on the local machine). Consumer code
- * should NEVER import them; always use a Host instance instead.
+ * instance. Use `connectHost()` from remote-host.ts to create one.
  */
-import { existsSync, readFileSync, statSync } from "fs";
 import * as p from "./clack.ts";
-import pc from "picocolors";
 
 // ─── Low-level shell primitives ─────────────────────────────────────────────
-// Used only by LocalHost / RemoteHost implementations.
 
 export interface RunResult {
   ok: boolean;
@@ -75,12 +68,6 @@ export interface ElevationResult {
   skipped: boolean;
 }
 
-function isRoot(): boolean {
-  return process.getuid?.() === 0;
-}
-
-let localElevationPolicy: ElevationPolicy = null;
-
 export function buildElevationMenu(sensitive: boolean): { value: string; label: string }[] {
   const options: { value: string; label: string }[] = [
     { value: "sudo-all", label: "Run with sudo (all remaining)" },
@@ -95,101 +82,21 @@ export function buildElevationMenu(sensitive: boolean): { value: string; label: 
   return options;
 }
 
-function showManualCommand(command: string): void {
-  p.log.info(`Run manually:\n  ${pc.cyan(`sudo sh -c '${command}'`)}`);
-}
-
 export async function confirmManualRun(): Promise<ElevationResult> {
   const done = await p.confirm({ message: "Have you run the command?", initialValue: true });
   if (!p.isCancel(done) && done) {
     return { success: true, output: "", skipped: false };
   }
   const abort = await p.confirm({ message: "Abort?", initialValue: false });
-  if (p.isCancel(abort) || abort) p.cancel("Aborted.");
-  return { success: false, output: "", skipped: true };
-}
-
-async function runLocalSudo(
-  command: string,
-  sensitive: boolean,
-): Promise<ElevationResult> {
-  process.stderr.write("\x1b[?25h\x1b[0m");
-  p.log.step(pc.dim("Enter your sudo password when prompted:"));
-
-  if (sensitive) {
-    const proc = Bun.spawn(["sudo", "sh", "-c", command], {
-      stdin: "ignore",
-      stdout: "pipe",
-      stderr: "inherit",
-    });
-    const [exitCode, stdout] = await Promise.all([
-      proc.exited,
-      new Response(proc.stdout).text(),
-    ]);
-
-    resetStdin();
-
-    return { success: exitCode === 0, output: stdout, skipped: false };
+  if (p.isCancel(abort) || abort) {
+    p.cancel("Aborted.");
   }
-
-  const result = await localRunInteractive(["sudo", "sh", "-c", command]);
-  return { success: result.ok, output: result.output, skipped: false };
-}
-
-async function localWithElevation(
-  command: string,
-  description: string,
-  options?: { sensitive?: boolean },
-): Promise<ElevationResult> {
-  const sensitive = options?.sensitive ?? false;
-
-  if (isRoot()) {
-    const result = await localRun(["sh", "-c", command]);
-    return { success: result.ok, output: result.output, skipped: false };
-  }
-
-  // Apply remembered policy if set.
-  if (localElevationPolicy === "sudo") {
-    p.log.step(pc.dim(description));
-    return runLocalSudo(command, sensitive);
-  }
-  if (localElevationPolicy === "manual" && !sensitive) {
-    p.log.step(pc.dim(description));
-    showManualCommand(command);
-    return confirmManualRun();
-  }
-
-  // First time (or sensitive command with manual policy): show menu.
-  const action = await p.select({
-    message: `${pc.yellow(description)} requires elevated privileges.`,
-    options: buildElevationMenu(sensitive),
-  });
-
-  if (p.isCancel(action)) {
-    p.cancel("Cancelled.");
-    return { success: false, output: "", skipped: true };
-  }
-
-  if (action === "sudo-all" || action === "sudo-once") {
-    if (action === "sudo-all") localElevationPolicy = "sudo";
-    return runLocalSudo(command, sensitive);
-  }
-
-  if (action === "manual-all" || action === "manual-once") {
-    if (action === "manual-all") localElevationPolicy = "manual";
-    showManualCommand(command);
-    return confirmManualRun();
-  }
-
   return { success: false, output: "", skipped: true };
 }
 
 // ─── Host interface ─────────────────────────────────────────────────────────
 
 export interface Host {
-  /** Whether this host is accessed over SSH (vs. local). */
-  readonly isRemote: boolean;
-
   /** Execute a command, returning a structured result. */
   run(args: string[]): Promise<RunResult>;
 
@@ -204,14 +111,11 @@ export interface Host {
    * May prompt the user for sudo, show the command, or skip.
    *
    * When `sensitive` is true the command involves secret values:
-   * - The sudo path captures stdout instead of inheriting it (prevents terminal leaks)
    * - The "show command" option is hidden (prevents printing secrets)
    */
   withElevation(command: string, description: string, options?: { sensitive?: boolean }): Promise<ElevationResult>;
 
-  /**
-   * Read a file, returning its content or null if not found / not accessible.
-   */
+  /** Read a file, returning its content or null if not found / not accessible. */
   readFile(path: string): Promise<string | null>;
 
   /** Return true if the path exists on this host. */
@@ -220,39 +124,29 @@ export interface Host {
   /**
    * Upload a local file to this host at destPath.
    * Returns the effective path of the file on the host.
-   * For LocalHost this is a no-op and returns localPath unchanged.
+   * For localhost this is a no-op and returns localPath unchanged.
    */
   uploadFile(localPath: string, destPath: string): Promise<string>;
 
-  /**
-   * Download a file from a URL to destPath on this host.
-   * For LocalHost uses fetch(). For RemoteHost uses curl over SSH.
-   */
+  /** Download a file from a URL to destPath on this host. */
   downloadFile(url: string, destPath: string): Promise<void>;
 
-  /**
-   * Verify a file's SHA256 checksum on this host.
-   * Returns true if the hash matches.
-   */
+  /** Verify a file's SHA256 checksum on this host. Returns true if the hash matches. */
   verifySha256(filePath: string, expectedHash: string): Promise<boolean>;
 
   /**
    * Compute the SHA256 hash of a file on this host.
-   * Returns the hex hash string, or null if the file doesn't exist or the operation fails.
+   * Returns the hex hash string, or null if the file doesn't exist.
    */
   computeSha256(filePath: string): Promise<string | null>;
 
-  /**
-   * Get the CPU architecture of this host (Node.js-style: "x64", "arm64").
-   */
+  /** Get the CPU architecture of this host (Node.js-style: "x64", "arm64"). */
   getArch(): Promise<string>;
 
   /**
-   * Open an SSH tunnel so that a service URL (e.g. postgres://localhost:5432)
-   * on the remote host becomes reachable from the local machine.
-   *
-   * For LocalHost this is a no-op, returns the URL unchanged.
-   * For RemoteHost this sets up SSH local port forwarding.
+   * Open a tunnel so that a service URL (e.g. postgres://remotehost:5432)
+   * becomes reachable from the local machine via SSH port forwarding.
+   * For localhost this is a no-op (services are already reachable).
    *
    * Returns the rewritten URL and a cleanup function to tear down the tunnel.
    */
@@ -272,8 +166,7 @@ export interface ReadSecretsResult {
  * Read multiple secret files from a directory, elevating if necessary.
  *
  * Tries an unelevated read first for each key. Any that fail (permission
- * denied) are batch-read via a single `withElevation` call. Returns a map
- * of key -> file content for files that were successfully read.
+ * denied) are batch-read via a single `withElevation` call.
  */
 export async function readSecrets(
   host: Host,
@@ -283,10 +176,11 @@ export async function readSecrets(
 ): Promise<ReadSecretsResult> {
   const secrets: Record<string, string> = {};
 
-  // Try unelevated reads first.
   for (const key of keys) {
     const content = await host.readFile(`${dir}/${key}`);
-    if (content !== null) secrets[key] = content.trim();
+    if (content !== null) {
+      secrets[key] = content.trim();
+    }
   }
 
   const missing = keys.filter((k) => !(k in secrets));
@@ -294,7 +188,6 @@ export async function readSecrets(
     return { secrets, permissionDenied: false, skipped: false };
   }
 
-  // Batch-read the rest via elevation.
   const script = missing
     .map((k) => `[ -f '${dir}/${k}' ] && printf '%s\\0%s\\0' '${k}' "$(cat '${dir}/${k}')"`)
     .join("; ") + "; true";
@@ -308,13 +201,13 @@ export async function readSecrets(
     return { secrets, permissionDenied: true, skipped: false };
   }
 
-  // NUL-delimited key\0value pairs with a trailing NUL. Don't drop empty
-  // tokens, or an empty value would misalign every later pair.
   const parts = result.output.split("\0");
   for (let i = 0; i + 1 < parts.length; i += 2) {
     const key = parts[i];
     const value = parts[i + 1];
-    if (key && value !== undefined) secrets[key] = value.trim();
+    if (key && value !== undefined) {
+      secrets[key] = value.trim();
+    }
   }
 
   return { secrets, permissionDenied: false, skipped: false };
@@ -329,102 +222,16 @@ export const COMMAND_FALLBACK_BIN_DIRS = [
   "/usr/local/bin",
 ];
 
-/**
- * Check whether a command exists on the given host.
- *
- * Uses `command -v` first, then falls back to checking common user-local
- * bin directories that may not be in PATH during non-interactive SSH
- * sessions. Done in a single shell invocation to minimise SSH round-trips.
- */
 export async function commandExistsOn(host: Host, name: string): Promise<boolean> {
   const fallbacks = COMMAND_FALLBACK_BIN_DIRS.map((dir) => `test -x "${dir}/${name}"`).join(" || ");
   const result = await host.runShell(`command -v ${name} || ${fallbacks}`);
   return result.ok;
 }
 
-/** Check whether a systemd unit is active on the given host. */
 export async function isUnitActiveOn(host: Host, unit: string): Promise<boolean> {
   return (await host.run(["systemctl", "is-active", unit])).ok;
 }
 
-/** Get the systemd unit state string on the given host. */
 export async function getUnitStatusOn(host: Host, unit: string): Promise<string> {
   return (await host.run(["systemctl", "is-active", unit])).output;
-}
-
-// ─── LocalHost ───────────────────────────────────────────────────────────────
-
-export class LocalHost implements Host {
-  readonly isRemote = false;
-
-  async run(args: string[]): Promise<RunResult> {
-    return localRun(args);
-  }
-
-  async runShell(command: string): Promise<RunResult> {
-    return localRun(["sh", "-c", command]);
-  }
-
-  async withElevation(command: string, description: string, options?: { sensitive?: boolean }): Promise<ElevationResult> {
-    return localWithElevation(command, description, options);
-  }
-
-  async readFile(path: string): Promise<string | null> {
-    if (!existsSync(path)) return null;
-    try {
-      return readFileSync(path, "utf-8");
-    } catch {
-      return null;
-    }
-  }
-
-  async fileExists(path: string): Promise<boolean> {
-    try {
-      statSync(path);
-      return true;
-    } catch (err: unknown) {
-      return (err as NodeJS.ErrnoException)?.code === "EACCES";
-    }
-  }
-
-  /** No-op: caller already has the file at localPath on the local filesystem. */
-  async uploadFile(localPath: string, _destPath: string): Promise<string> {
-    return localPath;
-  }
-
-  async downloadFile(url: string, destPath: string): Promise<void> {
-    const res = await fetch(url);
-    if (!res.ok) throw new Error(`Download failed: ${res.status} ${res.statusText}`);
-    const bytes = new Uint8Array(await res.arrayBuffer());
-    await Bun.write(destPath, bytes);
-  }
-
-  async verifySha256(filePath: string, expectedHash: string): Promise<boolean> {
-    const hash = await this.computeSha256(filePath);
-    return hash === expectedHash;
-  }
-
-  async computeSha256(filePath: string): Promise<string | null> {
-    const file = Bun.file(filePath);
-    if (!(await file.exists())) return null;
-    const hasher = new Bun.CryptoHasher("sha256");
-    for await (const chunk of file.stream()) {
-      hasher.update(chunk);
-    }
-    return hasher.digest("hex");
-  }
-
-  async getArch(): Promise<string> {
-    return process.arch;
-  }
-
-  async openTunnel(url: string): Promise<{ localUrl: string; close: () => Promise<void> }> {
-    return { localUrl: url, close: async () => {} };
-  }
-
-  async dispose(): Promise<void> {}
-}
-
-export function createLocalHost(): Host {
-  return new LocalHost();
 }

--- a/packages/xinity-cli/src/lib/host.ts
+++ b/packages/xinity-cli/src/lib/host.ts
@@ -25,7 +25,7 @@ export async function localRun(args: string[]): Promise<RunResult> {
   ]);
   return {
     ok: exitCode === 0,
-    output: (stdout || stderr).trim(),
+    output: [stdout, stderr].filter(Boolean).join("\n").trim(),
     exitCode,
   };
 }
@@ -62,6 +62,10 @@ export interface ElevationResult {
   success: boolean;
   output: string;
 }
+
+export type TunnelResult =
+  | { ok: true; localUrl: string; close: () => Promise<void> }
+  | { ok: false; error: string };
 
 // ─── Host interface ─────────────────────────────────────────────────────────
 
@@ -122,9 +126,10 @@ export interface Host {
    * becomes reachable from the local machine via SSH port forwarding.
    * For localhost this is a no-op (services are already reachable).
    *
-   * Returns the rewritten URL and a cleanup function to tear down the tunnel.
+   * Returns the rewritten URL and a cleanup function, or an error string
+   * when the URL is malformed or the SSH tunnel cannot be established.
    */
-  openTunnel(url: string): Promise<{ localUrl: string; close: () => Promise<void> }>;
+  openTunnel(url: string): Promise<TunnelResult>;
 
   /** Release any long-lived resources (persistent sessions, connections). */
   dispose(): Promise<void>;

--- a/packages/xinity-cli/src/lib/host.ts
+++ b/packages/xinity-cli/src/lib/host.ts
@@ -4,6 +4,8 @@
  * All operations that touch the filesystem or run commands go through a Host
  * instance. Use `connectHost()` from remote-host.ts to create one.
  */
+import { quoteShellArg } from "common-env";
+
 // ─── Low-level shell primitives ─────────────────────────────────────────────
 
 export interface RunResult {
@@ -198,8 +200,9 @@ export const COMMAND_FALLBACK_BIN_DIRS = [
 ];
 
 export async function commandExistsOn(host: Host, name: string): Promise<boolean> {
-  const fallbacks = COMMAND_FALLBACK_BIN_DIRS.map((dir) => `test -x "${dir}/${name}"`).join(" || ");
-  const result = await host.runShell(`command -v ${name} || ${fallbacks}`);
+  const q = quoteShellArg(name);
+  const fallbacks = COMMAND_FALLBACK_BIN_DIRS.map((dir) => `test -x "${dir}/"${q}`).join(" || ");
+  const result = await host.runShell(`command -v ${q} || ${fallbacks}`);
   return result.ok;
 }
 

--- a/packages/xinity-cli/src/lib/install-download.ts
+++ b/packages/xinity-cli/src/lib/install-download.ts
@@ -1,10 +1,6 @@
-import { fetchChecksums, verifySha256, resolveDirectUrl, type Release } from "./github.ts";
+import { fetchChecksums, verifySha256, resolveDirectUrl, downloadAsset, pickReleaseAsset, type Release } from "./github.ts";
 import { type Component, BIN_DIR, DASHBOARD_DIR, binaryBaseName } from "./component-meta.ts";
-import { type Host, createLocalHost } from "./host.ts";
-import { tmpdir } from "os";
-import { join } from "path";
-import { mkdirSync } from "fs";
-import { downloadAsset, pickReleaseAsset } from "./github.ts";
+import type { Host } from "./host.ts";
 import type { StepEvent } from "./step-event.ts";
 
 export type { Release } from "./github.ts";
@@ -47,6 +43,11 @@ async function* verifyReleaseChecksum(
   return true;
 }
 
+/**
+ * Download a release asset to a local directory using fetch().
+ * Used for CLI-machine operations (self-update, migration archive extraction)
+ * that always run on the machine where the CLI process lives.
+ */
 export async function* downloadAndVerify(
   release: Release,
   assetName: string,
@@ -74,7 +75,7 @@ export async function* downloadAndVerify(
   return verified ? filePath : null;
 }
 
-export async function* downloadAndVerifyOnHost(
+async function* downloadAndVerifyOnHost(
   release: Release,
   assetName: string,
   host: Host,
@@ -96,26 +97,26 @@ export async function* downloadAndVerifyOnHost(
   }
   yield { type: "spinner", id: "url-resolve", message: "URL resolved", done: true };
 
-  const remoteTmpDir = `/tmp/xinity-download-${Date.now()}`;
-  const remotePath = `${remoteTmpDir}/${assetName}`;
+  const tmpDir = `/tmp/xinity-download-${Date.now()}`;
+  const destPath = `${tmpDir}/${assetName}`;
 
-  yield { type: "spinner", id: "download", message: `Downloading ${assetName} on remote host (${assetSizeMb(asset)} MB)…` };
+  yield { type: "spinner", id: "download", message: `Downloading ${assetName} (${assetSizeMb(asset)} MB)…` };
   try {
-    await host.run(["mkdir", "-p", remoteTmpDir]);
-    await host.downloadFile(directUrl, remotePath);
+    await host.run(["mkdir", "-p", tmpDir]);
+    await host.downloadFile(directUrl, destPath);
   } catch (err) {
     yield { type: "spinner", id: "download", message: "Download failed", done: true };
     yield { type: "fail", label: "Download", detail: (err as Error).message };
     return null;
   }
-  yield { type: "spinner", id: "download", message: "Downloaded on remote", done: true };
+  yield { type: "spinner", id: "download", message: "Downloaded", done: true };
 
   const verified = yield* verifyReleaseChecksum(
-    release, assetName, remotePath,
+    release, assetName, destPath,
     (path, expected) => host.verifySha256(path, expected),
-    "Checksum verified on remote",
+    "Checksum verified",
   );
-  return verified ? remotePath : null;
+  return verified ? destPath : null;
 }
 
 export function extractCommandArgv(archivePath: string, destDir: string): string[] {
@@ -142,59 +143,21 @@ export async function* installBinary(
   host: Host,
 ): AsyncGenerator<StepEvent, boolean> {
   const binName = binaryBaseName(component);
+  const tmpExtract = stripArchiveSuffix(archivePath);
 
-  if (host.isRemote) {
-    const tmpExtract = stripArchiveSuffix(archivePath);
-    const result = await host.withElevation(
-      `mkdir -p ${tmpExtract} && ${extractCommand(archivePath, tmpExtract)}` +
-      ` && mkdir -p ${BIN_DIR} && rm -f ${BIN_DIR}/${binName}` +
-      ` && cp ${tmpExtract}/${binName} ${BIN_DIR}/${binName}` +
-      ` && chmod +x ${BIN_DIR}/${binName}` +
-      ` && rm -rf ${tmpExtract} ${archivePath}`,
-      `Install ${binName} binary`,
-    );
-    if (!result.success) {
-      if (!result.skipped) {
-        yield { type: "fail", label: "Install", detail: result.output };
-      }
-      return false;
+  const result = await host.withElevation(
+    `mkdir -p ${tmpExtract} && ${extractCommand(archivePath, tmpExtract)}` +
+    ` && mkdir -p ${BIN_DIR} && rm -f ${BIN_DIR}/${binName}` +
+    ` && cp ${tmpExtract}/${binName} ${BIN_DIR}/${binName}` +
+    ` && chmod +x ${BIN_DIR}/${binName}` +
+    ` && rm -rf ${tmpExtract} ${archivePath}`,
+    `Install ${binName} binary`,
+  );
+  if (!result.success) {
+    if (!result.skipped) {
+      yield { type: "fail", label: "Install", detail: result.output };
     }
-  } else {
-    const tmpExtract = stripArchiveSuffix(archivePath);
-    mkdirSync(tmpExtract, { recursive: true });
-
-    yield { type: "spinner", id: "extract", message: "Extracting…" };
-    const local = createLocalHost();
-    const extracted = await local.run(extractCommandArgv(archivePath, tmpExtract));
-    if (!extracted.ok) {
-      yield { type: "spinner", id: "extract", message: "Extract failed", done: true };
-      yield { type: "fail", label: "Extract", detail: extracted.output };
-      return false;
-    }
-
-    const localBinPath = `${tmpExtract}/${binName}`;
-    const remoteTmpPath = `/tmp/xinity-upload-${binName}`;
-    let effectivePath: string;
-    try {
-      effectivePath = await host.uploadFile(localBinPath, remoteTmpPath);
-    } catch (err) {
-      yield { type: "spinner", id: "extract", message: "Upload failed", done: true };
-      yield { type: "fail", label: "Upload", detail: (err as Error).message };
-      return false;
-    }
-    yield { type: "spinner", id: "extract", message: "Extracted", done: true };
-
-    const result = await host.withElevation(
-      `mkdir -p ${BIN_DIR} && rm -f ${BIN_DIR}/${binName} && cp ${effectivePath} ${BIN_DIR}/${binName} && chmod +x ${BIN_DIR}/${binName}` +
-        (effectivePath !== localBinPath ? ` && rm -f ${effectivePath}` : ""),
-      `Install ${binName} binary`,
-    );
-    if (!result.success) {
-      if (!result.skipped) {
-        yield { type: "fail", label: "Install", detail: result.output };
-      }
-      return false;
-    }
+    return false;
   }
 
   if (component === "dashboard") {
@@ -222,11 +185,5 @@ export async function* resolveRemoteArtifact(
     return null;
   }
 
-  if (host.isRemote) {
-    return yield* downloadAndVerifyOnHost(release, assetName, host);
-  }
-
-  const tmpDir = join(tmpdir(), `xinity-${Date.now()}`);
-  mkdirSync(tmpDir, { recursive: true });
-  return yield* downloadAndVerify(release, assetName, tmpDir);
+  return yield* downloadAndVerifyOnHost(release, assetName, host);
 }

--- a/packages/xinity-cli/src/lib/install-download.ts
+++ b/packages/xinity-cli/src/lib/install-download.ts
@@ -1,120 +1,116 @@
-import * as p from "./clack.ts";
 import { fetchChecksums, verifySha256, resolveDirectUrl, type Release } from "./github.ts";
-import { pass, fail, warn, elevationHardFailed } from "./output.ts";
 import { type Component, BIN_DIR, DASHBOARD_DIR, binaryBaseName } from "./component-meta.ts";
 import { type Host, createLocalHost } from "./host.ts";
 import { tmpdir } from "os";
 import { join } from "path";
 import { mkdirSync } from "fs";
 import { downloadAsset, pickReleaseAsset } from "./github.ts";
+import type { StepEvent } from "./step-event.ts";
 
 export type { Release } from "./github.ts";
 
-function findReleaseAssetOrFail(release: Release, assetName: string): Release["assets"][number] | null {
-  const asset = release.assets.find((a) => a.name === assetName);
-  if (!asset) {
-    fail("Download", `Asset ${assetName} not found in release ${release.tagName}`);
-    return null;
-  }
-  return asset;
+function findReleaseAsset(release: Release, assetName: string): Release["assets"][number] | null {
+  return release.assets.find((a) => a.name === assetName) ?? null;
 }
 
 export function assetSizeMb(asset: { size: number }): string {
   return (asset.size / 1024 / 1024).toFixed(1);
 }
 
-async function verifyReleaseChecksum(
+async function* verifyReleaseChecksum(
   release: Release,
   assetName: string,
   filePath: string,
   verify: (path: string, expected: string) => Promise<boolean>,
   successLabel: string,
-): Promise<boolean> {
-  const checksumSpinner = p.spinner();
-  checksumSpinner.start("Verifying checksum…");
+): AsyncGenerator<StepEvent, boolean> {
+  yield { type: "spinner", id: "checksum", message: "Verifying checksum…" };
   const checksums = await fetchChecksums(release);
   if (checksums.size === 0) {
-    checksumSpinner.stop("No checksums available");
-    warn("Checksum", "No SHASUMS256.txt found in release, skipping verification");
+    yield { type: "spinner", id: "checksum", message: "No checksums available", done: true };
+    yield { type: "warn", label: "Checksum", detail: "No SHASUMS256.txt found in release, skipping verification" };
     return true;
   }
   const expected = checksums.get(assetName);
   if (!expected) {
-    checksumSpinner.stop("No checksum entry");
-    warn("Checksum", `No checksum entry for ${assetName} in SHASUMS256.txt, skipping verification`);
+    yield { type: "spinner", id: "checksum", message: "No checksum entry", done: true };
+    yield { type: "warn", label: "Checksum", detail: `No checksum entry for ${assetName} in SHASUMS256.txt, skipping verification` };
     return true;
   }
   const valid = await verify(filePath, expected);
   if (!valid) {
-    checksumSpinner.stop("Verification failed");
-    fail("Checksum", "SHA256 mismatch, the download may be corrupted");
+    yield { type: "spinner", id: "checksum", message: "Verification failed", done: true };
+    yield { type: "fail", label: "Checksum", detail: "SHA256 mismatch, the download may be corrupted" };
     return false;
   }
-  checksumSpinner.stop(successLabel);
+  yield { type: "spinner", id: "checksum", message: successLabel, done: true };
   return true;
 }
 
-export async function downloadAndVerify(
+export async function* downloadAndVerify(
   release: Release,
   assetName: string,
   destDir: string,
-): Promise<string | null> {
-  const asset = findReleaseAssetOrFail(release, assetName);
-  if (!asset) return null;
+): AsyncGenerator<StepEvent, string | null> {
+  const asset = findReleaseAsset(release, assetName);
+  if (!asset) {
+    yield { type: "fail", label: "Download", detail: `Asset ${assetName} not found in release ${release.tagName}` };
+    return null;
+  }
 
-  const spinner = p.spinner();
-  spinner.start(`Downloading ${assetName} (${assetSizeMb(asset)} MB)…`);
+  yield { type: "spinner", id: "download", message: `Downloading ${assetName} (${assetSizeMb(asset)} MB)…` };
 
   let filePath: string;
   try {
     filePath = await downloadAsset(asset, destDir);
   } catch (err) {
-    spinner.stop("Download failed");
-    fail("Download", (err as Error).message);
+    yield { type: "spinner", id: "download", message: "Download failed", done: true };
+    yield { type: "fail", label: "Download", detail: (err as Error).message };
     return null;
   }
-  spinner.stop("Downloaded");
+  yield { type: "spinner", id: "download", message: "Downloaded", done: true };
 
-  const verified = await verifyReleaseChecksum(release, assetName, filePath, verifySha256, "Checksum verified");
+  const verified = yield* verifyReleaseChecksum(release, assetName, filePath, verifySha256, "Checksum verified");
   return verified ? filePath : null;
 }
 
-export async function downloadAndVerifyOnHost(
+export async function* downloadAndVerifyOnHost(
   release: Release,
   assetName: string,
   host: Host,
-): Promise<string | null> {
-  const asset = findReleaseAssetOrFail(release, assetName);
-  if (!asset) return null;
+): AsyncGenerator<StepEvent, string | null> {
+  const asset = findReleaseAsset(release, assetName);
+  if (!asset) {
+    yield { type: "fail", label: "Download", detail: `Asset ${assetName} not found in release ${release.tagName}` };
+    return null;
+  }
 
-  const urlSpinner = p.spinner();
-  urlSpinner.start("Resolving download URL…");
+  yield { type: "spinner", id: "url-resolve", message: "Resolving download URL…" };
   let directUrl: string;
   try {
     directUrl = await resolveDirectUrl(asset);
   } catch (err) {
-    urlSpinner.stop("URL resolution failed");
-    fail("Download", (err as Error).message);
+    yield { type: "spinner", id: "url-resolve", message: "URL resolution failed", done: true };
+    yield { type: "fail", label: "Download", detail: (err as Error).message };
     return null;
   }
-  urlSpinner.stop("URL resolved");
+  yield { type: "spinner", id: "url-resolve", message: "URL resolved", done: true };
 
   const remoteTmpDir = `/tmp/xinity-download-${Date.now()}`;
   const remotePath = `${remoteTmpDir}/${assetName}`;
 
-  const dlSpinner = p.spinner();
-  dlSpinner.start(`Downloading ${assetName} on remote host (${assetSizeMb(asset)} MB)…`);
+  yield { type: "spinner", id: "download", message: `Downloading ${assetName} on remote host (${assetSizeMb(asset)} MB)…` };
   try {
     await host.run(["mkdir", "-p", remoteTmpDir]);
     await host.downloadFile(directUrl, remotePath);
   } catch (err) {
-    dlSpinner.stop("Download failed");
-    fail("Download", (err as Error).message);
+    yield { type: "spinner", id: "download", message: "Download failed", done: true };
+    yield { type: "fail", label: "Download", detail: (err as Error).message };
     return null;
   }
-  dlSpinner.stop("Downloaded on remote");
+  yield { type: "spinner", id: "download", message: "Downloaded on remote", done: true };
 
-  const verified = await verifyReleaseChecksum(
+  const verified = yield* verifyReleaseChecksum(
     release, assetName, remotePath,
     (path, expected) => host.verifySha256(path, expected),
     "Checksum verified on remote",
@@ -123,8 +119,12 @@ export async function downloadAndVerifyOnHost(
 }
 
 export function extractCommandArgv(archivePath: string, destDir: string): string[] {
-  if (archivePath.endsWith(".tar.gz")) return ["tar", "-xzf", archivePath, "-C", destDir];
-  if (archivePath.endsWith(".zip")) return ["unzip", "-o", archivePath, "-d", destDir];
+  if (archivePath.endsWith(".tar.gz")) {
+    return ["tar", "-xzf", archivePath, "-C", destDir];
+  }
+  if (archivePath.endsWith(".zip")) {
+    return ["unzip", "-o", archivePath, "-d", destDir];
+  }
   throw new Error(`Unsupported archive format: ${archivePath}`);
 }
 
@@ -136,7 +136,11 @@ function stripArchiveSuffix(path: string): string {
   return path.replace(/\.tar\.gz$|\.zip$/, "");
 }
 
-export async function installBinary(component: Component, archivePath: string, host: Host): Promise<boolean> {
+export async function* installBinary(
+  component: Component,
+  archivePath: string,
+  host: Host,
+): AsyncGenerator<StepEvent, boolean> {
   const binName = binaryBaseName(component);
 
   if (host.isRemote) {
@@ -149,19 +153,22 @@ export async function installBinary(component: Component, archivePath: string, h
       ` && rm -rf ${tmpExtract} ${archivePath}`,
       `Install ${binName} binary`,
     );
-    if (elevationHardFailed(result, "Install")) return false;
-    if (result.skipped) return false;
+    if (!result.success) {
+      if (!result.skipped) {
+        yield { type: "fail", label: "Install", detail: result.output };
+      }
+      return false;
+    }
   } else {
     const tmpExtract = stripArchiveSuffix(archivePath);
     mkdirSync(tmpExtract, { recursive: true });
 
-    const extractSpinner = p.spinner();
-    extractSpinner.start("Extracting…");
+    yield { type: "spinner", id: "extract", message: "Extracting…" };
     const local = createLocalHost();
     const extracted = await local.run(extractCommandArgv(archivePath, tmpExtract));
     if (!extracted.ok) {
-      extractSpinner.stop("Extract failed");
-      fail("Extract", extracted.output);
+      yield { type: "spinner", id: "extract", message: "Extract failed", done: true };
+      yield { type: "fail", label: "Extract", detail: extracted.output };
       return false;
     }
 
@@ -171,19 +178,23 @@ export async function installBinary(component: Component, archivePath: string, h
     try {
       effectivePath = await host.uploadFile(localBinPath, remoteTmpPath);
     } catch (err) {
-      extractSpinner.stop("Upload failed");
-      fail("Upload", (err as Error).message);
+      yield { type: "spinner", id: "extract", message: "Upload failed", done: true };
+      yield { type: "fail", label: "Upload", detail: (err as Error).message };
       return false;
     }
-    extractSpinner.stop("Extracted");
+    yield { type: "spinner", id: "extract", message: "Extracted", done: true };
 
     const result = await host.withElevation(
       `mkdir -p ${BIN_DIR} && rm -f ${BIN_DIR}/${binName} && cp ${effectivePath} ${BIN_DIR}/${binName} && chmod +x ${BIN_DIR}/${binName}` +
         (effectivePath !== localBinPath ? ` && rm -f ${effectivePath}` : ""),
       `Install ${binName} binary`,
     );
-    if (elevationHardFailed(result, "Install")) return false;
-    if (result.skipped) return false;
+    if (!result.success) {
+      if (!result.skipped) {
+        yield { type: "fail", label: "Install", detail: result.output };
+      }
+      return false;
+    }
   }
 
   if (component === "dashboard") {
@@ -193,29 +204,29 @@ export async function installBinary(component: Component, archivePath: string, h
     );
   }
 
-  pass("Install", "Installed");
+  yield { type: "pass", label: "Install", detail: "Installed" };
   return true;
 }
 
-export async function resolveRemoteArtifact(
+export async function* resolveRemoteArtifact(
   release: Release,
   component: Component,
   host: Host,
-): Promise<string | null> {
+): AsyncGenerator<StepEvent, string | null> {
   const hostArch = await host.getArch();
   let assetName: string;
   try {
     assetName = pickReleaseAsset(release, component, hostArch);
   } catch (err) {
-    fail("Download", (err as Error).message);
+    yield { type: "fail", label: "Download", detail: (err as Error).message };
     return null;
   }
 
   if (host.isRemote) {
-    return downloadAndVerifyOnHost(release, assetName, host);
+    return yield* downloadAndVerifyOnHost(release, assetName, host);
   }
 
   const tmpDir = join(tmpdir(), `xinity-${Date.now()}`);
   mkdirSync(tmpDir, { recursive: true });
-  return downloadAndVerify(release, assetName, tmpDir);
+  return yield* downloadAndVerify(release, assetName, tmpDir);
 }

--- a/packages/xinity-cli/src/lib/install-download.ts
+++ b/packages/xinity-cli/src/lib/install-download.ts
@@ -105,6 +105,7 @@ export async function* downloadAndVerifyOnHost(
   } catch (err) {
     yield { type: "spinner", id: "download", message: "Download failed", done: true };
     yield { type: "fail", label: "Download", detail: (err as Error).message };
+    await host.run(["rm", "-rf", tmpDir]);
     return null;
   }
   yield { type: "spinner", id: "download", message: "Downloaded", done: true };
@@ -114,7 +115,11 @@ export async function* downloadAndVerifyOnHost(
     (path, expected) => host.verifySha256(path, expected),
     "Checksum verified",
   );
-  return verified ? destPath : null;
+  if (!verified) {
+    await host.run(["rm", "-rf", tmpDir]);
+    return null;
+  }
+  return destPath;
 }
 
 export function extractCommandArgv(archivePath: string, destDir: string): string[] {

--- a/packages/xinity-cli/src/lib/install-download.ts
+++ b/packages/xinity-cli/src/lib/install-download.ts
@@ -3,8 +3,6 @@ import { type Component, BIN_DIR, DASHBOARD_DIR, binaryBaseName } from "./compon
 import type { Host } from "./host.ts";
 import type { StepEvent } from "./step-event.ts";
 
-export type { Release } from "./github.ts";
-
 function findReleaseAsset(release: Release, assetName: string): Release["assets"][number] | null {
   return release.assets.find((a) => a.name === assetName) ?? null;
 }
@@ -75,7 +73,7 @@ export async function* downloadAndVerify(
   return verified ? filePath : null;
 }
 
-async function* downloadAndVerifyOnHost(
+export async function* downloadAndVerifyOnHost(
   release: Release,
   assetName: string,
   host: Host,
@@ -137,26 +135,35 @@ function stripArchiveSuffix(path: string): string {
   return path.replace(/\.tar\.gz$|\.zip$/, "");
 }
 
+/**
+ * The exact root shell command that extracts an archive and installs the
+ * component binary. Shared with the review phase's script dump.
+ */
+export function buildInstallBinaryCommand(component: Component, archivePath: string): string {
+  const binName = binaryBaseName(component);
+  const tmpExtract = stripArchiveSuffix(archivePath);
+  return (
+    `mkdir -p ${tmpExtract} && ${extractCommand(archivePath, tmpExtract)}` +
+    ` && mkdir -p ${BIN_DIR} && rm -f ${BIN_DIR}/${binName}` +
+    ` && cp ${tmpExtract}/${binName} ${BIN_DIR}/${binName}` +
+    ` && chmod +x ${BIN_DIR}/${binName}` +
+    ` && rm -rf ${tmpExtract} ${archivePath}`
+  );
+}
+
 export async function* installBinary(
   component: Component,
   archivePath: string,
   host: Host,
 ): AsyncGenerator<StepEvent, boolean> {
   const binName = binaryBaseName(component);
-  const tmpExtract = stripArchiveSuffix(archivePath);
 
   const result = await host.withElevation(
-    `mkdir -p ${tmpExtract} && ${extractCommand(archivePath, tmpExtract)}` +
-    ` && mkdir -p ${BIN_DIR} && rm -f ${BIN_DIR}/${binName}` +
-    ` && cp ${tmpExtract}/${binName} ${BIN_DIR}/${binName}` +
-    ` && chmod +x ${BIN_DIR}/${binName}` +
-    ` && rm -rf ${tmpExtract} ${archivePath}`,
+    buildInstallBinaryCommand(component, archivePath),
     `Install ${binName} binary`,
   );
   if (!result.success) {
-    if (!result.skipped) {
-      yield { type: "fail", label: "Install", detail: result.output };
-    }
+    yield { type: "fail", label: "Install", detail: result.output };
     return false;
   }
 

--- a/packages/xinity-cli/src/lib/install-remove.ts
+++ b/packages/xinity-cli/src/lib/install-remove.ts
@@ -2,7 +2,7 @@ import * as p from "./clack.ts";
 import pc from "picocolors";
 import { readManifest, writeManifest } from "./manifest.ts";
 import { analyzeEnvSchema, categorizeFields } from "./env-prompt.ts";
-import { type Host, createLocalHost, isUnitActiveOn } from "./host.ts";
+import { type Host, isUnitActiveOn } from "./host.ts";
 import { unitName } from "./systemd.ts";
 import { runSteps } from "./step-runner.ts";
 import type { StepEvent } from "./step-event.ts";
@@ -31,10 +31,9 @@ function* elevationStep(
 export async function* removeComponent(opts: {
   component: Component;
   purge?: boolean;
-  host?: Host;
+  host: Host;
 }): AsyncGenerator<StepEvent, RemoveResult> {
-  const { component, purge = false } = opts;
-  const host = opts.host ?? createLocalHost();
+  const { component, purge = false, host } = opts;
   const errors: string[] = [];
   const manifest = await readManifest(host);
   const entry = manifest.components[component];
@@ -149,13 +148,12 @@ export async function* removeComponent(opts: {
   return { success, errors };
 }
 
-export async function removeAll(purge = false, host?: Host): Promise<void> {
-  const h = host ?? createLocalHost();
+export async function removeAll(purge = false, host: Host): Promise<void> {
   const { runComponentSequence } = await import("./installer.ts");
 
   await runComponentSequence(
     ["gateway", "dashboard", "daemon", "infoserver"],
-    (component) => runSteps(removeComponent({ component, purge, host: h })),
+    (component) => runSteps(removeComponent({ component, purge, host })),
   );
 
   p.log.step(pc.bold("\n── Cleanup ──"));
@@ -165,5 +163,5 @@ export async function removeAll(purge = false, host?: Host): Promise<void> {
     `rmdir ${BIN_DIR} 2>/dev/null || true`,
     `rmdir /opt/xinity 2>/dev/null || true`,
   ].join(" && ");
-  await h.withElevation(cleanDirs, "Clean up empty directories");
+  await host.withElevation(cleanDirs, "Clean up empty directories");
 }

--- a/packages/xinity-cli/src/lib/install-remove.ts
+++ b/packages/xinity-cli/src/lib/install-remove.ts
@@ -1,10 +1,10 @@
-import * as p from "./clack.ts";
+import { confirm, isCancel } from "./clack.ts";
 import { heading } from "./output.ts";
 import { readManifest, writeManifest } from "./manifest.ts";
 import { analyzeEnvSchema, categorizeFields } from "./env-prompt.ts";
 import { type Host, isUnitActiveOn } from "./host.ts";
 import { unitName } from "./systemd.ts";
-import { runSteps } from "./step-runner.ts";
+import { runSteps, runStepsCollapsed } from "./step-runner.ts";
 import type { StepEvent } from "./step-event.ts";
 import {
   type Component, type RemoveResult,
@@ -26,6 +26,17 @@ function* elevationStep(
     errors.push(error);
     yield { type: "fail", label, detail: error };
   }
+}
+
+/** `removeComponent` in a collapsed progress scope with the standard messaging. */
+export function removeComponentCollapsed(
+  opts: { component: Component; purge?: boolean; host: Host },
+): Promise<RemoveResult> {
+  return runStepsCollapsed(
+    removeComponent(opts),
+    `Removing ${opts.component}…`,
+    `${opts.component} removed`,
+  );
 }
 
 export async function* removeComponent(opts: {
@@ -154,11 +165,11 @@ export async function removeAll(purge = false, host: Host): Promise<void> {
     heading(component);
     const result = await runSteps(removeComponent({ component, purge, host }));
     if (!result.success) {
-      const proceed = await p.confirm({
+      const proceed = await confirm({
         message: `${component} had issues: ${result.errors.join(", ")}. Continue with remaining components?`,
         initialValue: true,
       });
-      if (p.isCancel(proceed) || !proceed) return;
+      if (isCancel(proceed) || !proceed) return;
     }
   }
 

--- a/packages/xinity-cli/src/lib/install-remove.ts
+++ b/packages/xinity-cli/src/lib/install-remove.ts
@@ -1,5 +1,5 @@
 import * as p from "./clack.ts";
-import pc from "picocolors";
+import { heading } from "./output.ts";
 import { readManifest, writeManifest } from "./manifest.ts";
 import { analyzeEnvSchema, categorizeFields } from "./env-prompt.ts";
 import { type Host, isUnitActiveOn } from "./host.ts";
@@ -13,7 +13,7 @@ import {
 } from "./component-meta.ts";
 
 function* elevationStep(
-  result: { success: boolean; skipped: boolean; output: string },
+  result: { success: boolean; output: string },
   label: string,
   successMsg: string,
   failurePrefix: string,
@@ -21,7 +21,7 @@ function* elevationStep(
 ): Generator<StepEvent> {
   if (result.success) {
     yield { type: "pass", label, detail: successMsg };
-  } else if (!result.skipped) {
+  } else {
     const error = `${failurePrefix}: ${result.output}`;
     errors.push(error);
     yield { type: "fail", label, detail: error };
@@ -149,14 +149,20 @@ export async function* removeComponent(opts: {
 }
 
 export async function removeAll(purge = false, host: Host): Promise<void> {
-  const { runComponentSequence } = await import("./installer.ts");
+  const components: Component[] = ["gateway", "dashboard", "daemon", "infoserver"];
+  for (const component of components) {
+    heading(component);
+    const result = await runSteps(removeComponent({ component, purge, host }));
+    if (!result.success) {
+      const proceed = await p.confirm({
+        message: `${component} had issues: ${result.errors.join(", ")}. Continue with remaining components?`,
+        initialValue: true,
+      });
+      if (p.isCancel(proceed) || !proceed) return;
+    }
+  }
 
-  await runComponentSequence(
-    ["gateway", "dashboard", "daemon", "infoserver"],
-    (component) => runSteps(removeComponent({ component, purge, host })),
-  );
-
-  p.log.step(pc.bold("\n── Cleanup ──"));
+  heading("cleanup");
   const cleanDirs = [
     `rmdir ${SECRETS_DIR} 2>/dev/null || true`,
     `rmdir ${ENV_DIR} 2>/dev/null || true`,

--- a/packages/xinity-cli/src/lib/install-remove.ts
+++ b/packages/xinity-cli/src/lib/install-remove.ts
@@ -2,34 +2,37 @@ import * as p from "./clack.ts";
 import pc from "picocolors";
 import { readManifest, writeManifest } from "./manifest.ts";
 import { analyzeEnvSchema, categorizeFields } from "./env-prompt.ts";
-import { pass, warn, info } from "./output.ts";
 import { type Host, createLocalHost, isUnitActiveOn } from "./host.ts";
 import { unitName } from "./systemd.ts";
+import { runSteps } from "./step-runner.ts";
+import type { StepEvent } from "./step-event.ts";
 import {
   type Component, type RemoveResult,
   ENV_SCHEMAS, ENV_DIR, SECRETS_DIR, BIN_DIR, DASHBOARD_DIR, UNIT_DIR,
   binaryBaseName,
 } from "./component-meta.ts";
 
-function reportElevationStep(
+function* elevationStep(
   result: { success: boolean; skipped: boolean; output: string },
   label: string,
   successMsg: string,
   failurePrefix: string,
   errors: string[],
-): void {
+): Generator<StepEvent> {
   if (result.success) {
-    pass(label, successMsg);
+    yield { type: "pass", label, detail: successMsg };
   } else if (!result.skipped) {
-    errors.push(`${failurePrefix}: ${result.output}`);
+    const error = `${failurePrefix}: ${result.output}`;
+    errors.push(error);
+    yield { type: "fail", label, detail: error };
   }
 }
 
-export async function removeComponent(opts: {
+export async function* removeComponent(opts: {
   component: Component;
   purge?: boolean;
   host?: Host;
-}): Promise<RemoveResult> {
+}): AsyncGenerator<StepEvent, RemoveResult> {
   const { component, purge = false } = opts;
   const host = opts.host ?? createLocalHost();
   const errors: string[] = [];
@@ -37,21 +40,21 @@ export async function removeComponent(opts: {
   const entry = manifest.components[component];
 
   if (!entry) {
-    warn("Not installed", `${component} is not in the manifest`);
+    yield { type: "warn", label: "Not installed", detail: `${component} is not in the manifest` };
   }
 
   const unit = unitName(component);
 
   if (await isUnitActiveOn(host, unit)) {
-    info("Service", `Stopping ${unit}…`);
+    yield { type: "info", label: "Service", detail: `Stopping ${unit}…` };
     const result = await host.withElevation(
       `systemctl disable --now ${unit}`,
       `Stop and disable ${unit}`,
     );
-    reportElevationStep(result, "Service", `${unit} stopped and disabled`, `Failed to stop ${unit}`, errors);
+    yield* elevationStep(result, "Service", `${unit} stopped and disabled`, `Failed to stop ${unit}`, errors);
   } else {
     await host.withElevation(`systemctl disable ${unit} 2>/dev/null || true`, `Disable ${unit}`);
-    info("Service", `${unit} was not running`);
+    yield { type: "info", label: "Service", detail: `${unit} was not running` };
   }
 
   const unitPath = `${UNIT_DIR}/${unit}`;
@@ -59,7 +62,7 @@ export async function removeComponent(opts: {
     `rm -f ${unitPath} && systemctl daemon-reload`,
     `Remove ${unit} unit file`,
   );
-  reportElevationStep(rmUnit, "Systemd", `Removed ${unitPath}`, "Failed to remove unit", errors);
+  yield* elevationStep(rmUnit, "Systemd", `Removed ${unitPath}`, "Failed to remove unit", errors);
 
   const binaryPath = `${BIN_DIR}/${binaryBaseName(component)}`;
   const rmBin = await host.withElevation(
@@ -68,14 +71,14 @@ export async function removeComponent(opts: {
       : `rm -f ${binaryPath}`,
     `Remove ${component} binary`,
   );
-  reportElevationStep(rmBin, "Files", `Removed ${binaryPath}`, "Failed to remove binary", errors);
+  yield* elevationStep(rmBin, "Files", `Removed ${binaryPath}`, "Failed to remove binary", errors);
 
   const envPath = `${ENV_DIR}/${component}.env`;
   const rmEnv = await host.withElevation(
     `rm -f ${envPath}`,
     `Remove ${component} env config`,
   );
-  reportElevationStep(rmEnv, "Config", `Removed ${envPath}`, "Failed to remove env config", errors);
+  yield* elevationStep(rmEnv, "Config", `Removed ${envPath}`, "Failed to remove env config", errors);
 
   const schema = ENV_SCHEMAS[component];
   const fields = analyzeEnvSchema(schema);
@@ -95,7 +98,7 @@ export async function removeComponent(opts: {
     const kept = secretFields.filter((f) => sharedKeys.has(f.key));
 
     if (kept.length > 0) {
-      info("Secrets", `Keeping ${kept.map((f) => f.key).join(", ")} (used by other components)`);
+      yield { type: "info", label: "Secrets", detail: `Keeping ${kept.map((f) => f.key).join(", ")} (used by other components)` };
     }
 
     if (toDelete.length > 0) {
@@ -104,7 +107,7 @@ export async function removeComponent(opts: {
         `rm -f ${secretPaths}`,
         `Remove ${component} secret files`,
       );
-      reportElevationStep(rmSecrets, "Secrets", `Removed ${toDelete.length} secret file(s)`, "Failed to remove secrets", errors);
+      yield* elevationStep(rmSecrets, "Secrets", `Removed ${toDelete.length} secret file(s)`, "Failed to remove secrets", errors);
     }
   }
 
@@ -114,14 +117,14 @@ export async function removeComponent(opts: {
       `rm -f ${vllmTemplatePath} && systemctl daemon-reload`,
       "Remove vLLM systemd template unit",
     );
-    reportElevationStep(rmTemplate, "vLLM", `Removed ${vllmTemplatePath}`, "Failed to remove vLLM template", errors);
+    yield* elevationStep(rmTemplate, "vLLM", `Removed ${vllmTemplatePath}`, "Failed to remove vLLM template", errors);
 
     if (purge) {
       const rmVllmEnv = await host.withElevation(
         "rm -rf /etc/vllm",
         "Purge vLLM environment config",
       );
-      reportElevationStep(rmVllmEnv, "Purge", "Removed /etc/vllm", "Failed to purge /etc/vllm", errors);
+      yield* elevationStep(rmVllmEnv, "Purge", "Removed /etc/vllm", "Failed to purge /etc/vllm", errors);
     }
   }
 
@@ -131,16 +134,16 @@ export async function removeComponent(opts: {
       `rm -rf ${stateDir}`,
       `Purge ${component} state data`,
     );
-    reportElevationStep(rmState, "Purge", `Removed ${stateDir}`, "Failed to purge state", errors);
+    yield* elevationStep(rmState, "Purge", `Removed ${stateDir}`, "Failed to purge state", errors);
   }
 
   delete manifest.components[component];
   await writeManifest(manifest, host);
-  pass("Manifest", `Removed ${component} from manifest`);
+  yield { type: "pass", label: "Manifest", detail: `Removed ${component} from manifest` };
 
   const success = errors.length === 0;
   if (success) {
-    pass("Done", `${component} removed successfully`);
+    yield { type: "pass", label: "Done", detail: `${component} removed successfully` };
   }
 
   return { success, errors };
@@ -152,7 +155,7 @@ export async function removeAll(purge = false, host?: Host): Promise<void> {
 
   await runComponentSequence(
     ["gateway", "dashboard", "daemon", "infoserver"],
-    (component) => removeComponent({ component, purge, host: h }),
+    (component) => runSteps(removeComponent({ component, purge, host: h })),
   );
 
   p.log.step(pc.bold("\n── Cleanup ──"));

--- a/packages/xinity-cli/src/lib/installer.ts
+++ b/packages/xinity-cli/src/lib/installer.ts
@@ -488,19 +488,19 @@ export async function applyComponentAction(
     const binaryChanged = action.kind !== "reconfigure";
     const errors = await applyConfigAndStart(component, action.env, host, isUpdate, onFailure, progress, binaryChanged);
 
+    const success = errors.length === 0;
+
     if (action.kind !== "reconfigure") {
       const binaryPath = `${BIN_DIR}/${binaryBaseName(component)}`;
       const binaryChecksum = (await host.computeSha256(binaryPath)) ?? undefined;
       await updateManifestEntry(component, {
-        version: versionString,
+        version: success ? versionString : (action.installedVersion ?? versionString),
         installedAt: new Date().toISOString(),
         binaryPath,
         unitName: unitName(component),
         binaryChecksum,
       }, host);
     }
-
-    const success = errors.length === 0;
     if (success) {
       progress.done(actionSummary(action, versionString));
     }

--- a/packages/xinity-cli/src/lib/installer.ts
+++ b/packages/xinity-cli/src/lib/installer.ts
@@ -324,16 +324,18 @@ async function bringServiceUp(component: Component, host: Host, progress: Progre
 }
 
 /** Restore the .bak binary and configuration, then bring the service back up. */
-async function performRollback(component: Component, host: Host, progress: Progress): Promise<void> {
+async function performRollback(component: Component, host: Host, progress: Progress, restoreBinary = true): Promise<void> {
   const binPath = `${BIN_DIR}/${binaryBaseName(component)}`;
   const envPath = `${ENV_DIR}/${component}.env`;
   const unit = unitName(component);
 
-  info("Rollback", "Restoring previous version…");
-  await host.withElevation(
-    `[ -f ${binPath}.bak ] && cp -p ${binPath}.bak ${binPath} && chmod +x ${binPath} || true`,
-    `Restore ${component} binary`,
-  );
+  info("Rollback", restoreBinary ? "Restoring previous version…" : "Restoring previous configuration…");
+  if (restoreBinary) {
+    await host.withElevation(
+      `[ -f ${binPath}.bak ] && cp -p ${binPath}.bak ${binPath} && chmod +x ${binPath} || true`,
+      `Restore ${component} binary`,
+    );
+  }
   await host.withElevation(
     [
       `[ -f ${envPath}.bak ] && cp -p ${envPath}.bak ${envPath} || true`,
@@ -341,10 +343,10 @@ async function performRollback(component: Component, host: Host, progress: Progr
     ].join(" && "),
     `Restore ${component} configuration`,
   );
-  pass("Rollback", "Previous binary and configuration restored");
+  pass("Rollback", restoreBinary ? "Previous binary and configuration restored" : "Previous configuration restored");
 
   if (await bringServiceUp(component, host, progress)) {
-    pass("Rollback", `${unit} is back on the previous version`);
+    pass("Rollback", restoreBinary ? `${unit} is back on the previous version` : `${unit} restarted with previous configuration`);
   } else {
     warn("Rollback", "Service did not restart after rollback. Manual intervention may be needed");
     log.info(`  ${cyan(`systemctl start ${unit}`)}`);
@@ -364,6 +366,7 @@ async function applyConfigAndStart(
   isUpdate: boolean,
   onFailure: ServiceFailurePolicy,
   progress: Progress,
+  binaryChanged = true,
 ): Promise<string[]> {
   const errors: string[] = [];
   const unit = unitName(component);
@@ -398,8 +401,10 @@ async function applyConfigAndStart(
   printServiceFailureDiagnostics(unit);
 
   if (isUpdate && onFailure === "rollback") {
-    await performRollback(component, host, progress);
-    errors.push("Service failed to start; rolled back to the previous version");
+    await performRollback(component, host, progress, binaryChanged);
+    errors.push(binaryChanged
+      ? "Service failed to start; rolled back to the previous version"
+      : "Service failed to start; rolled back to the previous configuration");
     return errors;
   }
 
@@ -440,10 +445,13 @@ export async function applyComponentAction(
   const progress = createProgress(`${component}: preparing…`);
 
   try {
+    if (isUpdate) {
+      await backupCurrentConfig(component, host, progress);
+    }
+
     if (action.kind !== "reconfigure") {
       if (isUpdate) {
         await backupCurrentBinary(component, host, progress);
-        await backupCurrentConfig(component, host, progress);
 
         if (action.hardReset) {
           await stopService(component, host);
@@ -477,7 +485,8 @@ export async function applyComponentAction(
       if (!installed) return { success: false, version: versionString, errors: ["Installation failed or skipped"] };
     }
 
-    const errors = await applyConfigAndStart(component, action.env, host, isUpdate, onFailure, progress);
+    const binaryChanged = action.kind !== "reconfigure";
+    const errors = await applyConfigAndStart(component, action.env, host, isUpdate, onFailure, progress, binaryChanged);
 
     if (action.kind !== "reconfigure") {
       const binaryPath = `${BIN_DIR}/${binaryBaseName(component)}`;

--- a/packages/xinity-cli/src/lib/installer.ts
+++ b/packages/xinity-cli/src/lib/installer.ts
@@ -11,6 +11,7 @@ import { pass, fail, warn, info, cancelAndExit, promptOrExit } from "./output.ts
 import { type Host, createLocalHost, commandExistsOn, isUnitActiveOn, readSecrets } from "./host.ts";
 import { isOllamaRunning, waitForOllamaRunning } from "./ollama-setup.ts";
 import { writeEnvConfig, writeSystemdUnit, stopService, startService, restartService } from "./service.ts";
+import { runSteps } from "./step-runner.ts";
 import {
   type Component, type InstallResult,
   ENV_SCHEMAS, ENV_DIR, SECRETS_DIR, BIN_DIR, UNIT_DIR,
@@ -390,7 +391,7 @@ async function resolveLocalArtifact(
     return { status: "skipped", version: "local" };
   }
 
-  const buildResult = await buildLocalArtifact(component, repoPath, hostArch as "x64" | "arm64");
+  const buildResult = await runSteps(buildLocalArtifact(component, repoPath, hostArch as "x64" | "arm64"));
   if (!buildResult) return { status: "failed", version: "" };
 
   const isUpdate = !!(await readManifest(host)).components[component];
@@ -447,7 +448,7 @@ async function resolveArtifact(
     return { status: "skipped", version: dryRunSummary(component, release, isUpdate, hostArch).version };
   }
 
-  const archivePath = await resolveRemoteArtifact(release, component, host);
+  const archivePath = await runSteps(resolveRemoteArtifact(release, component, host));
   if (!archivePath) return { status: "failed", version: release.tagName };
   return { status: "ready", archivePath, versionString: release.tagName, isUpdate };
 }
@@ -481,11 +482,10 @@ async function backupCurrentConfig(component: Component, host: Host): Promise<vo
   if (result.success && !result.skipped) info("Backup", `Previous configuration saved to ${envPath}.bak`);
 }
 
-/** Restart the service if it's already running, otherwise start it. */
 async function bringServiceUp(component: Component, host: Host): Promise<boolean> {
   return (await isUnitActiveOn(host, unitName(component)))
-    ? restartService(component, host)
-    : startService(component, host);
+    ? runSteps(restartService(component, host))
+    : runSteps(startService(component, host));
 }
 
 /** Restore the .bak binary and configuration, then bring the service back up. */
@@ -537,16 +537,26 @@ async function configureAndStart(
     const envResult = await configureEnv(component, host, autoDefaults);
     if (!envResult) return null; // user cancelled
 
-    const wrote = await writeEnvConfig(component, envResult.config, envResult.secrets, host);
-    if (!wrote) errors.push("Failed to write configuration (may need manual setup)");
+    const configResult = await writeEnvConfig(component, envResult.config, envResult.secrets, host);
+    if (configResult.success) {
+      pass("Config", "Environment configured");
+    } else if (configResult.error) {
+      fail("Config", configResult.error);
+      errors.push("Failed to write configuration (may need manual setup)");
+    }
 
     if (component === "daemon") {
       await ensureDriverTools(envResult.config, envResult.secrets, host);
     }
 
     const secretKeys = Object.keys(envResult.secrets);
-    const unitInstalled = await writeSystemdUnit(component, secretKeys, host);
-    if (!unitInstalled) {
+    const unitResult = await writeSystemdUnit(component, secretKeys, host);
+    if (unitResult.success) {
+      pass("Systemd", `Unit installed`);
+    } else if (!unitResult.skipped) {
+      if (unitResult.error) {
+        fail("Systemd", unitResult.error);
+      }
       errors.push("Systemd unit not installed (may need manual setup)");
     }
 
@@ -633,7 +643,7 @@ export async function installComponent(opts: {
   }
 
   // 4. Install binary
-  const installed = await installBinary(component, archivePath, host);
+  const installed = await runSteps(installBinary(component, archivePath, host));
   if (!installed) return { success: false, version: versionString, errors: ["Installation failed or skipped"] };
 
   // 5. Configure env, install unit, restart (update) or start (fresh install)

--- a/packages/xinity-cli/src/lib/installer.ts
+++ b/packages/xinity-cli/src/lib/installer.ts
@@ -8,7 +8,7 @@ import { generateUnit, getComponentConfig, unitName } from "./systemd.ts";
 import { analyzeEnvSchema, categorizeFields, menuEditEnv, promptForEnv, splitValuesByCategory } from "./env-prompt.ts";
 import { parseEnvString } from "./env-file.ts";
 import { pass, fail, warn, info, cancelAndExit, promptOrExit } from "./output.ts";
-import { type Host, createLocalHost, commandExistsOn, isUnitActiveOn, readSecrets } from "./host.ts";
+import { type Host, commandExistsOn, isUnitActiveOn, readSecrets } from "./host.ts";
 import { isOllamaRunning, waitForOllamaRunning } from "./ollama-setup.ts";
 import { writeEnvConfig, writeSystemdUnit, stopService, startService, restartService } from "./service.ts";
 import { runSteps } from "./step-runner.ts";
@@ -61,13 +61,11 @@ export async function preflightCheck(
     (c) => c === "all" || serviceComponents.includes(c),
   );
   if (needsExtractor) {
-    const target = host.isRemote ? "the remote host" : "this machine";
-    await check("tar", `required on ${target} for binary extraction`, "apt install tar / dnf install tar / pacman -S tar");
+    await check("tar", "required on the target host for binary extraction", "apt install tar / dnf install tar / pacman -S tar");
   }
 
-  // curl is needed on remote hosts for downloading release assets
-  if (host.isRemote && components.some((c) => serviceComponents.includes(c) || c === "all" || c === "db")) {
-    await check("curl", "required on the remote host for downloading release assets");
+  if (components.some((c) => serviceComponents.includes(c) || c === "all" || c === "db")) {
+    await check("curl", "required on the target host for downloading release assets");
   }
 
   return issues;
@@ -396,15 +394,12 @@ async function resolveLocalArtifact(
 
   const isUpdate = !!(await readManifest(host)).components[component];
 
-  if (!host.isRemote) {
-    return { status: "ready", archivePath: buildResult.archivePath, versionString: buildResult.version, isUpdate };
-  }
-
   const remoteTmp = `/tmp/xinity-local-${Date.now()}.tar.gz`;
   const uploadSpinner = p.spinner();
   uploadSpinner.start("Uploading artifact...");
+  let effectivePath: string;
   try {
-    await host.uploadFile(buildResult.archivePath, remoteTmp);
+    effectivePath = await host.uploadFile(buildResult.archivePath, remoteTmp);
   } catch (err) {
     uploadSpinner.stop("Upload failed");
     fail("Upload", (err as Error).message);
@@ -412,13 +407,13 @@ async function resolveLocalArtifact(
   }
   uploadSpinner.stop("Uploaded");
 
-  const remoteHash = await host.computeSha256(remoteTmp);
-  if (remoteHash && remoteHash !== buildResult.sha256) {
-    fail("Verify", `Checksum mismatch after upload (local: ${buildResult.sha256}, remote: ${remoteHash})`);
+  const hostHash = await host.computeSha256(effectivePath);
+  if (hostHash && hostHash !== buildResult.sha256) {
+    fail("Verify", `Checksum mismatch after upload (local: ${buildResult.sha256}, host: ${hostHash})`);
     return { status: "failed", version: buildResult.version };
   }
   pass("Verify", "Checksum matched");
-  return { status: "ready", archivePath: remoteTmp, versionString: buildResult.version, isUpdate };
+  return { status: "ready", archivePath: effectivePath, versionString: buildResult.version, isUpdate };
 }
 
 /**
@@ -603,12 +598,11 @@ export async function installComponent(opts: {
   targetVersion: string;
   dryRun?: boolean;
   hardReset?: boolean;
-  host?: Host;
+  host: Host;
   /** Extra env defaults carried from prior setup steps (e.g. DB_CONNECTION_URL, REDIS_URL). */
   envOverrides?: Record<string, string>;
 }): Promise<InstallResult> {
-  const { component, targetVersion, dryRun = false, hardReset = false } = opts;
-  const host = opts.host ?? createLocalHost();
+  const { component, targetVersion, dryRun = false, hardReset = false, host } = opts;
 
   // 1. Pre-checks
   const preErrors = await preChecks(component, host);
@@ -786,13 +780,11 @@ export async function runComponentSequence<T extends { success: boolean; errors:
 }
 
 /** Install all components in sequence, carrying shared env vars forward. */
-export async function installAll(targetVersion: string, dryRun = false, hardReset = false, host?: Host): Promise<void> {
+export async function installAll(targetVersion: string, dryRun = false, hardReset = false, host: Host): Promise<void> {
   if (targetVersion.startsWith("local:")) {
     fail("Local build", "'xinity up all' does not support local: builds. Run 'xinity up <component>' for each component individually.");
     return;
   }
-
-  const resolvedHost = host ?? createLocalHost();
 
   // Shared env vars accumulated across setup steps
   const shared: Record<string, string> = {};
@@ -800,7 +792,7 @@ export async function installAll(targetVersion: string, dryRun = false, hardRese
   // ── 1. Database ────────────────────────────────────────────────────────
   p.log.step(pc.bold("\n── database ──"));
   const { runMigrations } = await import("./migrator.ts");
-  const dbResult = await runMigrations({ targetVersion, dryRun, host: resolvedHost });
+  const dbResult = await runMigrations({ targetVersion, dryRun, host: host });
   if (!dbResult.success) {
     const proceed = await confirmContinueAfterFailure("Database", `Had issues: ${dbResult.errors.join(", ")}`);
     if (!proceed) return;
@@ -812,7 +804,7 @@ export async function installAll(targetVersion: string, dryRun = false, hardRese
   // ── 2. Redis ───────────────────────────────────────────────────────────
   p.log.step(pc.bold("\n── redis ──"));
   const { discoverRedisUrl } = await import("./redis-setup.ts");
-  const redisUrl = await discoverRedisUrl(resolvedHost, dryRun);
+  const redisUrl = await discoverRedisUrl(host, dryRun);
   if (redisUrl) {
     shared.REDIS_URL = redisUrl;
   } else {
@@ -833,7 +825,7 @@ export async function installAll(targetVersion: string, dryRun = false, hardRese
     p.log.step(pc.bold("\n── infoserver ──"));
     const result = await installComponent({
       component: "infoserver",
-      targetVersion, dryRun, hardReset, host: resolvedHost,
+      targetVersion, dryRun, hardReset, host: host,
       envOverrides: shared,
     });
     if (!result.success) {
@@ -844,7 +836,7 @@ export async function installAll(targetVersion: string, dryRun = false, hardRese
 
   // ── 4+5. Gateway + Dashboard ───────────────────────────────────────────
   const coreOk = await runComponentSequence(["gateway", "dashboard"], (component) =>
-    installComponent({ component, targetVersion, dryRun, hardReset, host: resolvedHost, envOverrides: shared }),
+    installComponent({ component, targetVersion, dryRun, hardReset, host: host, envOverrides: shared }),
   );
   if (!coreOk) return;
 
@@ -863,7 +855,7 @@ export async function installAll(targetVersion: string, dryRun = false, hardRese
     if (p.isCancel(setupOllama)) return;
     if (setupOllama) {
       const { provisionOllama, LOCAL_OLLAMA_ENDPOINT } = await import("./ollama-setup.ts");
-      if (await provisionOllama(resolvedHost, dryRun)) {
+      if (await provisionOllama(host, dryRun)) {
         shared.XINITY_OLLAMA_ENDPOINT = LOCAL_OLLAMA_ENDPOINT;
       }
     }
@@ -871,7 +863,7 @@ export async function installAll(targetVersion: string, dryRun = false, hardRese
     p.log.step(pc.bold("\n── daemon ──"));
     const result = await installComponent({
       component: "daemon",
-      targetVersion, dryRun, hardReset, host: resolvedHost,
+      targetVersion, dryRun, hardReset, host: host,
       envOverrides: shared,
     });
     if (!result.success) {
@@ -886,7 +878,7 @@ export async function installAll(targetVersion: string, dryRun = false, hardRese
   doctorSpinner.start("Running diagnostics…");
   const report = await runDoctor({
     interactive: false,
-    host: resolvedHost,
+    host: host,
     spinner: {
       message: (msg: string) => doctorSpinner.message(msg),
       stop: () => doctorSpinner.stop(""),
@@ -906,11 +898,11 @@ export async function installAll(targetVersion: string, dryRun = false, hardRese
   // ── Post-install summary ──────────────────────────────────────────────
   const summaryLines: string[] = [];
 
-  const dashContent = await resolvedHost.readFile(`${ENV_DIR}/dashboard.env`);
+  const dashContent = await host.readFile(`${ENV_DIR}/dashboard.env`);
   const dashboardOrigin = dashContent ? parseEnvString(dashContent).ORIGIN : undefined;
   if (dashboardOrigin) summaryLines.push(`Dashboard:  ${pc.cyan(dashboardOrigin)}`);
 
-  const gwContent = await resolvedHost.readFile(`${ENV_DIR}/gateway.env`);
+  const gwContent = await host.readFile(`${ENV_DIR}/gateway.env`);
   if (gwContent) {
     const parsed = parseEnvString(gwContent);
     const gwHost = parsed.HOST || "localhost";

--- a/packages/xinity-cli/src/lib/installer.ts
+++ b/packages/xinity-cli/src/lib/installer.ts
@@ -372,8 +372,8 @@ async function applyConfigAndStart(
   const configResult = await writeEnvConfig(component, env.config, env.secrets, host);
   if (configResult.success) {
     progress.update("Environment configured");
-  } else if (configResult.error) {
-    progress.fail("Config", configResult.error);
+  } else {
+    progress.fail("Config", configResult.error || "failed to write config");
     errors.push("Failed to write configuration (may need manual setup)");
   }
 
@@ -386,9 +386,7 @@ async function applyConfigAndStart(
   if (unitResult.success) {
     progress.update("Systemd unit installed");
   } else {
-    if (unitResult.error) {
-      progress.fail("Systemd", unitResult.error);
-    }
+    progress.fail("Systemd", unitResult.error || "failed to install unit");
     errors.push("Systemd unit not installed (may need manual setup)");
   }
 

--- a/packages/xinity-cli/src/lib/installer.ts
+++ b/packages/xinity-cli/src/lib/installer.ts
@@ -13,7 +13,7 @@ import { parseEnvString } from "./env-file.ts";
 import { pass, fail, warn, info } from "./output.ts";
 import { type Host, commandExistsOn, isUnitActiveOn } from "./host.ts";
 import { isOllamaRunning } from "./ollama-setup.ts";
-import { writeEnvConfig, writeSystemdUnit, stopService, startService, restartService } from "./service.ts";
+import { heredoc, writeEnvConfig, writeSystemdUnit, stopService, startService, restartService } from "./service.ts";
 import { runSteps, createProgress, type Progress } from "./step-runner.ts";
 import {
   type Component, type InstallResult,
@@ -87,7 +87,7 @@ async function installVllmTemplate(host: Host, templatePath: string, progress: P
   }
 
   const result = await host.withElevation(
-    `cat > ${templatePath} << 'VLLMEOF'\n${vllmTemplateUnit}VLLMEOF\nsystemctl daemon-reload`,
+    `cat > ${templatePath} ${heredoc("VLLMEOF", vllmTemplateUnit)}\nsystemctl daemon-reload`,
     "Install vLLM systemd template unit",
   );
 

--- a/packages/xinity-cli/src/lib/installer.ts
+++ b/packages/xinity-cli/src/lib/installer.ts
@@ -2,8 +2,8 @@
  * Component installer: the apply half of the up flow. Executes decisions
  * already made and reviewed during planning (up-plan.ts); nothing prompts.
  */
-import * as p from "./clack.ts";
-import pc from "picocolors";
+import { log, note, spinner } from "./clack.ts";
+import { bold, cyan, yellow } from "picocolors";
 
 import { fetchRelease, type Release } from "./github.ts";
 import { buildLocalArtifact } from "./local-build.ts";
@@ -14,7 +14,7 @@ import { pass, fail, warn, info } from "./output.ts";
 import { type Host, commandExistsOn, isUnitActiveOn } from "./host.ts";
 import { isOllamaRunning } from "./ollama-setup.ts";
 import { writeEnvConfig, writeSystemdUnit, stopService, startService, restartService } from "./service.ts";
-import { runSteps } from "./step-runner.ts";
+import { runSteps, createProgress, type Progress } from "./step-runner.ts";
 import {
   type Component, type InstallResult,
   ENV_DIR, SECRETS_DIR, BIN_DIR, UNIT_DIR,
@@ -79,10 +79,10 @@ export async function preflightCheck(
 
 // ─── vLLM systemd template install ─────────────────────────────────────────
 
-async function installVllmTemplate(host: Host, templatePath: string): Promise<void> {
+async function installVllmTemplate(host: Host, templatePath: string, progress: Progress): Promise<void> {
   const exists = await host.fileExists(templatePath);
   if (exists) {
-    pass("vLLM template", `Already installed at ${templatePath}`);
+    progress.update(`vLLM template already installed at ${templatePath}`);
     return;
   }
 
@@ -91,17 +91,25 @@ async function installVllmTemplate(host: Host, templatePath: string): Promise<vo
     "Install vLLM systemd template unit",
   );
 
-  reportElevationWarning(result, "vLLM template", `Installed at ${templatePath}`, "Failed to install");
+  if (result.success) {
+    progress.update(`vLLM template installed at ${templatePath}`);
+  } else {
+    progress.warn("vLLM template", `Failed to install: ${result.output}`);
+  }
 }
 
 // ─── Driver tool checks (daemon only) ───────────────────────────────────────
 
-async function startOllama(host: Host): Promise<void> {
+async function startOllama(host: Host, progress: Progress): Promise<void> {
   const result = await host.withElevation(
     "systemctl enable --now ollama",
     "Start ollama service",
   );
-  reportElevationWarning(result, "Ollama", "ollama service started", "Failed to start ollama");
+  if (result.success) {
+    progress.update("ollama service started");
+  } else {
+    progress.warn("Ollama", `Failed to start ollama: ${result.output}`);
+  }
 }
 
 /**
@@ -113,6 +121,7 @@ async function checkDriverTools(
   config: Record<string, string>,
   secrets: Record<string, string>,
   host: Host,
+  progress: Progress,
 ): Promise<void> {
   const all = { ...config, ...secrets };
   const ollamaEnabled = !!all.XINITY_OLLAMA_ENDPOINT;
@@ -125,26 +134,28 @@ async function checkDriverTools(
   if (vllmEnabled) drivers.push("vllm");
 
   if (drivers.length === 0) {
-    warn("Drivers", "No drivers detected. Set XINITY_OLLAMA_ENDPOINT, VLLM_DOCKER_IMAGE, or VLLM_PATH to enable a driver");
+    progress.warn("Drivers", "No drivers detected. Set XINITY_OLLAMA_ENDPOINT, VLLM_DOCKER_IMAGE, or VLLM_PATH to enable a driver");
     return;
   }
 
-  info("Drivers", `Detected drivers: ${drivers.join(", ")}`);
+  progress.update(`Checking drivers: ${drivers.join(", ")}`);
 
   // ── Ollama ──
   if (ollamaEnabled) {
     const hasOllama = await commandExistsOn(host, "ollama");
     if (hasOllama) {
-      pass("Ollama", "ollama binary found");
       if (await isOllamaRunning(host)) {
-        pass("Ollama", "ollama service is running");
+        progress.update("ollama service is running");
       } else {
-        info("Ollama", "Service is not running, starting it");
-        await startOllama(host);
+        progress.update("ollama service is not running, starting it");
+        await startOllama(host, progress);
       }
     } else {
-      warn("Ollama", `ollama binary not found. Install it with ${pc.cyan("xinity up infra-ollama")}`);
-      p.log.info(pc.dim("  Or manually: curl -fsSL https://ollama.com/install.sh | sh"));
+      progress.warn(
+        "Ollama",
+        `ollama binary not found. Install it with ${cyan("xinity up infra-ollama")}`,
+        "  Or manually: curl -fsSL https://ollama.com/install.sh | sh",
+      );
     }
   }
 
@@ -152,26 +163,32 @@ async function checkDriverTools(
   if (vllmDockerEnabled) {
     const hasDocker = await commandExistsOn(host, "docker");
     if (hasDocker) {
-      pass("vLLM", "docker found (vllm-docker mode)");
+      progress.update("docker found (vllm-docker mode)");
 
       // Check for GPU container runtime matching the detected GPU vendor
       const hasNvidiaSmi = await commandExistsOn(host, "nvidia-smi");
       if (hasNvidiaSmi) {
         const rtResult = await host.run(["nvidia-container-runtime", "--version"]);
         if (rtResult.ok) {
-          pass("vLLM", "NVIDIA container runtime detected");
+          progress.update("NVIDIA container runtime detected");
         } else {
-          warn("vLLM", "NVIDIA container runtime not found, GPU passthrough may not work");
-          p.log.info(pc.dim("  Install nvidia-container-toolkit: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html"));
+          progress.warn(
+            "vLLM",
+            "NVIDIA container runtime not found, GPU passthrough may not work",
+            "  Install nvidia-container-toolkit: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html",
+          );
         }
       } else if (await commandExistsOn(host, "rocm-smi")) {
-        pass("vLLM", "AMD GPU detected (ROCm)");
+        progress.update("AMD GPU detected (ROCm)");
       } else {
-        warn("vLLM", "No GPU tools detected (nvidia-smi / rocm-smi), GPU passthrough may not work");
+        progress.warn("vLLM", "No GPU tools detected (nvidia-smi / rocm-smi), GPU passthrough may not work");
       }
     } else {
-      warn("vLLM", "docker not found but VLLM_DOCKER_IMAGE is set");
-      p.log.info(pc.dim("  Install Docker: https://docs.docker.com/engine/install/"));
+      progress.warn(
+        "vLLM",
+        "docker not found but VLLM_DOCKER_IMAGE is set",
+        "  Install Docker: https://docs.docker.com/engine/install/",
+      );
     }
   }
 
@@ -180,14 +197,13 @@ async function checkDriverTools(
     const vllmPath = all.VLLM_PATH!;
     const exists = await host.fileExists(vllmPath);
     if (exists) {
-      pass("vLLM", `vllm binary found at ${vllmPath}`);
+      progress.update(`vllm binary found at ${vllmPath}`);
     } else {
-      warn("vLLM", `vllm binary not found at ${vllmPath}`);
-      p.log.info(pc.dim("  Ensure vLLM is installed: pip install vllm"));
+      progress.warn("vLLM", `vllm binary not found at ${vllmPath}`, "  Ensure vLLM is installed: pip install vllm");
     }
 
     const templatePath = all.VLLM_TEMPLATE_UNIT_PATH ?? `${UNIT_DIR}/vllm-driver@.service`;
-    await installVllmTemplate(host, templatePath);
+    await installVllmTemplate(host, templatePath, progress);
   }
 }
 
@@ -203,14 +219,10 @@ export async function resolveVersion(
   targetVersion: string,
   host: Host,
 ): Promise<VersionResult> {
-  const spinner = p.spinner();
-  spinner.start("Checking for latest version…");
-
   let release: Release;
   try {
     release = await fetchRelease(targetVersion);
   } catch (err) {
-    spinner.stop("Version check failed");
     fail("GitHub API", (err as Error).message);
     return { status: "failed" };
   }
@@ -221,31 +233,27 @@ export async function resolveVersion(
   const isUpdate = !!installedVersion;
 
   if (installedVersion === release.tagName) {
-    spinner.stop(`${release.tagName} already installed`);
-
     // Verify the installed binary is intact before deciding.
     if (installedEntry?.binaryChecksum && installedEntry.binaryPath) {
-      const checksumSpinner = p.spinner();
-      checksumSpinner.start("Verifying installed binary…");
+      const checksumSpinner = spinner();
+      checksumSpinner.start(`Verifying installed ${component} binary…`);
       const currentHash = await host.computeSha256(installedEntry.binaryPath);
       if (currentHash === installedEntry.binaryChecksum) {
-        checksumSpinner.stop("Binary verified, checksums match");
+        checksumSpinner.stop(`${component} ${release.tagName} installed and verified`);
         return { status: "current", version: release.tagName };
       }
-      checksumSpinner.stop("Checksum mismatch, binary may be corrupted. Reinstalling");
-      warn("Checksum", "Installed binary does not match expected checksum");
+      checksumSpinner.stop(`${component}: checksum mismatch, binary may be corrupted. Reinstalling`);
       return { status: "proceed", release, isUpdate: true, installedVersion };
     }
 
     // No stored checksum (legacy install): treat as current.
-    info("Version", "Already installed (no checksum recorded to verify)");
+    info("Version", `${component} already installed (no checksum recorded to verify)`);
     return { status: "current", version: release.tagName };
-  } else if (isUpdate) {
-    spinner.stop(`Update available: ${installedVersion} → ${release.tagName}`);
-  } else {
-    spinner.stop(`Latest version: ${release.tagName}`);
   }
 
+  if (isUpdate) {
+    info("Version", `${component}: update available ${installedVersion} → ${release.tagName}`);
+  }
   return { status: "proceed", release, isUpdate, installedVersion };
 }
 
@@ -255,51 +263,49 @@ async function buildAndUploadLocalArtifact(
   component: Component,
   repoPath: string,
   host: Host,
+  progress: Progress,
 ): Promise<{ archivePath: string; version: string } | null> {
   const hostArch = await host.getArch();
-  const buildResult = await runSteps(buildLocalArtifact(component, repoPath, hostArch as "x64" | "arm64"));
+  const buildResult = await runSteps(buildLocalArtifact(component, repoPath, hostArch as "x64" | "arm64"), progress);
   if (!buildResult) return null;
 
   const remoteTmp = `/tmp/xinity-local-${Date.now()}.tar.gz`;
-  const uploadSpinner = p.spinner();
-  uploadSpinner.start("Uploading artifact...");
+  progress.update("Uploading artifact…");
   let effectivePath: string;
   try {
     effectivePath = await host.uploadFile(buildResult.archivePath, remoteTmp);
   } catch (err) {
-    uploadSpinner.stop("Upload failed");
-    fail("Upload", (err as Error).message);
+    progress.fail("Upload", (err as Error).message);
     return null;
   }
-  uploadSpinner.stop("Uploaded");
 
   const hostHash = await host.computeSha256(effectivePath);
   if (hostHash && hostHash !== buildResult.sha256) {
-    fail("Verify", `Checksum mismatch after upload (local: ${buildResult.sha256}, host: ${hostHash})`);
+    progress.fail("Verify", `Checksum mismatch after upload (local: ${buildResult.sha256}, host: ${hostHash})`);
     return null;
   }
-  pass("Verify", "Checksum matched");
+  progress.update("Upload checksum matched");
   return { archivePath: effectivePath, version: buildResult.version };
 }
 
 function printServiceFailureDiagnostics(unit: string): void {
-  p.log.warn(pc.yellow("Service failed to start. Diagnostic commands:"));
-  p.log.info(`  ${pc.cyan(`systemctl status ${unit}`)}`);
-  p.log.info(`  ${pc.cyan(`journalctl -u ${unit} -e --no-pager`)}`);
+  log.warn(yellow("Service failed to start. Diagnostic commands:"));
+  log.info(`  ${cyan(`systemctl status ${unit}`)}`);
+  log.info(`  ${cyan(`journalctl -u ${unit} -e --no-pager`)}`);
 }
 
 /** Move the current binary aside to <path>.bak before installing the new one. */
-async function backupCurrentBinary(component: Component, host: Host): Promise<void> {
+async function backupCurrentBinary(component: Component, host: Host, progress: Progress): Promise<void> {
   const binPath = `${BIN_DIR}/${binaryBaseName(component)}`;
   const result = await host.withElevation(
     `[ -f ${binPath} ] && mv -f ${binPath} ${binPath}.bak || true`,
     `Back up ${component} binary`,
   );
-  if (result.success) info("Backup", `Previous binary saved to ${binPath}.bak`);
+  if (result.success) progress.update(`Previous binary saved to ${binPath}.bak`);
 }
 
 /** Copy the current env file and secrets aside to .bak before reconfiguring. */
-async function backupCurrentConfig(component: Component, host: Host): Promise<void> {
+async function backupCurrentConfig(component: Component, host: Host, progress: Progress): Promise<void> {
   const envPath = `${ENV_DIR}/${component}.env`;
   const result = await host.withElevation(
     [
@@ -308,17 +314,17 @@ async function backupCurrentConfig(component: Component, host: Host): Promise<vo
     ].join(" && "),
     `Back up ${component} configuration`,
   );
-  if (result.success) info("Backup", `Previous configuration saved to ${envPath}.bak`);
+  if (result.success) progress.update(`Previous configuration saved to ${envPath}.bak`);
 }
 
-async function bringServiceUp(component: Component, host: Host): Promise<boolean> {
+async function bringServiceUp(component: Component, host: Host, progress: Progress): Promise<boolean> {
   return (await isUnitActiveOn(host, unitName(component)))
-    ? runSteps(restartService(component, host))
-    : runSteps(startService(component, host));
+    ? runSteps(restartService(component, host), progress)
+    : runSteps(startService(component, host), progress);
 }
 
 /** Restore the .bak binary and configuration, then bring the service back up. */
-async function performRollback(component: Component, host: Host): Promise<void> {
+async function performRollback(component: Component, host: Host, progress: Progress): Promise<void> {
   const binPath = `${BIN_DIR}/${binaryBaseName(component)}`;
   const envPath = `${ENV_DIR}/${component}.env`;
   const unit = unitName(component);
@@ -337,11 +343,11 @@ async function performRollback(component: Component, host: Host): Promise<void> 
   );
   pass("Rollback", "Previous binary and configuration restored");
 
-  if (await bringServiceUp(component, host)) {
+  if (await bringServiceUp(component, host, progress)) {
     pass("Rollback", `${unit} is back on the previous version`);
   } else {
     warn("Rollback", "Service did not restart after rollback. Manual intervention may be needed");
-    p.log.info(`  ${pc.cyan(`systemctl start ${unit}`)}`);
+    log.info(`  ${cyan(`systemctl start ${unit}`)}`);
   }
 }
 
@@ -357,39 +363,44 @@ async function applyConfigAndStart(
   host: Host,
   isUpdate: boolean,
   onFailure: ServiceFailurePolicy,
+  progress: Progress,
 ): Promise<string[]> {
   const errors: string[] = [];
   const unit = unitName(component);
 
+  progress.update("Writing configuration…");
   const configResult = await writeEnvConfig(component, env.config, env.secrets, host);
   if (configResult.success) {
-    pass("Config", "Environment configured");
+    progress.update("Environment configured");
   } else if (configResult.error) {
-    fail("Config", configResult.error);
+    progress.fail("Config", configResult.error);
     errors.push("Failed to write configuration (may need manual setup)");
   }
 
   if (component === "daemon") {
-    await checkDriverTools(env.config, env.secrets, host);
+    await checkDriverTools(env.config, env.secrets, host, progress);
   }
 
   const secretKeys = Object.keys(env.secrets);
   const unitResult = await writeSystemdUnit(component, secretKeys, host);
   if (unitResult.success) {
-    pass("Systemd", "Unit installed");
+    progress.update("Systemd unit installed");
   } else {
     if (unitResult.error) {
-      fail("Systemd", unitResult.error);
+      progress.fail("Systemd", unitResult.error);
     }
     errors.push("Systemd unit not installed (may need manual setup)");
   }
 
-  if (await bringServiceUp(component, host)) return errors;
+  if (await bringServiceUp(component, host, progress)) return errors;
 
+  if (!progress.hasFailed()) {
+    progress.fail("Service", `${unit} did not start successfully`);
+  }
   printServiceFailureDiagnostics(unit);
 
   if (isUpdate && onFailure === "rollback") {
-    await performRollback(component, host);
+    await performRollback(component, host, progress);
     errors.push("Service failed to start; rolled back to the previous version");
     return errors;
   }
@@ -403,6 +414,14 @@ async function applyConfigAndStart(
   }
   errors.push("Service did not start successfully");
   return errors;
+}
+
+function actionSummary(action: ComponentAction, versionString: string): string {
+  switch (action.kind) {
+    case "install": return `${action.component} ${versionString} installed, service active`;
+    case "update": return `${action.component} updated to ${versionString}, service active`;
+    default: return `${action.component} reconfigured, service restarted`;
+  }
 }
 
 /** Execute one reviewed component action from the plan. */
@@ -420,57 +439,68 @@ export async function applyComponentAction(
 
   const isUpdate = action.kind !== "install";
   let versionString = action.toVersion;
+  const progress = createProgress(`${component}: preparing…`);
 
-  if (action.kind !== "reconfigure") {
-    if (isUpdate) {
-      await backupCurrentBinary(component, host);
-      await backupCurrentConfig(component, host);
+  try {
+    if (action.kind !== "reconfigure") {
+      if (isUpdate) {
+        await backupCurrentBinary(component, host, progress);
+        await backupCurrentConfig(component, host, progress);
 
-      if (action.hardReset) {
-        await stopService(component, host);
-        const unit = unitName(component);
-        info("Hard reset", `Cleaning state for ${unit}…`);
-        const result = await host.withElevation(
-          `systemctl clean --what=state ${unit}`,
-          `Clean state for ${unit}`,
-        );
-        reportElevationWarning(result, "Hard reset", `State cleaned for ${unit}`, "Failed to clean state");
+        if (action.hardReset) {
+          await stopService(component, host);
+          const unit = unitName(component);
+          progress.update(`Cleaning state for ${unit}…`);
+          const result = await host.withElevation(
+            `systemctl clean --what=state ${unit}`,
+            `Clean state for ${unit}`,
+          );
+          if (result.success) {
+            progress.update(`State cleaned for ${unit}`);
+          } else {
+            progress.warn("Hard reset", `Failed to clean state: ${result.output}`);
+          }
+        }
       }
+
+      let archivePath: string;
+      if (action.localRepoPath) {
+        const built = await buildAndUploadLocalArtifact(component, action.localRepoPath, host, progress);
+        if (!built) return { success: false, version: versionString, errors: ["Local build failed"] };
+        archivePath = built.archivePath;
+        versionString = built.version;
+      } else {
+        const downloaded = await runSteps(downloadAndVerifyOnHost(action.release!, action.assetName!, host), progress);
+        if (!downloaded) return { success: false, version: versionString, errors: ["Download failed"] };
+        archivePath = downloaded;
+      }
+
+      const installed = await runSteps(installBinary(component, archivePath, host), progress);
+      if (!installed) return { success: false, version: versionString, errors: ["Installation failed or skipped"] };
     }
 
-    let archivePath: string;
-    if (action.localRepoPath) {
-      const built = await buildAndUploadLocalArtifact(component, action.localRepoPath, host);
-      if (!built) return { success: false, version: versionString, errors: ["Local build failed"] };
-      archivePath = built.archivePath;
-      versionString = built.version;
-    } else {
-      const downloaded = await runSteps(downloadAndVerifyOnHost(action.release!, action.assetName!, host));
-      if (!downloaded) return { success: false, version: versionString, errors: ["Download failed"] };
-      archivePath = downloaded;
+    const errors = await applyConfigAndStart(component, action.env, host, isUpdate, onFailure, progress);
+
+    if (action.kind !== "reconfigure") {
+      const binaryPath = `${BIN_DIR}/${binaryBaseName(component)}`;
+      const binaryChecksum = (await host.computeSha256(binaryPath)) ?? undefined;
+      await updateManifestEntry(component, {
+        version: versionString,
+        installedAt: new Date().toISOString(),
+        binaryPath,
+        unitName: unitName(component),
+        binaryChecksum,
+      }, host);
     }
 
-    const installed = await runSteps(installBinary(component, archivePath, host));
-    if (!installed) return { success: false, version: versionString, errors: ["Installation failed or skipped"] };
+    const success = errors.length === 0;
+    if (success) {
+      progress.done(actionSummary(action, versionString));
+    }
+    return { success, version: versionString, errors };
+  } finally {
+    progress.ensureSettled();
   }
-
-  const errors = await applyConfigAndStart(component, action.env, host, isUpdate, onFailure);
-
-  if (action.kind !== "reconfigure") {
-    const binaryPath = `${BIN_DIR}/${binaryBaseName(component)}`;
-    const binaryChecksum = (await host.computeSha256(binaryPath)) ?? undefined;
-    await updateManifestEntry(component, {
-      version: versionString,
-      installedAt: new Date().toISOString(),
-      binaryPath,
-      unitName: unitName(component),
-      binaryChecksum,
-    }, host);
-  }
-
-  const success = errors.length === 0;
-  if (success) pass("Done", `${component} ${versionString} applied successfully`);
-  return { success, version: versionString, errors };
 }
 
 /** Show onboarding hints after a dashboard install. */
@@ -480,32 +510,19 @@ export async function showDashboardHints(host: Host): Promise<void> {
 
   const lines: string[] = [];
   if (origin) {
-    lines.push(`Dashboard:  ${pc.cyan(origin)}`);
+    lines.push(`Dashboard:  ${cyan(origin)}`);
     lines.push("");
-    lines.push(pc.bold("Next steps:"));
+    lines.push(bold("Next steps:"));
     lines.push(`  1. Connect the CLI to your dashboard:`);
-    lines.push(`     ${pc.cyan(`xinity configure dashboardUrl ${origin}`)}`);
+    lines.push(`     ${cyan(`xinity configure dashboardUrl ${origin}`)}`);
     lines.push(`  2. Create your admin account from the CLI:`);
-    lines.push(`     ${pc.cyan("xinity act onboarding.cli")}`);
-    lines.push(`     Or open ${pc.cyan(origin)} in a browser to sign up there.`);
+    lines.push(`     ${cyan("xinity act onboarding.cli")}`);
+    lines.push(`     Or open ${cyan(origin)} in a browser to sign up there.`);
   } else {
-    lines.push(pc.bold("Next steps:"));
+    lines.push(bold("Next steps:"));
     lines.push(`  1. Create your admin account via the dashboard UI`);
-    lines.push(`     Or from the CLI: ${pc.cyan("xinity act onboarding.cli")}`);
+    lines.push(`     Or from the CLI: ${cyan("xinity act onboarding.cli")}`);
   }
 
-  p.note(lines.join("\n"), "Dashboard installed");
-}
-
-function reportElevationWarning(
-  result: { success: boolean; output: string },
-  label: string,
-  successMsg: string,
-  failurePrefix: string,
-): void {
-  if (result.success) {
-    pass(label, successMsg);
-  } else {
-    warn(label, `${failurePrefix}: ${result.output}`);
-  }
+  note(lines.join("\n"), "Dashboard installed");
 }

--- a/packages/xinity-cli/src/lib/installer.ts
+++ b/packages/xinity-cli/src/lib/installer.ts
@@ -432,17 +432,20 @@ export async function applyComponentAction(
   action: ComponentAction,
   host: Host,
   onFailure: ServiceFailurePolicy = "rollback",
+  externalProgress?: Progress,
 ): Promise<InstallResult> {
   const { component } = action;
 
   if (action.kind === "none") {
-    pass("Skip", `${component} ${action.toVersion} is current, configuration unchanged`);
+    if (!externalProgress) {
+      pass("Skip", `${component} ${action.toVersion} is current, configuration unchanged`);
+    }
     return { success: true, version: action.toVersion, errors: [] };
   }
 
   const isUpdate = action.kind !== "install";
   let versionString = action.toVersion;
-  const progress = createProgress(`${component}: preparing…`);
+  const progress = externalProgress ?? createProgress(`${component}: preparing…`);
 
   try {
     if (isUpdate) {

--- a/packages/xinity-cli/src/lib/installer.ts
+++ b/packages/xinity-cli/src/lib/installer.ts
@@ -1,31 +1,37 @@
+/**
+ * Component installer: the apply half of the up flow. Executes decisions
+ * already made and reviewed during planning (up-plan.ts); nothing prompts.
+ */
 import * as p from "./clack.ts";
 import pc from "picocolors";
 
-import { fetchRelease, pickReleaseAsset, assetPrefix, getProjectUrl, type Release } from "./github.ts";
+import { fetchRelease, type Release } from "./github.ts";
 import { buildLocalArtifact } from "./local-build.ts";
 import { readManifest, updateManifestEntry } from "./manifest.ts";
-import { generateUnit, getComponentConfig, unitName } from "./systemd.ts";
-import { analyzeEnvSchema, categorizeFields, menuEditEnv, promptForEnv, splitValuesByCategory } from "./env-prompt.ts";
+import { unitName } from "./systemd.ts";
 import { parseEnvString } from "./env-file.ts";
-import { pass, fail, warn, info, cancelAndExit, promptOrExit } from "./output.ts";
-import { type Host, commandExistsOn, isUnitActiveOn, readSecrets } from "./host.ts";
-import { isOllamaRunning, waitForOllamaRunning } from "./ollama-setup.ts";
+import { pass, fail, warn, info } from "./output.ts";
+import { type Host, commandExistsOn, isUnitActiveOn } from "./host.ts";
+import { isOllamaRunning } from "./ollama-setup.ts";
 import { writeEnvConfig, writeSystemdUnit, stopService, startService, restartService } from "./service.ts";
 import { runSteps } from "./step-runner.ts";
 import {
   type Component, type InstallResult,
-  ENV_SCHEMAS, ENV_DIR, SECRETS_DIR, BIN_DIR, UNIT_DIR,
-  binaryBaseName, getAutoDefaults,
+  ENV_DIR, SECRETS_DIR, BIN_DIR, UNIT_DIR,
+  binaryBaseName,
 } from "./component-meta.ts";
+import type { ComponentAction } from "./up-plan.ts";
 // @ts-expect-error Bun text import
 import vllmTemplateUnit from "xinity-ai-daemon/src/assets/vllm-driver@.service" with { type: "text" };
 
-export type { Release } from "./github.ts";
-import { installBinary, resolveRemoteArtifact, assetSizeMb } from "./install-download.ts";
+import { installBinary, downloadAndVerifyOnHost } from "./install-download.ts";
+import type { EnvBundle } from "./env-prompt.ts";
+
+export type ServiceFailurePolicy = "rollback" | "keep";
 
 // ─── Pre-checks ────────────────────────────────────────────────────────────
 
-interface PreflightIssue {
+export interface PreflightIssue {
   tool: string;
   reason: string;
   hint?: string;
@@ -71,12 +77,6 @@ export async function preflightCheck(
   return issues;
 }
 
-/** Legacy per-component pre-check, delegates to preflightCheck. */
-async function preChecks(component: Component, host: Host): Promise<string[]> {
-  const issues = await preflightCheck([component], host);
-  return issues.map((i) => `${i.reason}${i.hint ? `. Install it: ${i.hint}` : ""}`);
-}
-
 // ─── vLLM systemd template install ─────────────────────────────────────────
 
 async function installVllmTemplate(host: Host, templatePath: string): Promise<void> {
@@ -96,7 +96,7 @@ async function installVllmTemplate(host: Host, templatePath: string): Promise<vo
 
 // ─── Driver tool checks (daemon only) ───────────────────────────────────────
 
-async function enableOllamaService(host: Host): Promise<void> {
+async function startOllama(host: Host): Promise<void> {
   const result = await host.withElevation(
     "systemctl enable --now ollama",
     "Start ollama service",
@@ -105,10 +105,11 @@ async function enableOllamaService(host: Host): Promise<void> {
 }
 
 /**
- * Detects which drivers are enabled from the configured env values and ensures
- * the required tools are available. For ollama, offers automatic installation.
+ * Detects which drivers are enabled from the configured env values and checks
+ * the required tools are available. A stopped ollama service is started; a
+ * missing ollama install is reported (installing it is `up infra-ollama`).
  */
-async function ensureDriverTools(
+async function checkDriverTools(
   config: Record<string, string>,
   secrets: Record<string, string>,
   host: Host,
@@ -135,51 +136,15 @@ async function ensureDriverTools(
     const hasOllama = await commandExistsOn(host, "ollama");
     if (hasOllama) {
       pass("Ollama", "ollama binary found");
-
-      // Check if ollama service is running
       if (await isOllamaRunning(host)) {
         pass("Ollama", "ollama service is running");
       } else {
-        const startIt = await p.confirm({
-          message: "Ollama is installed but the service is not running. Start it?",
-          initialValue: true,
-        });
-        if (!p.isCancel(startIt) && startIt) {
-          await enableOllamaService(host);
-        }
+        info("Ollama", "Service is not running, starting it");
+        await startOllama(host);
       }
     } else {
-      warn("Ollama", "ollama binary not found");
-      const install = await p.confirm({
-        message: "Ollama is not installed. Install it now?",
-        initialValue: true,
-      });
-
-      if (!p.isCancel(install) && install) {
-        const result = await host.withElevation(
-          "curl -fsSL https://ollama.com/install.sh | sh",
-          "Install ollama",
-        );
-
-        if (result.success) {
-          pass("Ollama", "ollama installed successfully");
-
-          // Poll until the service comes up (install script usually starts it)
-          const ollamaSpinner = p.spinner();
-          ollamaSpinner.start("Waiting for ollama service…");
-          const ollamaRunning = await waitForOllamaRunning(host);
-          ollamaSpinner.stop(ollamaRunning ? "Service running" : "Service not started automatically");
-
-          if (!ollamaRunning) {
-            await enableOllamaService(host);
-          } else {
-            pass("Ollama", "ollama service is running");
-          }
-        } else {
-          warn("Ollama", `Automatic install failed: ${result.output}`);
-          p.log.info(pc.dim("  Install manually: curl -fsSL https://ollama.com/install.sh | sh"));
-        }
-      }
+      warn("Ollama", `ollama binary not found. Install it with ${pc.cyan("xinity up infra-ollama")}`);
+      p.log.info(pc.dim("  Or manually: curl -fsSL https://ollama.com/install.sh | sh"));
     }
   }
 
@@ -226,14 +191,14 @@ async function ensureDriverTools(
   }
 }
 
-// ─── Version resolution ────────────────────────────────────────────────────
+// ─── Version resolution (planning phase, read-only) ────────────────────────
 
-type VersionResult =
-  | { status: "proceed"; release: Release; isUpdate: boolean }
-  | { status: "skipped"; version: string }
+export type VersionResult =
+  | { status: "proceed"; release: Release; isUpdate: boolean; installedVersion?: string }
+  | { status: "current"; version: string }
   | { status: "failed" };
 
-async function resolveVersion(
+export async function resolveVersion(
   component: Component,
   targetVersion: string,
   host: Host,
@@ -264,135 +229,36 @@ async function resolveVersion(
       checksumSpinner.start("Verifying installed binary…");
       const currentHash = await host.computeSha256(installedEntry.binaryPath);
       if (currentHash === installedEntry.binaryChecksum) {
-        checksumSpinner.stop("Already installed and verified, checksums match");
-        return { status: "skipped", version: release.tagName };
+        checksumSpinner.stop("Binary verified, checksums match");
+        return { status: "current", version: release.tagName };
       }
       checksumSpinner.stop("Checksum mismatch, binary may be corrupted. Reinstalling");
       warn("Checksum", "Installed binary does not match expected checksum");
-      return { status: "proceed", release, isUpdate: true };
+      return { status: "proceed", release, isUpdate: true, installedVersion };
     }
 
-    // No stored checksum (legacy install), prompt the user.
-    const reinstall = await p.confirm({
-      message: `${component} ${release.tagName} is already installed. Reinstall?`,
-      initialValue: false,
-    });
-    if (p.isCancel(reinstall) || !reinstall) return { status: "skipped", version: release.tagName };
+    // No stored checksum (legacy install): treat as current.
+    info("Version", "Already installed (no checksum recorded to verify)");
+    return { status: "current", version: release.tagName };
   } else if (isUpdate) {
     spinner.stop(`Update available: ${installedVersion} → ${release.tagName}`);
   } else {
     spinner.stop(`Latest version: ${release.tagName}`);
   }
 
-  return { status: "proceed", release, isUpdate };
+  return { status: "proceed", release, isUpdate, installedVersion };
 }
 
-// ─── Env configuration ─────────────────────────────────────────────────────
+// ─── Apply ──────────────────────────────────────────────────────────────────
 
-async function configureEnv(
-  component: Component,
-  host: Host,
-  autoDefaults?: Record<string, string>,
-): Promise<{ config: Record<string, string>; secrets: Record<string, string> } | null> {
-  const schema = ENV_SCHEMAS[component];
-  const fields = analyzeEnvSchema(schema);
-  const { secretFields } = categorizeFields(fields);
-  const secretKeys = secretFields.map((f) => f.key);
-
-  // Load existing values from the host (auto-defaults < file config < file secrets)
-  const envPath = `${ENV_DIR}/${component}.env`;
-  const envContent = await host.readFile(envPath);
-  const existingConfig = envContent ? parseEnvString(envContent) : {};
-  let existingSecrets: Record<string, string> = {};
-  // Track which secret keys should be treated as "already set" even if we
-  // couldn't read their values. When elevation is skipped or denied, we
-  // can't stat the files either (the secrets dir is root-only), so we
-  // conservatively assume all secrets exist. Re-prompting for secrets the
-  // user chose not to unlock would be worse than skipping a truly missing one.
-  const secretsOnDisk = new Set<string>();
-  let secretsLocked = false;
-  if (secretKeys.length > 0) {
-    const sr = await readSecrets(host, SECRETS_DIR, secretKeys, "Read existing secrets");
-    existingSecrets = sr.secrets;
-    if (sr.skipped || sr.permissionDenied) {
-      secretsLocked = true;
-      for (const key of secretKeys) secretsOnDisk.add(key);
-    } else {
-      for (const key of Object.keys(sr.secrets)) secretsOnDisk.add(key);
-    }
-  }
-  // Only count config as "existing" based on actual values we read, not
-  // phantom secrets assumed present because elevation was skipped.
-  const hasExistingConfig = Object.keys(existingConfig).length > 0 || Object.keys(existingSecrets).length > 0;
-  const existing = { ...(autoDefaults ?? {}), ...existingConfig, ...existingSecrets };
-
-  // Check if all required fields already have values.
-  // Secrets on disk count as "have a value" even if we couldn't read them.
-  const missingRequired = fields.filter(
-    (f) => !f.isOptional && !f.hasDefault && !existing[f.key] && !secretsOnDisk.has(f.key),
-  );
-
-  const useExisting = () => splitValuesByCategory(fields, existing);
-
-  const isInstalled = !!(await readManifest(host)).components[component];
-
-  if (isInstalled && hasExistingConfig) {
-    if (missingRequired.length === 0) {
-      const action = await promptOrExit(p.select({
-        message: "All configuration variables are already set.",
-        options: [
-          { value: "skip", label: "Keep current configuration" },
-          { value: "edit", label: "Edit configuration" },
-        ],
-      }));
-      if (action === "skip") return useExisting();
-      const result = await menuEditEnv(schema, existing, { secretsLocked });
-      return result ?? useExisting();
-    } else {
-      p.log.info(
-        `${missingRequired.length} new variable(s) need to be set. Edit any other values too if you like.`,
-      );
-      const newKeys = new Set(missingRequired.map((f) => f.key));
-      const result = await menuEditEnv(schema, existing, { newKeys, secretsLocked });
-      if (result === null) cancelAndExit();
-      return result;
-    }
-  } else if (hasExistingConfig && missingRequired.length === 0) {
-    // Not in manifest but has existing config, preserve original behavior
-    const reconfigure = await promptOrExit(p.confirm({
-      message: "Existing configuration found. Reconfigure?",
-      initialValue: false,
-    }));
-    if (!reconfigure) return useExisting();
-  }
-
-  return promptForEnv(component, schema, existing);
-}
-
-// ─── Main orchestrator ─────────────────────────────────────────────────────
-
-type ArtifactResult =
-  | { status: "ready"; archivePath: string; versionString: string; isUpdate: boolean }
-  | { status: "skipped"; version: string }
-  | { status: "failed"; version: string };
-
-async function resolveLocalArtifact(
+async function buildAndUploadLocalArtifact(
   component: Component,
   repoPath: string,
-  dryRun: boolean,
   host: Host,
-): Promise<ArtifactResult> {
+): Promise<{ archivePath: string; version: string } | null> {
   const hostArch = await host.getArch();
-
-  if (dryRun) {
-    pass("Local build", `Would build ${component} from ${repoPath} for linux/${hostArch}`);
-    return { status: "skipped", version: "local" };
-  }
-
   const buildResult = await runSteps(buildLocalArtifact(component, repoPath, hostArch as "x64" | "arm64"));
-  if (!buildResult) return { status: "failed", version: "" };
-
-  const isUpdate = !!(await readManifest(host)).components[component];
+  if (!buildResult) return null;
 
   const remoteTmp = `/tmp/xinity-local-${Date.now()}.tar.gz`;
   const uploadSpinner = p.spinner();
@@ -403,49 +269,17 @@ async function resolveLocalArtifact(
   } catch (err) {
     uploadSpinner.stop("Upload failed");
     fail("Upload", (err as Error).message);
-    return { status: "failed", version: buildResult.version };
+    return null;
   }
   uploadSpinner.stop("Uploaded");
 
   const hostHash = await host.computeSha256(effectivePath);
   if (hostHash && hostHash !== buildResult.sha256) {
     fail("Verify", `Checksum mismatch after upload (local: ${buildResult.sha256}, host: ${hostHash})`);
-    return { status: "failed", version: buildResult.version };
+    return null;
   }
   pass("Verify", "Checksum matched");
-  return { status: "ready", archivePath: effectivePath, versionString: buildResult.version, isUpdate };
-}
-
-/**
- * Resolve what to install: either build from a local repo (local: prefix) or
- * fetch the appropriate zip from a GitHub release. Returns a ready archive path
- * on the target host plus the version label and update flag.
- */
-async function resolveArtifact(
-  component: Component,
-  targetVersion: string,
-  dryRun: boolean,
-  host: Host,
-): Promise<ArtifactResult> {
-  if (targetVersion.startsWith("local:")) {
-    return resolveLocalArtifact(component, targetVersion.slice(6), dryRun, host);
-  }
-
-  // GitHub release path
-  const versionResult = await resolveVersion(component, targetVersion, host);
-  if (versionResult.status === "skipped") return { status: "skipped", version: versionResult.version };
-  if (versionResult.status === "failed") return { status: "failed", version: "" };
-
-  const { release, isUpdate } = versionResult;
-
-  if (dryRun) {
-    const hostArch = await host.getArch();
-    return { status: "skipped", version: dryRunSummary(component, release, isUpdate, hostArch).version };
-  }
-
-  const archivePath = await runSteps(resolveRemoteArtifact(release, component, host));
-  if (!archivePath) return { status: "failed", version: release.tagName };
-  return { status: "ready", archivePath, versionString: release.tagName, isUpdate };
+  return { archivePath: effectivePath, version: buildResult.version };
 }
 
 function printServiceFailureDiagnostics(unit: string): void {
@@ -461,7 +295,7 @@ async function backupCurrentBinary(component: Component, host: Host): Promise<vo
     `[ -f ${binPath} ] && mv -f ${binPath} ${binPath}.bak || true`,
     `Back up ${component} binary`,
   );
-  if (result.success && !result.skipped) info("Backup", `Previous binary saved to ${binPath}.bak`);
+  if (result.success) info("Backup", `Previous binary saved to ${binPath}.bak`);
 }
 
 /** Copy the current env file and secrets aside to .bak before reconfiguring. */
@@ -474,7 +308,7 @@ async function backupCurrentConfig(component: Component, host: Host): Promise<vo
     ].join(" && "),
     `Back up ${component} configuration`,
   );
-  if (result.success && !result.skipped) info("Backup", `Previous configuration saved to ${envPath}.bak`);
+  if (result.success) info("Backup", `Previous configuration saved to ${envPath}.bak`);
 }
 
 async function bringServiceUp(component: Component, host: Host): Promise<boolean> {
@@ -512,152 +346,130 @@ async function performRollback(component: Component, host: Host): Promise<void> 
 }
 
 /**
- * Configure env, write unit, and bring the service up, looping on failure so
- * the user can reconfigure and retry without re-downloading the binary.
- * On an update the service is restarted and a rollback option is offered if it
- * fails. Returns accumulated non-fatal errors (or null on a hard cancel/abort).
+ * Write env config and systemd unit, then bring the service up. On failure
+ * the outcome follows the failure policy: roll back to the .bak backups
+ * (updates only) or keep the broken state for manual diagnosis.
+ * Returns accumulated non-fatal errors.
  */
-async function configureAndStart(
+async function applyConfigAndStart(
   component: Component,
-  autoDefaults: Record<string, string>,
+  env: EnvBundle,
   host: Host,
-  isUpdate = false,
-): Promise<string[] | null> {
+  isUpdate: boolean,
+  onFailure: ServiceFailurePolicy,
+): Promise<string[]> {
   const errors: string[] = [];
   const unit = unitName(component);
-  const verb = isUpdate ? "restart" : "start";
 
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    const envResult = await configureEnv(component, host, autoDefaults);
-    if (!envResult) return null; // user cancelled
-
-    const configResult = await writeEnvConfig(component, envResult.config, envResult.secrets, host);
-    if (configResult.success) {
-      pass("Config", "Environment configured");
-    } else if (configResult.error) {
-      fail("Config", configResult.error);
-      errors.push("Failed to write configuration (may need manual setup)");
-    }
-
-    if (component === "daemon") {
-      await ensureDriverTools(envResult.config, envResult.secrets, host);
-    }
-
-    const secretKeys = Object.keys(envResult.secrets);
-    const unitResult = await writeSystemdUnit(component, secretKeys, host);
-    if (unitResult.success) {
-      pass("Systemd", `Unit installed`);
-    } else if (!unitResult.skipped) {
-      if (unitResult.error) {
-        fail("Systemd", unitResult.error);
-      }
-      errors.push("Systemd unit not installed (may need manual setup)");
-    }
-
-    if (await bringServiceUp(component, host)) return errors;
-
-    printServiceFailureDiagnostics(unit);
-
-    // On a fresh install, disable the broken unit so it doesn't start on boot.
-    // On an update, leave it enabled so a rollback can bring the old version back.
-    await host.withElevation(
-      isUpdate
-        ? `systemctl reset-failed ${unit} 2>/dev/null || true`
-        : `systemctl disable --now ${unit} 2>/dev/null; systemctl reset-failed ${unit} 2>/dev/null`,
-      isUpdate ? `Reset failed state for ${unit}` : `Disable ${unit}`,
-    );
-
-    const action = await p.select({
-      message: "How would you like to proceed?",
-      options: [
-        ...(isUpdate
-          ? [{ value: "rollback", label: "Roll back to previous version (restore backup)" }]
-          : []),
-        { value: "retry", label: "Reconfigure and try again" },
-        { value: "continue", label: "Continue anyway (service not running)" },
-        { value: "abort", label: "Abort" },
-      ],
-    });
-
-    if (p.isCancel(action) || action === "abort") return null;
-    if (action === "rollback") {
-      await performRollback(component, host);
-      return null;
-    }
-    if (action === "continue") {
-      errors.push(`Service did not ${verb} successfully`);
-      return errors;
-    }
-    // retry → loop back to configureEnv
+  const configResult = await writeEnvConfig(component, env.config, env.secrets, host);
+  if (configResult.success) {
+    pass("Config", "Environment configured");
+  } else if (configResult.error) {
+    fail("Config", configResult.error);
+    errors.push("Failed to write configuration (may need manual setup)");
   }
+
+  if (component === "daemon") {
+    await checkDriverTools(env.config, env.secrets, host);
+  }
+
+  const secretKeys = Object.keys(env.secrets);
+  const unitResult = await writeSystemdUnit(component, secretKeys, host);
+  if (unitResult.success) {
+    pass("Systemd", "Unit installed");
+  } else {
+    if (unitResult.error) {
+      fail("Systemd", unitResult.error);
+    }
+    errors.push("Systemd unit not installed (may need manual setup)");
+  }
+
+  if (await bringServiceUp(component, host)) return errors;
+
+  printServiceFailureDiagnostics(unit);
+
+  if (isUpdate && onFailure === "rollback") {
+    await performRollback(component, host);
+    errors.push("Service failed to start; rolled back to the previous version");
+    return errors;
+  }
+
+  if (!isUpdate) {
+    // Disable the broken unit so it doesn't start on boot.
+    await host.withElevation(
+      `systemctl disable --now ${unit} 2>/dev/null; systemctl reset-failed ${unit} 2>/dev/null`,
+      `Disable ${unit}`,
+    );
+  }
+  errors.push("Service did not start successfully");
+  return errors;
 }
 
-export async function installComponent(opts: {
-  component: Component;
-  targetVersion: string;
-  dryRun?: boolean;
-  hardReset?: boolean;
-  host: Host;
-  /** Extra env defaults carried from prior setup steps (e.g. DB_CONNECTION_URL, REDIS_URL). */
-  envOverrides?: Record<string, string>;
-}): Promise<InstallResult> {
-  const { component, targetVersion, dryRun = false, hardReset = false, host } = opts;
+/** Execute one reviewed component action from the plan. */
+export async function applyComponentAction(
+  action: ComponentAction,
+  host: Host,
+  onFailure: ServiceFailurePolicy = "rollback",
+): Promise<InstallResult> {
+  const { component } = action;
 
-  // 1. Pre-checks
-  const preErrors = await preChecks(component, host);
-  if (preErrors.length > 0) {
-    for (const err of preErrors) fail("Pre-check", err);
-    return { success: false, version: "", errors: preErrors };
+  if (action.kind === "none") {
+    pass("Skip", `${component} ${action.toVersion} is current, configuration unchanged`);
+    return { success: true, version: action.toVersion, errors: [] };
   }
-  if (dryRun) pass("Pre-checks", "passed");
 
-  // 2. Resolve version and download / build archive
-  const artifact = await resolveArtifact(component, targetVersion, dryRun, host);
-  if (artifact.status === "skipped") return { success: true, version: artifact.version, errors: [] };
-  if (artifact.status === "failed") return { success: false, version: artifact.version, errors: ["Artifact resolution failed"] };
+  const isUpdate = action.kind !== "install";
+  let versionString = action.toVersion;
 
-  const { archivePath, versionString, isUpdate } = artifact;
+  if (action.kind !== "reconfigure") {
+    if (isUpdate) {
+      await backupCurrentBinary(component, host);
+      await backupCurrentConfig(component, host);
 
-  // 3. Prepare for update: back up binary + config, then optionally hard-reset state
-  if (isUpdate) {
-    await backupCurrentBinary(component, host);
-    await backupCurrentConfig(component, host);
-
-    if (hardReset) {
-      await stopService(component, host);
-      const unit = unitName(component);
-      info("Hard reset", `Cleaning state for ${unit}…`);
-      const result = await host.withElevation(
-        `systemctl clean --what=state ${unit}`,
-        `Clean state for ${unit}`,
-      );
-      reportElevationWarning(result, "Hard reset", `State cleaned for ${unit}`, "Failed to clean state");
+      if (action.hardReset) {
+        await stopService(component, host);
+        const unit = unitName(component);
+        info("Hard reset", `Cleaning state for ${unit}…`);
+        const result = await host.withElevation(
+          `systemctl clean --what=state ${unit}`,
+          `Clean state for ${unit}`,
+        );
+        reportElevationWarning(result, "Hard reset", `State cleaned for ${unit}`, "Failed to clean state");
+      }
     }
+
+    let archivePath: string;
+    if (action.localRepoPath) {
+      const built = await buildAndUploadLocalArtifact(component, action.localRepoPath, host);
+      if (!built) return { success: false, version: versionString, errors: ["Local build failed"] };
+      archivePath = built.archivePath;
+      versionString = built.version;
+    } else {
+      const downloaded = await runSteps(downloadAndVerifyOnHost(action.release!, action.assetName!, host));
+      if (!downloaded) return { success: false, version: versionString, errors: ["Download failed"] };
+      archivePath = downloaded;
+    }
+
+    const installed = await runSteps(installBinary(component, archivePath, host));
+    if (!installed) return { success: false, version: versionString, errors: ["Installation failed or skipped"] };
   }
 
-  // 4. Install binary
-  const installed = await runSteps(installBinary(component, archivePath, host));
-  if (!installed) return { success: false, version: versionString, errors: ["Installation failed or skipped"] };
+  const errors = await applyConfigAndStart(component, action.env, host, isUpdate, onFailure);
 
-  // 5. Configure env, install unit, restart (update) or start (fresh install)
-  const autoDefaults = { ...getAutoDefaults(component), ...(opts.envOverrides ?? {}) };
-  const errors = await configureAndStart(component, autoDefaults, host, isUpdate);
-  if (errors === null) return { success: false, version: versionString, errors: ["Aborted"] };
-
-  // 6. Update manifest
-  const binaryPath = `${BIN_DIR}/${binaryBaseName(component)}`;
-  const binaryChecksum = (await host.computeSha256(binaryPath)) ?? undefined;
-  await updateManifestEntry(component, {
-    version: versionString,
-    installedAt: new Date().toISOString(),
-    binaryPath,
-    unitName: unitName(component),
-    binaryChecksum,
-  }, host);
+  if (action.kind !== "reconfigure") {
+    const binaryPath = `${BIN_DIR}/${binaryBaseName(component)}`;
+    const binaryChecksum = (await host.computeSha256(binaryPath)) ?? undefined;
+    await updateManifestEntry(component, {
+      version: versionString,
+      installedAt: new Date().toISOString(),
+      binaryPath,
+      unitName: unitName(component),
+      binaryChecksum,
+    }, host);
+  }
 
   const success = errors.length === 0;
-  if (success) pass("Done", `${component} ${versionString} installed successfully`);
+  if (success) pass("Done", `${component} ${versionString} applied successfully`);
   return { success, version: versionString, errors };
 }
 
@@ -685,260 +497,15 @@ export async function showDashboardHints(host: Host): Promise<void> {
   p.note(lines.join("\n"), "Dashboard installed");
 }
 
-// ─── Dry run ───────────────────────────────────────────────────────────────
-
-function dryRunSummary(
-  component: Component,
-  release: Release,
-  isUpdate: boolean,
-  arch?: string,
-): InstallResult {
-  let assetName: string;
-  try {
-    assetName = pickReleaseAsset(release, component, arch);
-  } catch {
-    assetName = `${assetPrefix(component, arch)}.tar.gz`;
-  }
-  const asset = release.assets.find((a) => a.name === assetName);
-  const schema = ENV_SCHEMAS[component];
-  const fields = analyzeEnvSchema(schema);
-  const { configFields, secretFields } = categorizeFields(fields);
-  const baseConfig = getComponentConfig(component);
-  const unit = generateUnit({ ...baseConfig, secretKeys: secretFields.map((f) => f.key) });
-
-  p.log.step(pc.bold("Actions that would be performed:"));
-
-  // Version
-  if (isUpdate) {
-    info("Version", `Update to ${release.tagName}`);
-  } else {
-    info("Version", `Fresh install ${release.tagName}`);
-  }
-
-  // Download
-  if (asset) {
-    info("Download", `${assetName} (${assetSizeMb(asset)} MB)`);
-  } else {
-    warn("Download", `Asset ${assetName} not found in release`);
-  }
-
-  // Install path
-  info("Install", `Binary → ${BIN_DIR}/${binaryBaseName(component)}`);
-
-  // Env config
-  info("Config", `${configFields.length} config fields → ${ENV_DIR}/${component}.env`);
-  for (const f of configFields) {
-    const def = f.hasDefault ? pc.dim(` [default: ${f.defaultValue}]`) : "";
-    const opt = f.isOptional ? pc.dim(" (optional)") : "";
-    p.log.info(`  ${f.key}${def}${opt}`);
-  }
-
-  // Secrets
-  info("Secrets", `${secretFields.length} secret fields → ${SECRETS_DIR}/`);
-  for (const f of secretFields) {
-    const opt = f.isOptional ? pc.dim(" (optional)") : "";
-    p.log.info(`  ${f.key}${opt}`);
-  }
-
-  // Systemd unit
-  info("Systemd", `Unit → ${UNIT_DIR}/${unitName(component)}`);
-  p.log.info(pc.dim(unit));
-
-  // Service
-  if (isUpdate) {
-    info("Service", `Restart ${unitName(component)}`);
-  } else {
-    info("Service", `Enable and start ${unitName(component)}`);
-  }
-
-  return { success: true, version: release.tagName, errors: [] };
-}
-
-async function confirmContinueAfterFailure(warnLabel: string, warnDetail: string): Promise<boolean> {
-  warn(warnLabel, warnDetail);
-  const cont = await p.confirm({ message: "Continue with remaining components?", initialValue: true });
-  return !p.isCancel(cont) && cont;
-}
-
-/**
- * Run an action for each component in sequence, prompting to continue on failure.
- * Returns true if all components completed, false if the user aborted mid-sequence.
- */
-export async function runComponentSequence<T extends { success: boolean; errors: string[] }>(
-  components: Component[],
-  action: (component: Component) => Promise<T>,
-): Promise<boolean> {
-  for (const component of components) {
-    p.log.step(pc.bold(`\n── ${component} ──`));
-    const result = await action(component);
-    if (!result.success) {
-      const proceed = await confirmContinueAfterFailure("Partial", `${component} had issues: ${result.errors.join(", ")}`);
-      if (!proceed) return false;
-    }
-  }
-  return true;
-}
-
-/** Install all components in sequence, carrying shared env vars forward. */
-export async function installAll(targetVersion: string, dryRun = false, hardReset = false, host: Host): Promise<void> {
-  if (targetVersion.startsWith("local:")) {
-    fail("Local build", "'xinity up all' does not support local: builds. Run 'xinity up <component>' for each component individually.");
-    return;
-  }
-
-  // Shared env vars accumulated across setup steps
-  const shared: Record<string, string> = {};
-
-  // ── 1. Database ────────────────────────────────────────────────────────
-  p.log.step(pc.bold("\n── database ──"));
-  const { runMigrations } = await import("./migrator.ts");
-  const dbResult = await runMigrations({ targetVersion, dryRun, host: host });
-  if (!dbResult.success) {
-    const proceed = await confirmContinueAfterFailure("Database", `Had issues: ${dbResult.errors.join(", ")}`);
-    if (!proceed) return;
-  }
-  if (dbResult.connectionUrl) {
-    shared.DB_CONNECTION_URL = dbResult.connectionUrl;
-  }
-
-  // ── 2. Redis ───────────────────────────────────────────────────────────
-  p.log.step(pc.bold("\n── redis ──"));
-  const { discoverRedisUrl } = await import("./redis-setup.ts");
-  const redisUrl = await discoverRedisUrl(host, dryRun);
-  if (redisUrl) {
-    shared.REDIS_URL = redisUrl;
-  } else {
-    warn("Redis", "No Redis URL configured");
-    const cont = await p.confirm({ message: "Continue without Redis?", initialValue: true });
-    if (p.isCancel(cont) || !cont) return;
-  }
-
-  // ── 3. Infoserver (optional) ───────────────────────────────────────────
-  p.log.info(pc.dim(`Model registry guide: ${getProjectUrl()}/tree/main/packages/xinity-infoserver#readme`));
-  const installInfoserver = await p.confirm({
-    message: "Install the info server? (optional - most installations use the default at sysinfo.xinity.ai)",
-    initialValue: false,
-  });
-  if (p.isCancel(installInfoserver)) return;
-
-  if (installInfoserver) {
-    p.log.step(pc.bold("\n── infoserver ──"));
-    const result = await installComponent({
-      component: "infoserver",
-      targetVersion, dryRun, hardReset, host: host,
-      envOverrides: shared,
-    });
-    if (!result.success) {
-      const proceed = await confirmContinueAfterFailure("Partial", `infoserver had issues: ${result.errors.join(", ")}`);
-      if (!proceed) return;
-    }
-  }
-
-  // ── 4+5. Gateway + Dashboard ───────────────────────────────────────────
-  const coreOk = await runComponentSequence(["gateway", "dashboard"], (component) =>
-    installComponent({ component, targetVersion, dryRun, hardReset, host: host, envOverrides: shared }),
-  );
-  if (!coreOk) return;
-
-  // ── 6. Daemon (optional) ──────────────────────────────────────────────
-  const installDaemon = await p.confirm({
-    message: "Install the daemon? (only needed on inference hardware)",
-    initialValue: false,
-  });
-  if (p.isCancel(installDaemon)) return;
-
-  if (installDaemon) {
-    const setupOllama = await p.confirm({
-      message: "Set up Ollama on this machine? (one inference driver the daemon can use)",
-      initialValue: false,
-    });
-    if (p.isCancel(setupOllama)) return;
-    if (setupOllama) {
-      const { provisionOllama, LOCAL_OLLAMA_ENDPOINT } = await import("./ollama-setup.ts");
-      if (await provisionOllama(host, dryRun)) {
-        shared.XINITY_OLLAMA_ENDPOINT = LOCAL_OLLAMA_ENDPOINT;
-      }
-    }
-
-    p.log.step(pc.bold("\n── daemon ──"));
-    const result = await installComponent({
-      component: "daemon",
-      targetVersion, dryRun, hardReset, host: host,
-      envOverrides: shared,
-    });
-    if (!result.success) {
-      warn("Partial", `daemon had issues: ${result.errors.join(", ")}`);
-    }
-  }
-
-  // ── Health check ──────────────────────────────────────────────────────
-  p.log.step(pc.bold("\n── health check ──"));
-  const { runDoctor } = await import("./doctor.ts");
-  const doctorSpinner = p.spinner();
-  doctorSpinner.start("Running diagnostics…");
-  const report = await runDoctor({
-    interactive: false,
-    host: host,
-    spinner: {
-      message: (msg: string) => doctorSpinner.message(msg),
-      stop: () => doctorSpinner.stop(""),
-    },
-  });
-  doctorSpinner.stop("");
-
-  const { pass: passCount, warn: warnCount, fail: failCount } = report.summary;
-  if (failCount > 0) {
-    warn("Health", `${failCount} check(s) failed. Run ${pc.cyan("xinity doctor")} for details.`);
-  } else if (warnCount > 0) {
-    pass("Health", `All checks passed (${warnCount} warning(s))`);
-  } else {
-    pass("Health", `All ${passCount} checks passed`);
-  }
-
-  // ── Post-install summary ──────────────────────────────────────────────
-  const summaryLines: string[] = [];
-
-  const dashContent = await host.readFile(`${ENV_DIR}/dashboard.env`);
-  const dashboardOrigin = dashContent ? parseEnvString(dashContent).ORIGIN : undefined;
-  if (dashboardOrigin) summaryLines.push(`Dashboard:  ${pc.cyan(dashboardOrigin)}`);
-
-  const gwContent = await host.readFile(`${ENV_DIR}/gateway.env`);
-  if (gwContent) {
-    const parsed = parseEnvString(gwContent);
-    const gwHost = parsed.HOST || "localhost";
-    const gwPort = parsed.PORT || "4010";
-    summaryLines.push(`Gateway:    ${pc.cyan(`http://${gwHost}:${gwPort}`)}`);
-  }
-
-  if (summaryLines.length > 0) summaryLines.push("");
-  summaryLines.push(pc.bold("Next steps:"));
-  if (dashboardOrigin) {
-    summaryLines.push(`  1. Connect the CLI to your dashboard:`);
-    summaryLines.push(`     ${pc.cyan(`xinity configure dashboardUrl ${dashboardOrigin}`)}`);
-    summaryLines.push(`  2. Create your admin account from the CLI:`);
-    summaryLines.push(`     ${pc.cyan("xinity act onboarding.cli")}`);
-    summaryLines.push(`     Or open ${pc.cyan(dashboardOrigin)} in a browser to sign up there.`);
-  } else {
-    summaryLines.push(`  1. Create your admin account via the dashboard UI`);
-    summaryLines.push(`     Or from the CLI: ${pc.cyan("xinity act onboarding.cli")}`);
-  }
-  summaryLines.push(`  ${dashboardOrigin ? "3" : "2"}. Add inference nodes: ${pc.cyan("xinity up daemon")} on each GPU machine`);
-  summaryLines.push(`  ${dashboardOrigin ? "4" : "3"}. Check health anytime: ${pc.cyan("xinity doctor")}`);
-  summaryLines.push("");
-  summaryLines.push(pc.dim(`Model registry guide: ${getProjectUrl()}/tree/main/packages/xinity-infoserver#readme`));
-
-  p.note(summaryLines.join("\n"), "Installation complete");
-}
-
 function reportElevationWarning(
-  result: { success: boolean; skipped: boolean; output: string },
+  result: { success: boolean; output: string },
   label: string,
   successMsg: string,
   failurePrefix: string,
 ): void {
   if (result.success) {
     pass(label, successMsg);
-  } else if (!result.skipped) {
+  } else {
     warn(label, `${failurePrefix}: ${result.output}`);
   }
 }

--- a/packages/xinity-cli/src/lib/local-build.ts
+++ b/packages/xinity-cli/src/lib/local-build.ts
@@ -1,14 +1,9 @@
-/**
- * Build a component binary from a local monorepo checkout and package it
- * as a zip archive ready for installation via installBinary().
- */
 import { resolve, join, dirname, basename } from "path";
 import { existsSync } from "fs";
 import { tmpdir } from "os";
 import { $ } from "bun";
-import * as p from "./clack.ts";
-import { fail, pass } from "./output.ts";
 import { binaryBaseName, type Component } from "./component-meta.ts";
+import type { StepEvent } from "./step-event.ts";
 
 const BUILDABLE_COMPONENTS = ["daemon", "gateway", "dashboard", "infoserver"] as const;
 type BuildableComponent = (typeof BUILDABLE_COMPONENTS)[number];
@@ -24,7 +19,6 @@ const PACKAGE_DIRS: Record<BuildableComponent, string> = {
   infoserver: "packages/xinity-infoserver",
 };
 
-/** Entry file passed to `bun build --compile`. Dashboard runs its own build script instead. */
 const BUN_BUILD_ENTRYPOINTS: Record<Exclude<BuildableComponent, "dashboard">, string> = {
   daemon: "./src/index.ts",
   gateway: "./src/gatewayServer.ts",
@@ -44,38 +38,42 @@ function buildCommand(component: BuildableComponent, arch: "x64" | "arm64"): str
 async function readVersion(repoPath: string): Promise<string> {
   try {
     const pkgJson = await Bun.file(join(repoPath, "package.json")).json();
-    if (typeof pkgJson.version === "string") return pkgJson.version;
+    if (typeof pkgJson.version === "string") {
+      return pkgJson.version;
+    }
   } catch {
     // fall through
   }
   try {
     const result = await $`git -C ${repoPath} rev-parse --short HEAD`.quiet();
-    if (result.exitCode === 0) return result.stdout.toString().trim();
+    if (result.exitCode === 0) {
+      return result.stdout.toString().trim();
+    }
   } catch {
     // fall through
   }
   return "local";
 }
 
-export async function buildLocalArtifact(
+export async function* buildLocalArtifact(
   component: Component,
   repoPath: string,
   targetArch: "x64" | "arm64",
-): Promise<{ archivePath: string; version: string; sha256: string } | null> {
+): AsyncGenerator<StepEvent, { archivePath: string; version: string; sha256: string } | null> {
   if (!isBuildable(component)) {
-    fail("Local build", `${component} does not support local builds (only: ${BUILDABLE_COMPONENTS.join(", ")})`);
+    yield { type: "fail", label: "Local build", detail: `${component} does not support local builds (only: ${BUILDABLE_COMPONENTS.join(", ")})` };
     return null;
   }
 
   const absRepoPath = resolve(repoPath);
   if (!existsSync(absRepoPath)) {
-    fail("Local build", `Directory not found: ${absRepoPath}`);
+    yield { type: "fail", label: "Local build", detail: `Directory not found: ${absRepoPath}` };
     return null;
   }
 
   const pkgDir = join(absRepoPath, PACKAGE_DIRS[component]);
   if (!existsSync(pkgDir)) {
-    fail("Local build", `Package directory not found: ${pkgDir}`);
+    yield { type: "fail", label: "Local build", detail: `Package directory not found: ${pkgDir}` };
     return null;
   }
 
@@ -83,36 +81,36 @@ export async function buildLocalArtifact(
   const binName = binaryBaseName(component);
   const binPath = join(pkgDir, binName);
 
-  const spinner = p.spinner();
-  spinner.start(`Building ${component} for linux/${targetArch}...`);
+  yield { type: "spinner", id: "build", message: `Building ${component} for linux/${targetArch}...` };
 
   const result = await $`${cmd}`.cwd(pkgDir).nothrow().quiet();
   if (result.exitCode !== 0) {
-    spinner.stop("Build failed");
+    yield { type: "spinner", id: "build", message: "Build failed", done: true };
     const stderr = result.stderr.toString().trim();
-    if (stderr) fail("Build", stderr);
+    if (stderr) {
+      yield { type: "fail", label: "Build", detail: stderr };
+    }
     return null;
   }
 
   if (!existsSync(binPath)) {
-    spinner.stop("Build failed");
-    fail("Local build", `Expected binary not found after build: ${binPath}`);
+    yield { type: "spinner", id: "build", message: "Build failed", done: true };
+    yield { type: "fail", label: "Local build", detail: `Expected binary not found after build: ${binPath}` };
     return null;
   }
 
-  spinner.stop(`Built ${binName}`);
+  yield { type: "spinner", id: "build", message: `Built ${binName}`, done: true };
 
   const tmpArchive = join(tmpdir(), `xinity-local-${component}-${Date.now()}.tar.gz`);
-  const packageSpinner = p.spinner();
-  packageSpinner.start("Packaging...");
+  yield { type: "spinner", id: "package", message: "Packaging..." };
 
   const tarResult = await $`tar -czf ${tmpArchive} -C ${dirname(binPath)} ${basename(binPath)}`.nothrow().quiet();
   if (tarResult.exitCode !== 0) {
-    packageSpinner.stop("Packaging failed");
-    fail("Tar", tarResult.stderr.toString().trim());
+    yield { type: "spinner", id: "package", message: "Packaging failed", done: true };
+    yield { type: "fail", label: "Tar", detail: tarResult.stderr.toString().trim() };
     return null;
   }
-  packageSpinner.stop("Packaged");
+  yield { type: "spinner", id: "package", message: "Packaged", done: true };
 
   const hasher = new Bun.CryptoHasher("sha256");
   for await (const chunk of Bun.file(tmpArchive).stream()) {
@@ -123,6 +121,6 @@ export async function buildLocalArtifact(
   const version = await readVersion(absRepoPath);
   const versionString = `local-${version}`;
 
-  pass("Local build", `${component} ${versionString} (${targetArch})`);
+  yield { type: "pass", label: "Local build", detail: `${component} ${versionString} (${targetArch})` };
   return { archivePath: tmpArchive, version: versionString, sha256 };
 }

--- a/packages/xinity-cli/src/lib/manifest.ts
+++ b/packages/xinity-cli/src/lib/manifest.ts
@@ -20,6 +20,10 @@ export interface Manifest {
 
 const MANIFEST_PATH = "/opt/xinity/manifest.json";
 
+// One SSH read per run and host; writes invalidate so the next read
+// reflects disk again (a skipped elevated write must not go unnoticed).
+const manifestCache = new WeakMap<Host, Manifest>();
+
 async function readManifestContent(host: Host): Promise<string | null> {
   const direct = await host.readFile(MANIFEST_PATH);
   if (direct) return direct;
@@ -33,14 +37,20 @@ async function readManifestContent(host: Host): Promise<string | null> {
  * Returns an empty manifest if the file doesn't exist.
  */
 export async function readManifest(host: Host): Promise<Manifest> {
-  const empty: Manifest = { components: {} };
+  const cached = manifestCache.get(host);
+  if (cached) return structuredClone(cached);
+
+  let manifest: Manifest = { components: {} };
   const content = await readManifestContent(host);
-  if (!content) return empty;
-  try {
-    return JSON.parse(content) as Manifest;
-  } catch {
-    return empty;
+  if (content) {
+    try {
+      manifest = JSON.parse(content) as Manifest;
+    } catch {
+      // Unreadable manifest counts as empty, same as a missing file.
+    }
   }
+  manifestCache.set(host, manifest);
+  return structuredClone(manifest);
 }
 
 /** Get the installed version for a component, or null if not installed. */
@@ -50,6 +60,7 @@ export async function getInstalledVersion(component: string, host: Host): Promis
 
 /** Write the manifest to disk (requires elevation). */
 export async function writeManifest(manifest: Manifest, host: Host): Promise<void> {
+  manifestCache.delete(host);
   const json = JSON.stringify(manifest, null, 2);
   const cmd = `mkdir -p /opt/xinity && cat > ${MANIFEST_PATH} << 'MANIFEST_EOF'\n${json}\nMANIFEST_EOF\nchmod 644 ${MANIFEST_PATH}`;
   await host.withElevation(cmd, "Write install manifest");

--- a/packages/xinity-cli/src/lib/manifest.ts
+++ b/packages/xinity-cli/src/lib/manifest.ts
@@ -2,6 +2,7 @@
  * Version manifest tracking installed components at /opt/xinity/manifest.json.
  */
 import type { Host } from "./host.ts";
+import { heredoc } from "./service.ts";
 
 export interface ComponentEntry {
   version: string;
@@ -69,7 +70,7 @@ export async function getInstalledVersion(component: string, host: Host): Promis
 export async function writeManifest(manifest: Manifest, host: Host): Promise<boolean> {
   manifestCache.delete(host);
   const json = JSON.stringify(manifest, null, 2);
-  const cmd = `mkdir -p /opt/xinity && cat > ${MANIFEST_PATH} << 'MANIFEST_EOF'\n${json}\nMANIFEST_EOF\nchmod 644 ${MANIFEST_PATH}`;
+  const cmd = `mkdir -p /opt/xinity && cat > ${MANIFEST_PATH} ${heredoc("MANIFEST_EOF", json)}\nchmod 644 ${MANIFEST_PATH}`;
   const result = await host.withElevation(cmd, "Write install manifest");
   return result.success;
 }

--- a/packages/xinity-cli/src/lib/manifest.ts
+++ b/packages/xinity-cli/src/lib/manifest.ts
@@ -66,11 +66,12 @@ export async function getInstalledVersion(component: string, host: Host): Promis
 }
 
 /** Write the manifest to disk (requires elevation). */
-export async function writeManifest(manifest: Manifest, host: Host): Promise<void> {
+export async function writeManifest(manifest: Manifest, host: Host): Promise<boolean> {
   manifestCache.delete(host);
   const json = JSON.stringify(manifest, null, 2);
   const cmd = `mkdir -p /opt/xinity && cat > ${MANIFEST_PATH} << 'MANIFEST_EOF'\n${json}\nMANIFEST_EOF\nchmod 644 ${MANIFEST_PATH}`;
-  await host.withElevation(cmd, "Write install manifest");
+  const result = await host.withElevation(cmd, "Write install manifest");
+  return result.success;
 }
 
 /** Persist a non-secret DB hint (user@host:port/dbname) into the manifest. */

--- a/packages/xinity-cli/src/lib/manifest.ts
+++ b/packages/xinity-cli/src/lib/manifest.ts
@@ -1,7 +1,7 @@
 /**
  * Version manifest tracking installed components at /opt/xinity/manifest.json.
  */
-import { type Host, createLocalHost } from "./host.ts";
+import type { Host } from "./host.ts";
 
 export interface ComponentEntry {
   version: string;
@@ -20,12 +20,11 @@ export interface Manifest {
 
 const MANIFEST_PATH = "/opt/xinity/manifest.json";
 
-async function readManifestContent(h: Host): Promise<string | null> {
-  const direct = await h.readFile(MANIFEST_PATH);
+async function readManifestContent(host: Host): Promise<string | null> {
+  const direct = await host.readFile(MANIFEST_PATH);
   if (direct) return direct;
-  // The manifest may be root-owned from an older install; retry via elevation.
-  if (!(await h.fileExists(MANIFEST_PATH))) return null;
-  const elevated = await h.withElevation(`cat '${MANIFEST_PATH}'`, "Read install manifest");
+  if (!(await host.fileExists(MANIFEST_PATH))) return null;
+  const elevated = await host.withElevation(`cat '${MANIFEST_PATH}'`, "Read install manifest");
   return elevated.success ? elevated.output : null;
 }
 
@@ -33,9 +32,9 @@ async function readManifestContent(h: Host): Promise<string | null> {
  * Read the manifest from the given host.
  * Returns an empty manifest if the file doesn't exist.
  */
-export async function readManifest(host?: Host): Promise<Manifest> {
+export async function readManifest(host: Host): Promise<Manifest> {
   const empty: Manifest = { components: {} };
-  const content = await readManifestContent(host ?? createLocalHost());
+  const content = await readManifestContent(host);
   if (!content) return empty;
   try {
     return JSON.parse(content) as Manifest;
@@ -45,20 +44,19 @@ export async function readManifest(host?: Host): Promise<Manifest> {
 }
 
 /** Get the installed version for a component, or null if not installed. */
-export async function getInstalledVersion(component: string, host?: Host): Promise<string | null> {
+export async function getInstalledVersion(component: string, host: Host): Promise<string | null> {
   return (await readManifest(host)).components[component]?.version ?? null;
 }
 
 /** Write the manifest to disk (requires elevation). */
-export async function writeManifest(manifest: Manifest, host?: Host): Promise<void> {
-  const h = host ?? createLocalHost();
+export async function writeManifest(manifest: Manifest, host: Host): Promise<void> {
   const json = JSON.stringify(manifest, null, 2);
   const cmd = `mkdir -p /opt/xinity && cat > ${MANIFEST_PATH} << 'MANIFEST_EOF'\n${json}\nMANIFEST_EOF\nchmod 644 ${MANIFEST_PATH}`;
-  await h.withElevation(cmd, "Write install manifest");
+  await host.withElevation(cmd, "Write install manifest");
 }
 
 /** Persist a non-secret DB hint (user@host:port/dbname) into the manifest. */
-export async function saveDbHint(hint: string, host?: Host): Promise<void> {
+export async function saveDbHint(hint: string, host: Host): Promise<void> {
   const manifest = await readManifest(host);
   manifest.db = { hint };
   await writeManifest(manifest, host);
@@ -68,7 +66,7 @@ export async function saveDbHint(hint: string, host?: Host): Promise<void> {
 export async function updateManifestEntry(
   component: string,
   entry: ComponentEntry,
-  host?: Host,
+  host: Host,
 ): Promise<void> {
   const manifest = await readManifest(host);
   manifest.components[component] = entry;

--- a/packages/xinity-cli/src/lib/manifest.ts
+++ b/packages/xinity-cli/src/lib/manifest.ts
@@ -12,10 +12,17 @@ export interface ComponentEntry {
   binaryChecksum?: string;
 }
 
+export interface StackMembership {
+  name: string;
+  fleet?: string;
+}
+
 export interface Manifest {
   components: Partial<Record<string, ComponentEntry>>;
   /** Non-secret metadata about the configured DB connection. */
   db?: { hint: string };
+  /** Which stack (and fleet) manages this machine; maintained by `stack up`. */
+  stack?: StackMembership;
 }
 
 const MANIFEST_PATH = "/opt/xinity/manifest.json";
@@ -70,6 +77,19 @@ export async function writeManifest(manifest: Manifest, host: Host): Promise<voi
 export async function saveDbHint(hint: string, host: Host): Promise<void> {
   const manifest = await readManifest(host);
   manifest.db = { hint };
+  await writeManifest(manifest, host);
+}
+
+/** Record (or clear, with null) which stack and fleet own this host. No-op when already current. */
+export async function saveStackMembership(membership: StackMembership | null, host: Host): Promise<void> {
+  const manifest = await readManifest(host);
+  if (membership === null) {
+    if (!manifest.stack) return;
+    delete manifest.stack;
+  } else {
+    if (manifest.stack?.name === membership.name && manifest.stack?.fleet === membership.fleet) return;
+    manifest.stack = membership;
+  }
   await writeManifest(manifest, host);
 }
 

--- a/packages/xinity-cli/src/lib/migrator.ts
+++ b/packages/xinity-cli/src/lib/migrator.ts
@@ -272,6 +272,11 @@ export async function runMigrations(opts: {
 
   // 4. Apply migrations (tunnels through SSH when targeting a remote host)
   const tunnel = await opts.host.openTunnel(connectionUrl);
+  if (!tunnel.ok) {
+    fail("Tunnel", tunnel.error);
+    errors.push(tunnel.error);
+    return { success: false, errors };
+  }
 
   spinner.start("Applying migrations…");
   let connection: postgres.Sql | undefined;

--- a/packages/xinity-cli/src/lib/migrator.ts
+++ b/packages/xinity-cli/src/lib/migrator.ts
@@ -1,9 +1,10 @@
 /**
- * Database migration runner for `xinity up db`.
+ * Database migration runner.
  *
- * Downloads the migration tarball from a GitHub release, extracts it,
- * discovers or prompts for DB_CONNECTION_URL, then applies pending
- * migrations using drizzle-orm's programmatic migrator.
+ * `discoverConnectionUrl` is the planning-phase half: find or ask for the
+ * DB_CONNECTION_URL without changing anything. `runMigrations` is the apply
+ * half: download the migration tarball from a GitHub release, extract it,
+ * and apply pending migrations via drizzle-orm's programmatic migrator.
  */
 import { tmpdir } from "os";
 import { join } from "path";
@@ -19,7 +20,7 @@ import { downloadAndVerify } from "./install-download.ts";
 import { runSteps } from "./step-runner.ts";
 import { parseEnvString } from "./env-file.ts";
 import { fail, pass, info, warn } from "./output.ts";
-import { postgresSetup } from "./postgres-setup.ts";
+import { planPostgresProvision, type PostgresProvision } from "./postgres-setup.ts";
 import { type Host, localRun } from "./host.ts";
 import { readManifest, saveDbHint, updateManifestEntry } from "./manifest.ts";
 import { ENV_DIR, SECRETS_DIR } from "./component-meta.ts";
@@ -30,7 +31,7 @@ const DB_SECRET_PATH = `${SECRETS_DIR}/DB_CONNECTION_URL`;
  * Return a safe display string for a postgres URL: user@host:port/dbname.
  * Never includes the password.
  */
-function dbHint(url: string): string {
+export function dbHint(url: string): string {
   try {
     const u = new URL(url);
     const host = u.port ? `${u.hostname}:${u.port}` : u.hostname;
@@ -57,15 +58,20 @@ async function confirmCandidate(
   return use ? url : null;
 }
 
+/** The database half of a plan: the URL to use, plus provisioning when the user chose setup. */
+export interface DbPlan {
+  connectionUrl: string;
+  provision?: PostgresProvision;
+}
+
 /**
- * Discover DB_CONNECTION_URL from environment, stored secret, or installed
- * component configs. Confirms each candidate before returning it. If nothing
- * usable is found, guides the user through interactive setup.
+ * Planning-phase discovery of DB_CONNECTION_URL from environment, stored
+ * secret, or installed component configs. Confirms each candidate before
+ * returning it. If nothing usable is found, either takes a URL from the user
+ * or plans a new PostgreSQL stack. Reads and prompts only; provisioning and
+ * migrations are separate apply steps.
  */
-async function discoverConnectionUrl(
-  host: Host,
-  dryRun: boolean,
-): Promise<string | undefined> {
+export async function discoverConnectionUrl(host: Host): Promise<DbPlan | undefined> {
   let foundCandidate = false;
 
   // 1. Previously stored secret on the target host (written by a prior migration run).
@@ -85,9 +91,10 @@ async function discoverConnectionUrl(
       const readResult = await host.withElevation(
         `cat '${DB_SECRET_PATH}'; echo`,
         "Read stored DB connection URL",
-        { sensitive: true },
       );
-      if (readResult.success && readResult.output.trim()) return readResult.output.trim();
+      if (readResult.success && readResult.output.trim()) {
+        return { connectionUrl: readResult.output.trim() };
+      }
       warn("DB secret", "Could not read stored secret - please provide the URL manually");
       // Fall through to manual entry
     }
@@ -98,7 +105,7 @@ async function discoverConnectionUrl(
     foundCandidate = true;
     const result = await confirmCandidate("in environment", process.env.DB_CONNECTION_URL);
     if (result === undefined) return undefined;
-    if (result) return result;
+    if (result) return { connectionUrl: result };
   }
 
   // 3. Component env files on the target host.
@@ -112,7 +119,7 @@ async function discoverConnectionUrl(
           foundCandidate = true;
           const result = await confirmCandidate(`in ${component}.env`, env.DB_CONNECTION_URL);
           if (result === undefined) return undefined;
-          if (result) return result;
+          if (result) return { connectionUrl: result };
         }
       }
     }
@@ -134,21 +141,13 @@ async function discoverConnectionUrl(
   if (p.isCancel(choice)) { p.cancel("Cancelled."); return undefined; }
 
   if (choice === "setup") {
-    const url = await postgresSetup(host, dryRun);
-    if (url) {
-      const { testPostgresConnection } = await import("./connectivity.ts");
-      const spinner = p.spinner();
-      spinner.start("Testing database connection…");
-      const result = await testPostgresConnection(url, host);
-      spinner.stop(result.success ? "Database connection successful" : "Database connection failed");
-      if (!result.success && result.error) {
-        p.log.error(pc.dim(result.error));
-      }
-    }
-    return url;
+    p.log.step(pc.bold("PostgreSQL setup"));
+    const provision = await planPostgresProvision(host);
+    return provision ? { connectionUrl: provision.url, provision } : undefined;
   }
 
-  return promptAndValidateDbUrl(host);
+  const url = await promptAndValidateDbUrl(host);
+  return url ? { connectionUrl: url } : undefined;
 }
 
 /**
@@ -202,30 +201,21 @@ async function promptAndValidateDbUrl(host: Host): Promise<string | undefined> {
 export interface MigrateResult {
   success: boolean;
   errors: string[];
-  /** The DB connection URL that was used (or discovered), if any. */
-  connectionUrl?: string;
 }
 
 /**
  * Download migrations from a release, extract, and apply to the database.
  */
 export async function runMigrations(opts: {
+  connectionUrl: string;
   targetVersion: string;
   dryRun: boolean;
   host: Host;
 }): Promise<MigrateResult> {
   const errors: string[] = [];
+  const { connectionUrl } = opts;
 
-  // 1. Discover DB connection URL first, before any spinners run.
-  //    This keeps the interactive select prompt clean (spinners can
-  //    interfere with terminal raw-mode), and avoids downloading
-  //    migrations if the user cancels or needs to install Postgres first.
-  const connectionUrl = await discoverConnectionUrl(opts.host, opts.dryRun);
-  if (!connectionUrl) {
-    return { success: false, errors: ["No DB connection URL provided"] };
-  }
-
-  // 2. Fetch release
+  // 1. Fetch release
   const spinner = p.spinner();
   spinner.start("Fetching release info…");
   let release: Release;
@@ -236,35 +226,35 @@ export async function runMigrations(opts: {
     spinner.stop("Failed");
     const msg = e instanceof Error ? e.message : String(e);
     fail("Release", msg);
-    return { success: false, errors: [msg], connectionUrl };
+    return { success: false, errors: [msg] };
   }
 
-  // 3. Download & verify
+  // 2. Download & verify
   const assetName = pickReleaseAsset(release, "db");
   const tmpDir = join(tmpdir(), `xinity-db-migrate-${Date.now()}`);
   mkdirSync(tmpDir, { recursive: true });
 
   const archivePath = await runSteps(downloadAndVerify(release, assetName, tmpDir));
   if (!archivePath) {
-    return { success: false, errors: [], connectionUrl };
+    return { success: false, errors: ["Download failed"] };
   }
 
-  // 4. Extract
+  // 3. Extract
   const extractDir = join(tmpDir, "db-migration");
   mkdirSync(extractDir, { recursive: true });
   const extract = await localRun(["tar", "xzf", archivePath, "-C", extractDir]);
   if (!extract.ok) {
     fail("Extract", "Failed to extract migration archive");
-    return { success: false, errors: ["Extraction failed"], connectionUrl };
+    return { success: false, errors: ["Extraction failed"] };
   }
   pass("Extract", "Migrations extracted");
 
   if (opts.dryRun) {
     info("Dry run", "Would apply migrations, skipping actual execution");
-    return { success: true, errors: [], connectionUrl };
+    return { success: true, errors: [] };
   }
 
-  // 5. Apply migrations (tunnels through SSH when targeting a remote host)
+  // 4. Apply migrations (tunnels through SSH when targeting a remote host)
   const tunnel = await opts.host.openTunnel(connectionUrl);
 
   spinner.start("Applying migrations…");
@@ -280,7 +270,7 @@ export async function runMigrations(opts: {
     const msg = e instanceof Error ? e.message : String(e);
     fail("Migrate", msg);
     errors.push(msg);
-    return { success: false, errors, connectionUrl };
+    return { success: false, errors };
   } finally {
     if (connection) {
       await connection.end();
@@ -311,16 +301,5 @@ export async function runMigrations(opts: {
     }, opts.host);
   }
 
-  // 6. Redis discovery (shared infrastructure dependency).
-  //    Non-fatal: warn but don't fail the db command if Redis is skipped.
-  p.log.step(pc.bold("\nRedis"));
-  const { discoverRedisUrl } = await import("./redis-setup.ts");
-  const redisUrl = await discoverRedisUrl(opts.host, opts.dryRun);
-  if (redisUrl) {
-    pass("Redis", "Connection configured");
-  } else {
-    warn("Redis", "No Redis URL configured (can be set up later with xinity up infra-redis)");
-  }
-
-  return { success: true, errors, connectionUrl };
+  return { success: true, errors };
 }

--- a/packages/xinity-cli/src/lib/migrator.ts
+++ b/packages/xinity-cli/src/lib/migrator.ts
@@ -16,6 +16,7 @@ import pc from "picocolors";
 
 import { fetchRelease, pickReleaseAsset, type Release } from "./github.ts";
 import { downloadAndVerify } from "./install-download.ts";
+import { runSteps } from "./step-runner.ts";
 import { parseEnvString } from "./env-file.ts";
 import { fail, pass, info, warn } from "./output.ts";
 import { postgresSetup } from "./postgres-setup.ts";
@@ -136,7 +137,13 @@ async function discoverConnectionUrl(
     const url = await postgresSetup(host, dryRun);
     if (url) {
       const { testPostgresConnection } = await import("./connectivity.ts");
-      await testPostgresConnection(url, host);
+      const spinner = p.spinner();
+      spinner.start("Testing database connection…");
+      const result = await testPostgresConnection(url, host);
+      spinner.stop(result.success ? "Database connection successful" : "Database connection failed");
+      if (!result.success && result.error) {
+        p.log.error(pc.dim(result.error));
+      }
     }
     return url;
   }
@@ -166,8 +173,16 @@ async function promptAndValidateDbUrl(host: Host): Promise<string | undefined> {
       return undefined;
     }
 
-    const ok = await testPostgresConnection(value, host);
-    if (ok) return value;
+    const spinner = p.spinner();
+    spinner.start("Testing database connection…");
+    const connResult = await testPostgresConnection(value, host);
+    spinner.stop(connResult.success ? "Database connection successful" : "Database connection failed");
+    if (!connResult.success && connResult.error) {
+      p.log.error(pc.dim(connResult.error));
+    }
+    if (connResult.success) {
+      return value;
+    }
 
     const action = await p.select({
       message: "Could not connect to the database.",
@@ -229,7 +244,7 @@ export async function runMigrations(opts: {
   const tmpDir = join(tmpdir(), `xinity-db-migrate-${Date.now()}`);
   mkdirSync(tmpDir, { recursive: true });
 
-  const archivePath = await downloadAndVerify(release, assetName, tmpDir);
+  const archivePath = await runSteps(downloadAndVerify(release, assetName, tmpDir));
   if (!archivePath) {
     return { success: false, errors: [], connectionUrl };
   }

--- a/packages/xinity-cli/src/lib/migrator.ts
+++ b/packages/xinity-cli/src/lib/migrator.ts
@@ -42,6 +42,20 @@ export function dbHint(url: string): string {
   }
 }
 
+/** The one wording every plan review uses for the migration step. */
+export function describeMigrationStep(targetVersion: string, connectionUrl: string): string {
+  return `Apply database migrations from release ${targetVersion} to ${dbHint(connectionUrl)}`;
+}
+
+/** Script-dump stand-in for migrations, which run through drizzle and have no bash equivalent. */
+export function migrationScriptComment(cliCommand: string): string[] {
+  return [
+    "# Database migrations run inside the CLI (drizzle migrator, no bash equivalent):",
+    `#   ${cliCommand}`,
+    "",
+  ];
+}
+
 /**
  * Offer a discovered candidate URL to the user, showing only the safe hint.
  * Returns the full URL if accepted, null if declined, undefined if cancelled.

--- a/packages/xinity-cli/src/lib/migrator.ts
+++ b/packages/xinity-cli/src/lib/migrator.ts
@@ -12,8 +12,8 @@ import { mkdirSync } from "fs";
 import postgres from "postgres";
 import { drizzle } from "drizzle-orm/postgres-js";
 import { migrate } from "drizzle-orm/postgres-js/migrator";
-import * as p from "./clack.ts";
-import pc from "picocolors";
+import { cancel, confirm, isCancel, log, select, spinner as clackSpinner, text } from "./clack.ts";
+import { bold, cyan, dim } from "picocolors";
 
 import { fetchRelease, pickReleaseAsset, type Release } from "./github.ts";
 import { downloadAndVerify } from "./install-download.ts";
@@ -50,11 +50,11 @@ async function confirmCandidate(
   label: string,
   url: string,
 ): Promise<string | null | undefined> {
-  const use = await p.confirm({
+  const use = await confirm({
     message: `DB connection found ${label} (${dbHint(url)}). Use this?`,
     initialValue: true,
   });
-  if (p.isCancel(use)) { p.cancel("Cancelled."); return undefined; }
+  if (isCancel(use)) { cancel("Cancelled."); return undefined; }
   return use ? url : null;
 }
 
@@ -80,11 +80,11 @@ export async function discoverConnectionUrl(host: Host): Promise<DbPlan | undefi
   const manifest = await readManifest(host);
   if (manifest.db?.hint) {
     foundCandidate = true;
-    const use = await p.confirm({
+    const use = await confirm({
       message: `DB connection found in stored secret (${manifest.db.hint}). Use this?`,
       initialValue: true,
     });
-    if (p.isCancel(use)) { p.cancel("Cancelled."); return undefined; }
+    if (isCancel(use)) { cancel("Cancelled."); return undefined; }
     if (use) {
       // Append `; echo` so the output ends with a newline, keeping the ::exit:: marker
       // on its own line regardless of whether the secret file has a trailing newline.
@@ -130,7 +130,7 @@ export async function discoverConnectionUrl(host: Host): Promise<DbPlan | undefi
     ? "None of the found connections were used. How would you like to connect?"
     : "No database connection found. Do you already have a PostgreSQL database?";
 
-  const choice = await p.select({
+  const choice = await select({
     message,
     options: [
       { value: "existing", label: "Yes, I have a connection URL", hint: "enter your PostgreSQL connection string" },
@@ -138,10 +138,10 @@ export async function discoverConnectionUrl(host: Host): Promise<DbPlan | undefi
     ],
   });
 
-  if (p.isCancel(choice)) { p.cancel("Cancelled."); return undefined; }
+  if (isCancel(choice)) { cancel("Cancelled."); return undefined; }
 
   if (choice === "setup") {
-    p.log.step(pc.bold("PostgreSQL setup"));
+    log.step(bold("PostgreSQL setup"));
     const provision = await planPostgresProvision(host);
     return provision ? { connectionUrl: provision.url, provision } : undefined;
   }
@@ -158,7 +158,7 @@ async function promptAndValidateDbUrl(host: Host): Promise<string | undefined> {
 
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const value = await p.text({
+    const value = await text({
       message: "DB_CONNECTION_URL",
       placeholder: "postgresql://user:pass@host:5432/dbname",
       validate: (val) => {
@@ -167,31 +167,31 @@ async function promptAndValidateDbUrl(host: Host): Promise<string | undefined> {
         return undefined;
       },
     });
-    if (p.isCancel(value)) {
-      p.cancel("Cancelled.");
+    if (isCancel(value)) {
+      cancel("Cancelled.");
       return undefined;
     }
 
-    const spinner = p.spinner();
+    const spinner = clackSpinner();
     spinner.start("Testing database connection…");
     const connResult = await testPostgresConnection(value, host);
     spinner.stop(connResult.success ? "Database connection successful" : "Database connection failed");
     if (!connResult.success && connResult.error) {
-      p.log.error(pc.dim(connResult.error));
+      log.error(dim(connResult.error));
     }
     if (connResult.success) {
       return value;
     }
 
-    const action = await p.select({
+    const action = await select({
       message: "Could not connect to the database.",
       options: [
         { value: "retry", label: "Enter a different URL" },
         { value: "proceed", label: "Use this URL anyway" },
       ],
     });
-    if (p.isCancel(action)) {
-      p.cancel("Cancelled.");
+    if (isCancel(action)) {
+      cancel("Cancelled.");
       return undefined;
     }
     if (action === "proceed") return value;
@@ -211,17 +211,19 @@ export async function runMigrations(opts: {
   targetVersion: string;
   dryRun: boolean;
   host: Host;
+  /** Store the URL/hint in the host's secrets dir and manifest (default). Stacks carry the URL themselves. */
+  persist?: boolean;
 }): Promise<MigrateResult> {
   const errors: string[] = [];
   const { connectionUrl } = opts;
 
   // 1. Fetch release
-  const spinner = p.spinner();
+  const spinner = clackSpinner();
   spinner.start("Fetching release info…");
   let release: Release;
   try {
     release = await fetchRelease(opts.targetVersion);
-    spinner.stop(`Release ${pc.cyan(release.tagName)}`);
+    spinner.stop(`Release ${cyan(release.tagName)}`);
   } catch (e) {
     spinner.stop("Failed");
     const msg = e instanceof Error ? e.message : String(e);
@@ -276,6 +278,10 @@ export async function runMigrations(opts: {
       await connection.end();
     }
     await tunnel.close();
+  }
+
+  if (opts.persist === false) {
+    return { success: true, errors };
   }
 
   // Persist secret and manifest only if something actually changed.

--- a/packages/xinity-cli/src/lib/migrator.ts
+++ b/packages/xinity-cli/src/lib/migrator.ts
@@ -20,7 +20,7 @@ import { runSteps } from "./step-runner.ts";
 import { parseEnvString } from "./env-file.ts";
 import { fail, pass, info, warn } from "./output.ts";
 import { postgresSetup } from "./postgres-setup.ts";
-import { type Host, createLocalHost } from "./host.ts";
+import { type Host, localRun } from "./host.ts";
 import { readManifest, saveDbHint, updateManifestEntry } from "./manifest.ts";
 import { ENV_DIR, SECRETS_DIR } from "./component-meta.ts";
 
@@ -252,8 +252,7 @@ export async function runMigrations(opts: {
   // 4. Extract
   const extractDir = join(tmpDir, "db-migration");
   mkdirSync(extractDir, { recursive: true });
-  const local = createLocalHost();
-  const extract = await local.run(["tar", "xzf", archivePath, "-C", extractDir]);
+  const extract = await localRun(["tar", "xzf", archivePath, "-C", extractDir]);
   if (!extract.ok) {
     fail("Extract", "Failed to extract migration archive");
     return { success: false, errors: ["Extraction failed"], connectionUrl };

--- a/packages/xinity-cli/src/lib/multi-host.ts
+++ b/packages/xinity-cli/src/lib/multi-host.ts
@@ -39,3 +39,20 @@ export async function connectHosts(addresses: string[]): Promise<Map<string, Hos
 export async function disposeAll(hosts: Map<string, Host>): Promise<void> {
   await Promise.allSettled([...hosts.values()].map((host) => host.dispose()));
 }
+
+/** How many hosts are worked on at once wherever host operations run in parallel. */
+export const HOST_CONCURRENCY = 8;
+
+/** Map over items with at most `limit` calls in flight; results keep item order. */
+export async function mapBounded<T, R>(items: T[], limit: number, fn: (item: T) => Promise<R>): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  const worker = async () => {
+    while (next < items.length) {
+      const i = next++;
+      results[i] = await fn(items[i]!);
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+  return results;
+}

--- a/packages/xinity-cli/src/lib/multi-host.ts
+++ b/packages/xinity-cli/src/lib/multi-host.ts
@@ -1,7 +1,21 @@
 import { log } from "./clack.ts";
 import { type Host } from "./host.ts";
 import { connectHost } from "./remote-host.ts";
-import { heading } from "./output.ts";
+
+export async function connectElevated(
+  address: string,
+): Promise<{ host: Host } | { failed: "unreachable" | "declined"; message: string }> {
+  try {
+    const host = await connectHost(address === "local" ? undefined : address);
+    if (await host.prepareElevation()) {
+      return { host };
+    }
+    await host.dispose();
+    return { failed: "declined", message: `Root privileges on ${address} were declined` };
+  } catch (err) {
+    return { failed: "unreachable", message: `Could not connect to ${address}: ${(err as Error).message}` };
+  }
+}
 
 /**
  * Connect and establish root privileges on every address up front, so the
@@ -11,36 +25,15 @@ import { heading } from "./output.ts";
 export async function connectHosts(addresses: string[]): Promise<Map<string, Host> | null> {
   const hosts = new Map<string, Host>();
   for (const addr of addresses) {
-    try {
-      const host = await connectHost(addr === "local" ? undefined : addr);
-      hosts.set(addr, host);
-      if (!(await host.prepareElevation())) {
-        log.error(`Root privileges on ${addr} were declined`);
-        await disposeAll(hosts);
-        return null;
-      }
-    } catch (err) {
-      log.error(`Could not connect to ${addr}: ${(err as Error).message}`);
+    const connection = await connectElevated(addr);
+    if ("failed" in connection) {
+      log.error(connection.message);
       await disposeAll(hosts);
       return null;
     }
+    hosts.set(addr, connection.host);
   }
   return hosts;
-}
-
-/** Run an action per host under its own heading; an error is reported and the loop continues. */
-export async function forEachHost(
-  hosts: Map<string, Host>,
-  action: (host: Host, address: string) => Promise<void>,
-): Promise<void> {
-  for (const [address, host] of hosts) {
-    heading(address);
-    try {
-      await action(host, address);
-    } catch (err) {
-      log.error(`${address}: ${err instanceof Error ? err.message : String(err)}`);
-    }
-  }
 }
 
 export async function disposeAll(hosts: Map<string, Host>): Promise<void> {

--- a/packages/xinity-cli/src/lib/multi-host.ts
+++ b/packages/xinity-cli/src/lib/multi-host.ts
@@ -1,0 +1,48 @@
+import { log } from "./clack.ts";
+import { type Host } from "./host.ts";
+import { connectHost } from "./remote-host.ts";
+import { heading } from "./output.ts";
+
+/**
+ * Connect and establish root privileges on every address up front, so the
+ * flows that follow never stop for authentication. Returns null (after
+ * cleanup) when a connection fails or elevation is declined.
+ */
+export async function connectHosts(addresses: string[]): Promise<Map<string, Host> | null> {
+  const hosts = new Map<string, Host>();
+  for (const addr of addresses) {
+    try {
+      const host = await connectHost(addr === "local" ? undefined : addr);
+      hosts.set(addr, host);
+      if (!(await host.prepareElevation())) {
+        log.error(`Root privileges on ${addr} were declined`);
+        await disposeAll(hosts);
+        return null;
+      }
+    } catch (err) {
+      log.error(`Could not connect to ${addr}: ${(err as Error).message}`);
+      await disposeAll(hosts);
+      return null;
+    }
+  }
+  return hosts;
+}
+
+/** Run an action per host under its own heading; an error is reported and the loop continues. */
+export async function forEachHost(
+  hosts: Map<string, Host>,
+  action: (host: Host, address: string) => Promise<void>,
+): Promise<void> {
+  for (const [address, host] of hosts) {
+    heading(address);
+    try {
+      await action(host, address);
+    } catch (err) {
+      log.error(`${address}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+}
+
+export async function disposeAll(hosts: Map<string, Host>): Promise<void> {
+  await Promise.allSettled([...hosts.values()].map((host) => host.dispose()));
+}

--- a/packages/xinity-cli/src/lib/multi-host.ts
+++ b/packages/xinity-cli/src/lib/multi-host.ts
@@ -5,14 +5,16 @@ import { connectHost } from "./remote-host.ts";
 export async function connectElevated(
   address: string,
 ): Promise<{ host: Host } | { failed: "unreachable" | "declined"; message: string }> {
+  let host: Host | undefined;
   try {
-    const host = await connectHost(address === "local" ? undefined : address);
+    host = await connectHost(address === "local" ? undefined : address);
     if (await host.prepareElevation()) {
       return { host };
     }
     await host.dispose();
     return { failed: "declined", message: `Root privileges on ${address} were declined` };
   } catch (err) {
+    await host?.dispose();
     return { failed: "unreachable", message: `Could not connect to ${address}: ${(err as Error).message}` };
   }
 }

--- a/packages/xinity-cli/src/lib/multi-progress.ts
+++ b/packages/xinity-cli/src/lib/multi-progress.ts
@@ -1,0 +1,272 @@
+/**
+ * Multi-line progress tree for concurrent tasks.
+ *
+ * Renders a parent spinner with indented child rows, one per task.
+ * Each row animates independently and settles (success/failure) as its
+ * task completes. The parent spinner keeps animating until every child
+ * has settled, then the whole tree freezes in place as static output.
+ *
+ * On a TTY the tree redraws in place using ANSI cursor movement.
+ * In CI or piped output, each slot emits a single line when it settles.
+ *
+ * Usage:
+ *
+ *   const multi = createMultiProgress({
+ *     message: "Deploying to 3 hosts",
+ *     slots: ["10.0.0.1", "10.0.0.2", "10.0.0.3"],
+ *   });
+ *
+ *   await mapBounded(hosts, 8, async (host) => {
+ *     const slot = multi.slot(host.address);
+ *     slot.update("installing daemon");
+ *     // ... work ...
+ *     slot.done("applied");
+ *   });
+ *
+ *   multi.done();
+ *
+ * Each slot conforms to the Progress interface from step-runner.ts,
+ * so it can be passed to any function that accepts a Progress handle.
+ * Use createDoneGuard(slot) when passing to functions that call
+ * progress.done() internally (like applyComponentAction), so the
+ * per-component done() does not prematurely settle the host slot.
+ */
+
+import { dim, green, red, magenta } from "picocolors";
+import { createSilentProgress, type Progress } from "./step-runner.ts";
+
+const SPINNER_FRAMES = ["◒", "◐", "◓", "◑"];
+const S_SUCCESS = "◆";
+const S_ERROR = "■";
+const S_BAR = "├";
+const S_BAR_END = "└";
+
+interface SlotState {
+  label: string;
+  message: string;
+  settled: boolean;
+  failed: boolean;
+}
+
+export interface MultiProgressResult {
+  slot(label: string): Progress;
+  done(): void;
+}
+
+export function createDoneGuard(target: Progress): Progress {
+  return {
+    update: (msg) => target.update(msg),
+    warn: (label, detail, hint) => target.warn(label, detail, hint),
+    fail: (label, detail) => target.fail(label, detail),
+    hasFailed: () => target.hasFailed(),
+    done() {},
+    ensureSettled() {},
+  };
+}
+
+export function createMultiProgress(opts: {
+  message: string;
+  slots: string[];
+}): MultiProgressResult {
+  const out = process.stderr;
+  const isTTY = out.isTTY === true;
+
+  const states: SlotState[] = opts.slots.map((label) => ({
+    label,
+    message: label,
+    settled: false,
+    failed: false,
+  }));
+  const labelIndex = new Map(opts.slots.map((label, i) => [label, i]));
+
+  let frameIdx = 0;
+  let lastLineCount = 0;
+  let finished = false;
+
+  function buildFrame(): string {
+    const frame = SPINNER_FRAMES[frameIdx % SPINNER_FRAMES.length]!;
+    const allSettled = states.every((s) => s.settled);
+    const anyFailed = states.some((s) => s.failed);
+
+    const lines: string[] = [];
+
+    if (allSettled) {
+      const icon = anyFailed ? red(S_ERROR) : green(S_SUCCESS);
+      lines.push(`${icon}  ${opts.message}`);
+    } else {
+      lines.push(`${magenta(frame)}  ${opts.message}`);
+    }
+
+    for (let i = 0; i < states.length; i++) {
+      const s = states[i]!;
+      const isLast = i === states.length - 1;
+      const connector = dim(isLast ? S_BAR_END : S_BAR);
+
+      let icon: string;
+      if (s.settled) {
+        icon = s.failed ? red(S_ERROR) : green(S_SUCCESS);
+      } else {
+        icon = magenta(frame);
+      }
+
+      lines.push(`${connector}  ${icon} ${s.label}  ${dim(s.message)}`);
+    }
+
+    return lines.join("\n") + "\n";
+  }
+
+  function clear() {
+    if (lastLineCount > 0) {
+      out.write(`\x1B[${lastLineCount}A\x1B[1G\x1B[J`);
+    }
+    lastLineCount = 0;
+  }
+
+  function render() {
+    if (!isTTY || finished) {
+      return;
+    }
+    if (lastLineCount > 0) {
+      clear();
+    }
+    const frame = buildFrame();
+    out.write(frame);
+    lastLineCount = states.length + 1;
+  }
+
+  function showCursor() {
+    if (isTTY) {
+      out.write("\x1B[?25h");
+    }
+  }
+
+  function cleanup() {
+    if (finished) {
+      return;
+    }
+    finished = true;
+    clearInterval(interval);
+    if (isTTY && lastLineCount > 0) {
+      clear();
+    }
+    showCursor();
+    removeHandlers();
+  }
+
+  const onExit = () => cleanup();
+  const onSignal = () => {
+    cleanup();
+    process.exit(128);
+  };
+
+  function installHandlers() {
+    process.on("exit", onExit);
+    process.on("SIGINT", onSignal);
+    process.on("SIGTERM", onSignal);
+  }
+
+  function removeHandlers() {
+    process.removeListener("exit", onExit);
+    process.removeListener("SIGINT", onSignal);
+    process.removeListener("SIGTERM", onSignal);
+  }
+
+  if (isTTY) {
+    out.write("\x1B[?25l");
+  }
+  installHandlers();
+  render();
+  const interval = setInterval(() => {
+    frameIdx++;
+    render();
+  }, 80);
+  if (typeof interval === "object" && "unref" in interval) {
+    (interval as NodeJS.Timeout).unref();
+  }
+
+  function emitNonTTY(label: string, message: string, failed: boolean) {
+    if (isTTY) {
+      return;
+    }
+    const icon = failed ? S_ERROR : S_SUCCESS;
+    out.write(`${icon} ${label}  ${message}\n`);
+  }
+
+  return {
+    slot(label: string): Progress {
+      const idx = labelIndex.get(label);
+      if (idx === undefined) {
+        return createSilentProgress();
+      }
+      const state = states[idx]!;
+
+      return {
+        update(message: string) {
+          if (state.settled) {
+            return;
+          }
+          state.message = message;
+        },
+        warn(warnLabel: string, detail?: string) {
+          if (state.settled) {
+            return;
+          }
+          state.message = detail ? `${warnLabel}: ${detail}` : warnLabel;
+        },
+        fail(failLabel: string, detail?: string) {
+          if (state.settled) {
+            return;
+          }
+          state.message = detail ? `${failLabel}: ${detail}` : failLabel;
+          state.failed = true;
+          state.settled = true;
+          emitNonTTY(state.label, state.message, true);
+        },
+        hasFailed: () => state.failed,
+        done(summary: string) {
+          if (state.settled) {
+            return;
+          }
+          state.message = summary;
+          state.settled = true;
+          emitNonTTY(state.label, state.message, false);
+        },
+        ensureSettled() {
+          if (state.settled) {
+            return;
+          }
+          state.settled = true;
+          emitNonTTY(state.label, state.message, state.failed);
+        },
+      };
+    },
+
+    done() {
+      if (finished) {
+        return;
+      }
+      for (const s of states) {
+        if (!s.settled) {
+          s.settled = true;
+        }
+      }
+      finished = true;
+      clearInterval(interval);
+      removeHandlers();
+
+      if (isTTY) {
+        if (lastLineCount > 0) {
+          clear();
+        }
+        frameIdx = 0;
+        const frame = buildFrame();
+        out.write(frame);
+        showCursor();
+      } else {
+        const anyFailed = states.some((s) => s.failed);
+        const icon = anyFailed ? S_ERROR : S_SUCCESS;
+        out.write(`${icon}  ${opts.message}\n`);
+      }
+    },
+  };
+}

--- a/packages/xinity-cli/src/lib/ollama-setup.ts
+++ b/packages/xinity-cli/src/lib/ollama-setup.ts
@@ -3,8 +3,8 @@
  * `xinity up all`. Ollama runs alongside the daemon on the same host, so it is
  * left on its default localhost binding.
  */
-import * as p from "./clack.ts";
-import pc from "picocolors";
+import { confirm, isCancel, log, select, spinner as clackSpinner } from "./clack.ts";
+import { bold, dim } from "picocolors";
 import { type Host, commandExistsOn, isUnitActiveOn } from "./host.ts";
 import { pass, fail, info, warn } from "./output.ts";
 import { parseEnvString, serializeEnvFile } from "./env-file.ts";
@@ -64,14 +64,14 @@ async function installOrUpdateOllama(host: Host): Promise<boolean> {
   const result = await host.withElevation(INSTALL_COMMAND, "Install/update ollama");
   if (!result.success) {
     fail("Ollama", result.output || "Installation failed");
-    p.log.info(pc.dim(`  Install manually: ${INSTALL_COMMAND}`));
+    log.info(dim(`  Install manually: ${INSTALL_COMMAND}`));
     return false;
   }
 
   pass("Ollama", "Installed successfully");
 
   // The install script usually starts the service, but not always; wait, then start it ourselves.
-  const spinner = p.spinner();
+  const spinner = clackSpinner();
   spinner.start("Waiting for ollama service…");
   const running = await waitForOllamaRunning(host);
   spinner.stop(running ? "Service running" : "Service not started automatically");
@@ -99,14 +99,14 @@ async function startOllamaService(host: Host, opts: { warnOnFail?: boolean } = {
 async function promptInstallOllama(host: Host, dryRun: boolean): Promise<boolean> {
   info("Ollama", "Not found on this system");
 
-  const action = await p.select({
+  const action = await select({
     message: "Ollama is not installed.",
     options: [
       { value: "install", label: "Install ollama", hint: "uses official install script" },
       { value: "skip", label: "Skip" },
     ],
   });
-  if (p.isCancel(action) || action === "skip") return false;
+  if (isCancel(action) || action === "skip") return false;
 
   if (dryRun) {
     info("Dry run", `Would install ollama: ${INSTALL_COMMAND}`);
@@ -118,14 +118,14 @@ async function promptInstallOllama(host: Host, dryRun: boolean): Promise<boolean
 async function promptUpdateRunningOllama(host: Host, dryRun: boolean): Promise<boolean> {
   pass("Ollama", "Service is running");
 
-  const action = await p.select({
+  const action = await select({
     message: "Ollama is installed and running.",
     options: [
       { value: "keep", label: "Keep current setup" },
       { value: "update", label: "Update ollama to latest version" },
     ],
   });
-  if (p.isCancel(action) || action === "keep") return true;
+  if (isCancel(action) || action === "keep") return true;
 
   if (dryRun) {
     info("Dry run", "Would update ollama");
@@ -137,14 +137,14 @@ async function promptUpdateRunningOllama(host: Host, dryRun: boolean): Promise<b
 async function promptStartStoppedOllama(host: Host, dryRun: boolean): Promise<boolean> {
   warn("Ollama", "Installed but service is not running");
 
-  const action = await p.select({
+  const action = await select({
     message: "Ollama service is not running.",
     options: [
       { value: "start", label: "Start the service" },
       { value: "update", label: "Update and start" },
     ],
   });
-  if (p.isCancel(action)) return false;
+  if (isCancel(action)) return false;
 
   if (dryRun) {
     info("Dry run", `Would ${action} ollama`);
@@ -158,7 +158,7 @@ async function promptStartStoppedOllama(host: Host, dryRun: boolean): Promise<bo
  * ollama is set up and expected to answer at {@link LOCAL_OLLAMA_ENDPOINT}.
  */
 export async function provisionOllama(host: Host, dryRun: boolean): Promise<boolean> {
-  p.log.step(pc.bold("Ollama setup"));
+  log.step(bold("Ollama setup"));
 
   const status = await detectOllamaStatus(host);
   if (status === "missing") return promptInstallOllama(host, dryRun);
@@ -177,7 +177,7 @@ export async function provisionOllama(host: Host, dryRun: boolean): Promise<bool
  * Returns true when ollama is expected to answer at {@link LOCAL_OLLAMA_ENDPOINT}.
  */
 export async function ensureOllama(host: Host, dryRun: boolean): Promise<boolean> {
-  p.log.step(pc.bold("Ollama setup"));
+  log.step(bold("Ollama setup"));
 
   const status = await detectOllamaStatus(host);
 
@@ -247,8 +247,8 @@ async function pointDaemonAtOllama(host: Host): Promise<void> {
     pass("Ollama", `Endpoint reachable at ${LOCAL_OLLAMA_ENDPOINT}`);
   } else {
     warn("Ollama", `Endpoint not reachable at ${LOCAL_OLLAMA_ENDPOINT}. The daemon may not be able to connect.`);
-    const proceed = await p.confirm({ message: "Save this endpoint anyway?", initialValue: true });
-    if (p.isCancel(proceed) || !proceed) return;
+    const proceed = await confirm({ message: "Save this endpoint anyway?", initialValue: true });
+    if (isCancel(proceed) || !proceed) return;
   }
   await writeDaemonEndpoint(host, LOCAL_OLLAMA_ENDPOINT);
 }

--- a/packages/xinity-cli/src/lib/ollama-setup.ts
+++ b/packages/xinity-cli/src/lib/ollama-setup.ts
@@ -9,7 +9,7 @@ import { type Host, commandExistsOn, isUnitActiveOn } from "./host.ts";
 import { pass, fail, info, warn } from "./output.ts";
 import { parseEnvString, serializeEnvFile } from "./env-file.ts";
 import { ENV_DIR } from "./component-meta.ts";
-import { restartService } from "./service.ts";
+import { heredoc, restartService } from "./service.ts";
 import { runSteps } from "./step-runner.ts";
 
 const DEFAULT_PORT = "11434";
@@ -226,7 +226,7 @@ async function writeDaemonEndpoint(host: Host, endpoint: string): Promise<boolea
   env.XINITY_OLLAMA_ENDPOINT = endpoint;
   const content = serializeEnvFile(env);
   const result = await host.withElevation(
-    `mkdir -p '${ENV_DIR}' && cat > '${envPath}' << 'ENVEOF'\n${content}ENVEOF\nchmod 644 '${envPath}'`,
+    `mkdir -p '${ENV_DIR}' && cat > '${envPath}' ${heredoc("ENVEOF", content)}\nchmod 644 '${envPath}'`,
     "Write XINITY_OLLAMA_ENDPOINT to daemon config",
   );
   if (result.success) {

--- a/packages/xinity-cli/src/lib/ollama-setup.ts
+++ b/packages/xinity-cli/src/lib/ollama-setup.ts
@@ -10,6 +10,7 @@ import { pass, fail, info, warn } from "./output.ts";
 import { parseEnvString, serializeEnvFile } from "./env-file.ts";
 import { ENV_DIR } from "./component-meta.ts";
 import { restartService } from "./service.ts";
+import { runSteps } from "./step-runner.ts";
 
 const DEFAULT_PORT = "11434";
 const INSTALL_COMMAND = "curl -fsSL https://ollama.com/install.sh | sh";
@@ -202,7 +203,7 @@ async function writeDaemonEndpoint(host: Host, endpoint: string): Promise<boolea
   );
   if (result.success) {
     pass("Daemon config", `XINITY_OLLAMA_ENDPOINT=${endpoint}`);
-    await restartService("daemon", host);
+    await runSteps(restartService("daemon", host));
     return true;
   }
   if (!result.skipped) {

--- a/packages/xinity-cli/src/lib/ollama-setup.ts
+++ b/packages/xinity-cli/src/lib/ollama-setup.ts
@@ -63,10 +63,8 @@ async function getOllamaVersion(host: Host): Promise<string | null> {
 async function installOrUpdateOllama(host: Host): Promise<boolean> {
   const result = await host.withElevation(INSTALL_COMMAND, "Install/update ollama");
   if (!result.success) {
-    if (!result.skipped) {
-      fail("Ollama", result.output || "Installation failed");
-      p.log.info(pc.dim(`  Install manually: ${INSTALL_COMMAND}`));
-    }
+    fail("Ollama", result.output || "Installation failed");
+    p.log.info(pc.dim(`  Install manually: ${INSTALL_COMMAND}`));
     return false;
   }
 
@@ -92,9 +90,7 @@ async function startOllamaService(host: Host, opts: { warnOnFail?: boolean } = {
     pass("Ollama", "Service started");
     return true;
   }
-  if (!result.skipped) {
-    (opts.warnOnFail ? warn : fail)("Ollama", result.output || "Failed to start service");
-  }
+  (opts.warnOnFail ? warn : fail)("Ollama", result.output || "Failed to start service");
   return false;
 }
 
@@ -175,6 +171,38 @@ export async function provisionOllama(host: Host, dryRun: boolean): Promise<bool
     : promptStartStoppedOllama(host, dryRun);
 }
 
+/**
+ * Non-interactive provisioning for `xinity plan apply`: install ollama when
+ * missing, start the service when stopped, leave a running instance alone.
+ * Returns true when ollama is expected to answer at {@link LOCAL_OLLAMA_ENDPOINT}.
+ */
+export async function ensureOllama(host: Host, dryRun: boolean): Promise<boolean> {
+  p.log.step(pc.bold("Ollama setup"));
+
+  const status = await detectOllamaStatus(host);
+
+  if (dryRun) {
+    info("Dry run", status === "missing"
+      ? `Would install ollama: ${INSTALL_COMMAND}`
+      : status === "stopped" ? "Would start the ollama service" : "Ollama already running");
+    return true;
+  }
+
+  if (status === "missing") {
+    info("Ollama", "Not found, installing");
+    return installOrUpdateOllama(host);
+  }
+
+  const version = await getOllamaVersion(host);
+  pass("Ollama", `Installed${version ? ` (v${version.replace(/^v/, "")})` : ""}`);
+
+  if (status === "running") {
+    pass("Ollama", "Service is running");
+    return true;
+  }
+  return startOllamaService(host);
+}
+
 // ─── Wiring the daemon to ollama (standalone `infra-ollama`) ──────────────────
 
 async function isOllamaEndpointReachable(host: Host): Promise<boolean> {
@@ -206,9 +234,7 @@ async function writeDaemonEndpoint(host: Host, endpoint: string): Promise<boolea
     await runSteps(restartService("daemon", host));
     return true;
   }
-  if (!result.skipped) {
-    fail("Daemon config", result.output || "Failed to write daemon env");
-  }
+  fail("Daemon config", result.output || "Failed to write daemon env");
   return false;
 }
 

--- a/packages/xinity-cli/src/lib/output.ts
+++ b/packages/xinity-cli/src/lib/output.ts
@@ -22,8 +22,9 @@ export function info(label: string, detail?: string) {
   p.log.info(formatLabelDetail(label, detail));
 }
 
+/** Section header rendered as a colored badge. */
 export function heading(text: string) {
-  p.log.step(pc.bold(text));
+  p.log.step(pc.bgCyan(pc.black(` ${text} `)));
 }
 
 /** Cancel the current prompt flow and exit the process cleanly. */
@@ -62,36 +63,26 @@ export function logErrors(result: { success: boolean; errors: string[] }): void 
   }
 }
 
-/**
- * Reports a hard elevation failure and returns true so the caller can short-circuit.
- * A "hard failure" excludes the user-chose-to-skip case, which the caller handles separately if relevant.
- */
+/** Reports a failed elevation result and returns true so the caller can short-circuit. */
 export function elevationHardFailed(
-  result: { success: boolean; skipped: boolean; output: string },
+  result: { success: boolean; output: string },
   label: string,
 ): boolean {
-  if (result.success || result.skipped) return false;
+  if (result.success) return false;
   fail(label, result.output);
   return true;
 }
 
-/**
- * Reports a three-way elevation outcome (success/skipped/failed) with the appropriate log level.
- * Returns true on success, false otherwise.
- */
+/** Reports an elevation outcome with the appropriate log level. Returns true on success. */
 export function reportElevationOutcome(
-  result: { success: boolean; skipped: boolean },
+  result: { success: boolean },
   label: string,
-  messages: { success: string; skipped: string; failed: string },
+  messages: { success: string; failed: string },
 ): boolean {
   if (result.success) {
     pass(label, messages.success);
     return true;
   }
-  if (result.skipped) {
-    warn(label, messages.skipped);
-  } else {
-    fail(label, messages.failed);
-  }
+  fail(label, messages.failed);
   return false;
 }

--- a/packages/xinity-cli/src/lib/output.ts
+++ b/packages/xinity-cli/src/lib/output.ts
@@ -1,35 +1,35 @@
-import * as p from "./clack.ts";
-import pc from "picocolors";
+import { cancel, isCancel, log } from "./clack.ts";
+import { bgCyan, black, dim } from "picocolors";
 
 function formatLabelDetail(label: string, detail?: string): string {
   if (!detail) return label;
-  return `${label} ${pc.dim("-")} ${pc.dim(detail)}`;
+  return `${label} ${dim("-")} ${dim(detail)}`;
 }
 
 export function pass(label: string, detail?: string) {
-  p.log.success(formatLabelDetail(label, detail));
+  log.success(formatLabelDetail(label, detail));
 }
 
 export function fail(label: string, detail?: string) {
-  p.log.error(formatLabelDetail(label, detail));
+  log.error(formatLabelDetail(label, detail));
 }
 
 export function warn(label: string, detail?: string) {
-  p.log.warn(formatLabelDetail(label, detail));
+  log.warn(formatLabelDetail(label, detail));
 }
 
 export function info(label: string, detail?: string) {
-  p.log.info(formatLabelDetail(label, detail));
+  log.info(formatLabelDetail(label, detail));
 }
 
 /** Section header rendered as a colored badge. */
 export function heading(text: string) {
-  p.log.step(pc.bgCyan(pc.black(` ${text} `)));
+  log.step(bgCyan(black(` ${text} `)));
 }
 
 /** Cancel the current prompt flow and exit the process cleanly. */
 export function cancelAndExit(): never {
-  p.cancel("Cancelled.");
+  cancel("Cancelled.");
   process.exit(0);
 }
 
@@ -39,7 +39,7 @@ export function cancelAndExit(): never {
  */
 export async function promptOrExit<T>(prompt: Promise<T | symbol>): Promise<Exclude<T, symbol>> {
   const value = await prompt;
-  if (p.isCancel(value)) cancelAndExit();
+  if (isCancel(value)) cancelAndExit();
   return value as Exclude<T, symbol>;
 }
 
@@ -50,7 +50,7 @@ export async function promptOrExit<T>(prompt: Promise<T | symbol>): Promise<Excl
  */
 export async function promptOrUndefined<T>(prompt: Promise<T | symbol>): Promise<Exclude<T, symbol> | undefined> {
   const value = await prompt;
-  if (p.isCancel(value)) return undefined;
+  if (isCancel(value)) return undefined;
   return value as Exclude<T, symbol>;
 }
 
@@ -58,7 +58,7 @@ export async function promptOrUndefined<T>(prompt: Promise<T | symbol>): Promise
 export function logErrors(result: { success: boolean; errors: string[] }): void {
   if (!result.success && result.errors.length > 0) {
     for (const err of result.errors) {
-      p.log.error(err);
+      log.error(err);
     }
   }
 }

--- a/packages/xinity-cli/src/lib/postgres-setup.ts
+++ b/packages/xinity-cli/src/lib/postgres-setup.ts
@@ -156,6 +156,11 @@ async function waitForPostgresReady(
 
 // ─── File writing ──────────────────────────────────────────────────────────
 
+function buildWriteFileCommand(path: string, content: string, mode?: string): string {
+  const chmod = mode ? `\nchmod ${mode} ${path}` : "";
+  return `cat > ${path} << 'XINITY_PG_EOF'\n${content}\nXINITY_PG_EOF${chmod}`;
+}
+
 async function writeFile(
   host: Host,
   path: string,
@@ -163,12 +168,8 @@ async function writeFile(
   label: string,
   mode?: string,
 ): Promise<boolean> {
-  const chmod = mode ? `\nchmod ${mode} ${path}` : "";
-  const result = await host.withElevation(
-    `cat > ${path} << 'XINITY_PG_EOF'\n${content}\nXINITY_PG_EOF${chmod}`,
-    `Write ${label}`,
-  );
-  if (!result.success && !result.skipped) {
+  const result = await host.withElevation(buildWriteFileCommand(path, content, mode), `Write ${label}`);
+  if (!result.success) {
     fail("Config", `Failed to write ${label}`);
     return false;
   }
@@ -183,7 +184,7 @@ async function startAndWait(host: Host, compose: ComposeCmd, user: string, port:
     composeArgs(compose, COMPOSE_PATH, "up", "-d").join(" "),
     "Start PostgreSQL container",
   );
-  if (!upResult.success && !upResult.skipped) {
+  if (!upResult.success) {
     fail("Start", "Failed to start the PostgreSQL container");
     return false;
   }
@@ -209,8 +210,21 @@ function reportSuccess(compose: ComposeCmd, connectionUrl: string): void {
     `  credentials: ${ENV_PATH} (0600)\n` +
     `  data:        Docker volume ${pc.cyan(VOLUME_NAME)} (inspect: docker volume inspect ${VOLUME_NAME})\n` +
     `  ${pc.cyan(`${manageCmd} down`)}       (stop and remove the container; data volume is kept)\n` +
-    `  ${pc.cyan(`${manageCmd} down -v`)}    (also delete the database volume — destroys data)`,
+    `  ${pc.cyan(`${manageCmd} down -v`)}    (also delete the database volume, destroys data)`,
   );
+}
+
+/**
+ * A fully-decided provisioning action: everything the apply half needs to
+ * bring the database up without asking anything else.
+ */
+export interface PostgresProvision {
+  compose: ComposeCmd;
+  user: string;
+  port: number;
+  url: string;
+  /** Present when creating a new stack; absent when restarting an existing one. */
+  files?: { envFile: string; composeFile: string };
 }
 
 /**
@@ -218,12 +232,10 @@ function reportSuccess(compose: ComposeCmd, connectionUrl: string): void {
  * applies POSTGRES_* on first init, so we must NOT regenerate credentials: we
  * reuse the existing env file, or refuse if we can't recover the password.
  */
-async function reuseExisting(
-  host: Host,
+function planReuseExisting(
   compose: ComposeCmd,
   existing: ExistingPostgres,
-  dryRun: boolean,
-): Promise<string | undefined> {
+): PostgresProvision | undefined {
   const creds = existing.envFile ? parsePostgresEnv(existing.envFile) : {};
   if (!creds.user || !creds.password || !creds.db) {
     warn("PostgreSQL", `An existing data volume (${VOLUME_NAME}) was found, but its credentials could not be recovered from ${ENV_PATH}.`);
@@ -238,19 +250,14 @@ async function reuseExisting(
   const port = existing.composeFile ? parsePublishedPort(existing.composeFile) : DEFAULT_PORT;
   const connectionUrl = buildConnectionUrl({ user: creds.user, password: creds.password, db: creds.db, port });
   info("PostgreSQL", `Reusing the existing database (credentials from ${ENV_PATH}); not regenerating.`);
-
-  if (dryRun) {
-    info("Dry run", `Would ensure the existing stack is running: ${pc.dim(composeArgs(compose, COMPOSE_PATH, "up", "-d").join(" "))}`);
-    p.note(`DB_CONNECTION_URL=${connectionUrl}`, "Existing connection URL");
-    return connectionUrl;
-  }
-
-  if (!(await startAndWait(host, compose, creds.user, port))) return undefined;
-  reportSuccess(compose, connectionUrl);
-  return connectionUrl;
+  return { compose, user: creds.user, port, url: connectionUrl };
 }
 
-async function provisionWithDocker(host: Host, dryRun: boolean): Promise<string | undefined> {
+/**
+ * Planning half: environment checks and configuration prompts only, nothing
+ * on the host changes.
+ */
+export async function planPostgresProvision(host: Host): Promise<PostgresProvision | undefined> {
   const compose = await resolveComposeCmd(host);
   if (!compose) {
     warn("Docker", "Docker with Compose is required to provision a database, and was not found.");
@@ -275,7 +282,7 @@ async function provisionWithDocker(host: Host, dryRun: boolean): Promise<string 
   // so reuse rather than silently hand out a password the database never adopted.
   const existing = await inspectExistingPostgres(host);
   if (existing.volumeExists) {
-    return reuseExisting(host, compose, existing, dryRun);
+    return planReuseExisting(compose, existing);
   }
 
   p.log.step(pc.bold("Configure the new database"));
@@ -320,37 +327,70 @@ async function provisionWithDocker(host: Host, dryRun: boolean): Promise<string 
     warn("Port", `Something is already listening on localhost:${port}. Starting the container will fail if it is still bound.`);
   }
 
-  const connectionUrl = buildConnectionUrl({ user, password, db, port });
-  const envFile = buildPostgresEnv({ db, user, password });
-  const composeFile = buildComposeFile(port, ENV_PATH);
+  return {
+    compose,
+    user,
+    port,
+    url: buildConnectionUrl({ user, password, db, port }),
+    files: {
+      envFile: buildPostgresEnv({ db, user, password }),
+      composeFile: buildComposeFile(port, ENV_PATH),
+    },
+  };
+}
 
-  if (dryRun) {
-    info("Dry run", `Would write ${ENV_PATH} (0600) and ${COMPOSE_PATH}`);
-    info("Dry run", `Would run: ${pc.dim(composeArgs(compose, COMPOSE_PATH, "up", "-d").join(" "))}`);
-    p.note(`DB_CONNECTION_URL=${connectionUrl}`, "Connection URL (not yet created)");
-    return connectionUrl;
+/** One-line summary of the provisioning action for review lists. */
+export function describePostgresProvision(prov: PostgresProvision): string {
+  return prov.files
+    ? `Provision PostgreSQL via Docker (${POSTGRES_IMAGE} on localhost:${prov.port})`
+    : `Start the existing PostgreSQL Docker stack (localhost:${prov.port})`;
+}
+
+/** The exact root shell commands the apply half runs, for the script dump. */
+export function buildPostgresProvisionCommands(prov: PostgresProvision): string[] {
+  const up = composeArgs(prov.compose, COMPOSE_PATH, "up", "-d").join(" ");
+  if (!prov.files) return [up];
+  return [
+    `mkdir -p ${STACK_DIR}`,
+    buildWriteFileCommand(ENV_PATH, prov.files.envFile, "600"),
+    buildWriteFileCommand(COMPOSE_PATH, prov.files.composeFile),
+    up,
+  ];
+}
+
+/** Apply half: write the stack files (new stacks only), start, wait for readiness. */
+export async function applyPostgresProvision(prov: PostgresProvision, host: Host): Promise<boolean> {
+  if (prov.files) {
+    await host.withElevation(`mkdir -p ${STACK_DIR}`, "Create stack directory");
+    if (!(await writeFile(host, ENV_PATH, prov.files.envFile, "database env file", "600"))) return false;
+    if (!(await writeFile(host, COMPOSE_PATH, prov.files.composeFile, "compose file"))) return false;
+    pass("Config", `Wrote ${COMPOSE_PATH} and ${ENV_PATH}`);
   }
 
-  await host.withElevation(`mkdir -p ${STACK_DIR}`, "Create stack directory");
-  if (!(await writeFile(host, ENV_PATH, envFile, "database env file", "600"))) return undefined;
-  if (!(await writeFile(host, COMPOSE_PATH, composeFile, "compose file"))) return undefined;
-  pass("Config", `Wrote ${COMPOSE_PATH} and ${ENV_PATH}`);
-
-  if (!(await startAndWait(host, compose, user, port))) return undefined;
-  reportSuccess(compose, connectionUrl);
-  return connectionUrl;
+  if (!(await startAndWait(host, prov.compose, prov.user, prov.port))) return false;
+  reportSuccess(prov.compose, prov.url);
+  return true;
 }
 
 // ─── Main entry point ───────────────────────────────────────────────────────
 
 /**
- * Provision a new PostgreSQL database via Docker.
- *
- * Returns the connection URL on success, or undefined if the user cancelled or
- * the environment is unsupported. The existing-database case is handled upstream
- * by the migrator (see the module comment), not here.
+ * `xinity up infra-postgres`: plan, then immediately apply (or describe, on
+ * dry runs). The existing-database case is handled upstream by the migrator
+ * (see the module comment), not here.
  */
 export async function postgresSetup(host: Host, dryRun: boolean): Promise<string | undefined> {
   p.log.step(pc.bold("PostgreSQL setup"));
-  return provisionWithDocker(host, dryRun);
+  const prov = await planPostgresProvision(host);
+  if (!prov) return undefined;
+
+  if (dryRun) {
+    for (const cmd of buildPostgresProvisionCommands(prov)) {
+      info("Dry run", `Would run: ${pc.dim(cmd.split("\n")[0] ?? cmd)}`);
+    }
+    p.note(`DB_CONNECTION_URL=${prov.url}`, prov.files ? "Connection URL (not yet created)" : "Existing connection URL");
+    return prov.url;
+  }
+
+  return (await applyPostgresProvision(prov, host)) ? prov.url : undefined;
 }

--- a/packages/xinity-cli/src/lib/postgres-setup.ts
+++ b/packages/xinity-cli/src/lib/postgres-setup.ts
@@ -7,8 +7,8 @@
  * assistant when the user chose to set one up.
  */
 import { randomBytes } from "crypto";
-import * as p from "./clack.ts";
-import pc from "picocolors";
+import { confirm, log, note, password as passwordPrompt, spinner as clackSpinner, text } from "./clack.ts";
+import { bold, cyan, dim } from "picocolors";
 import { type Host } from "./host.ts";
 import { pass, fail, info, warn, promptOrUndefined } from "./output.ts";
 import {
@@ -189,7 +189,7 @@ async function startAndWait(host: Host, compose: ComposeCmd, user: string, port:
     return false;
   }
 
-  const spinner = p.spinner();
+  const spinner = clackSpinner();
   spinner.start("Waiting for PostgreSQL to become ready…");
   const ready = await waitForPostgresReady(host, compose, user);
   if (ready) {
@@ -204,13 +204,13 @@ async function startAndWait(host: Host, compose: ComposeCmd, user: string, port:
 
 function reportSuccess(compose: ComposeCmd, connectionUrl: string): void {
   const manageCmd = composeArgs(compose, COMPOSE_PATH).join(" ");
-  p.note(`DB_CONNECTION_URL=${connectionUrl}`, "Use this in your gateway, dashboard, and daemon env files");
-  p.log.info(
+  note(`DB_CONNECTION_URL=${connectionUrl}`, "Use this in your gateway, dashboard, and daemon env files");
+  log.info(
     `This stack is yours to manage. Files live in ${STACK_DIR}:\n` +
     `  credentials: ${ENV_PATH} (0600)\n` +
-    `  data:        Docker volume ${pc.cyan(VOLUME_NAME)} (inspect: docker volume inspect ${VOLUME_NAME})\n` +
-    `  ${pc.cyan(`${manageCmd} down`)}       (stop and remove the container; data volume is kept)\n` +
-    `  ${pc.cyan(`${manageCmd} down -v`)}    (also delete the database volume, destroys data)`,
+    `  data:        Docker volume ${cyan(VOLUME_NAME)} (inspect: docker volume inspect ${VOLUME_NAME})\n` +
+    `  ${cyan(`${manageCmd} down`)}       (stop and remove the container; data volume is kept)\n` +
+    `  ${cyan(`${manageCmd} down -v`)}    (also delete the database volume, destroys data)`,
   );
 }
 
@@ -239,10 +239,10 @@ function planReuseExisting(
   const creds = existing.envFile ? parsePostgresEnv(existing.envFile) : {};
   if (!creds.user || !creds.password || !creds.db) {
     warn("PostgreSQL", `An existing data volume (${VOLUME_NAME}) was found, but its credentials could not be recovered from ${ENV_PATH}.`);
-    p.log.info(
-      pc.dim("  The database already holds data and its password cannot be changed by re-running setup.\n") +
-      pc.dim("  Either choose \"use an existing database\" and supply its connection URL, or, to start\n") +
-      pc.dim(`  fresh (DESTROYS DATA), run: ${composeArgs(compose, COMPOSE_PATH, "down", "-v").join(" ")}`),
+    log.info(
+      dim("  The database already holds data and its password cannot be changed by re-running setup.\n") +
+      dim("  Either choose \"use an existing database\" and supply its connection URL, or, to start\n") +
+      dim(`  fresh (DESTROYS DATA), run: ${composeArgs(compose, COMPOSE_PATH, "down", "-v").join(" ")}`),
     );
     return undefined;
   }
@@ -261,22 +261,22 @@ export async function planPostgresProvision(host: Host): Promise<PostgresProvisi
   const compose = await resolveComposeCmd(host);
   if (!compose) {
     warn("Docker", "Docker with Compose is required to provision a database, and was not found.");
-    p.log.info(
-      pc.dim("  This environment is not supported for CLI-managed PostgreSQL.\n") +
-      pc.dim("  Install Docker (https://docs.docker.com/engine/install/) and re-run,\n") +
-      pc.dim("  or re-run and choose \"use an existing database\" with a connection URL."),
+    log.info(
+      dim("  This environment is not supported for CLI-managed PostgreSQL.\n") +
+      dim("  Install Docker (https://docs.docker.com/engine/install/) and re-run,\n") +
+      dim("  or re-run and choose \"use an existing database\" with a connection URL."),
     );
     return undefined;
   }
   if (compose.docker === "docker" && !(await dockerDaemonReady(host))) {
     warn("Docker", "The Docker CLI is installed but the daemon is not reachable.");
-    p.log.info(
-      pc.dim("  Start Docker (e.g. `systemctl start docker`) or ensure your user can\n") +
-      pc.dim("  access the Docker socket (docker group), then re-run."),
+    log.info(
+      dim("  Start Docker (e.g. `systemctl start docker`) or ensure your user can\n") +
+      dim("  access the Docker socket (docker group), then re-run."),
     );
     return undefined;
   }
-  pass("Docker", `Using ${pc.cyan(composeName(compose))}`);
+  pass("Docker", `Using ${cyan(composeName(compose))}`);
 
   // Re-running over an already-initialized cluster cannot change its credentials,
   // so reuse rather than silently hand out a password the database never adopted.
@@ -285,19 +285,19 @@ export async function planPostgresProvision(host: Host): Promise<PostgresProvisi
     return planReuseExisting(compose, existing);
   }
 
-  p.log.step(pc.bold("Configure the new database"));
+  log.step(bold("Configure the new database"));
 
-  const db = await promptOrUndefined(p.text({
+  const db = await promptOrUndefined(text({
     message: "Database name", placeholder: "xinity", defaultValue: "xinity",
   }));
   if (db === undefined) return undefined;
 
-  const user = await promptOrUndefined(p.text({
+  const user = await promptOrUndefined(text({
     message: "Database user", placeholder: "xinity", defaultValue: "xinity",
   }));
   if (user === undefined) return undefined;
 
-  const useGenerated = await promptOrUndefined(p.confirm({
+  const useGenerated = await promptOrUndefined(confirm({
     message: "Generate a random password?", initialValue: true,
   }));
   if (useGenerated === undefined) return undefined;
@@ -305,9 +305,9 @@ export async function planPostgresProvision(host: Host): Promise<PostgresProvisi
   let password: string;
   if (useGenerated) {
     password = generatePassword();
-    info("Password", `Generated: ${pc.cyan(password)}`);
+    info("Password", `Generated: ${cyan(password)}`);
   } else {
-    const pw = await promptOrUndefined(p.password({
+    const pw = await promptOrUndefined(passwordPrompt({
       message: "Database password",
       validate: (val) => (!val || val.length < 4 ? "Password must be at least 4 characters" : undefined),
     }));
@@ -315,7 +315,7 @@ export async function planPostgresProvision(host: Host): Promise<PostgresProvisi
     password = pw;
   }
 
-  const portStr = await promptOrUndefined(p.text({
+  const portStr = await promptOrUndefined(text({
     message: "Port to publish on localhost", placeholder: String(DEFAULT_PORT), defaultValue: String(DEFAULT_PORT),
   }));
   if (portStr === undefined) return undefined;
@@ -380,15 +380,15 @@ export async function applyPostgresProvision(prov: PostgresProvision, host: Host
  * (see the module comment), not here.
  */
 export async function postgresSetup(host: Host, dryRun: boolean): Promise<string | undefined> {
-  p.log.step(pc.bold("PostgreSQL setup"));
+  log.step(bold("PostgreSQL setup"));
   const prov = await planPostgresProvision(host);
   if (!prov) return undefined;
 
   if (dryRun) {
     for (const cmd of buildPostgresProvisionCommands(prov)) {
-      info("Dry run", `Would run: ${pc.dim(cmd.split("\n")[0] ?? cmd)}`);
+      info("Dry run", `Would run: ${dim(cmd.split("\n")[0] ?? cmd)}`);
     }
-    p.note(`DB_CONNECTION_URL=${prov.url}`, prov.files ? "Connection URL (not yet created)" : "Existing connection URL");
+    note(`DB_CONNECTION_URL=${prov.url}`, prov.files ? "Connection URL (not yet created)" : "Existing connection URL");
     return prov.url;
   }
 

--- a/packages/xinity-cli/src/lib/postgres-setup.ts
+++ b/packages/xinity-cli/src/lib/postgres-setup.ts
@@ -11,6 +11,7 @@ import { confirm, log, note, password as passwordPrompt, spinner as clackSpinner
 import { bold, cyan, dim } from "picocolors";
 import { type Host } from "./host.ts";
 import { pass, fail, info, warn, promptOrUndefined } from "./output.ts";
+import { heredoc } from "./service.ts";
 import {
   resolveComposeCmd, composeArgs, composeName, stackDir,
   dockerDaemonReady, tcpPortInUse, type ComposeCmd,
@@ -158,7 +159,7 @@ async function waitForPostgresReady(
 
 function buildWriteFileCommand(path: string, content: string, mode?: string): string {
   const chmod = mode ? `\nchmod ${mode} ${path}` : "";
-  return `cat > ${path} << 'XINITY_PG_EOF'\n${content}\nXINITY_PG_EOF${chmod}`;
+  return `cat > ${path} ${heredoc("XINITY_PG_EOF", content)}${chmod}`;
 }
 
 async function writeFile(

--- a/packages/xinity-cli/src/lib/prometheus-setup.ts
+++ b/packages/xinity-cli/src/lib/prometheus-setup.ts
@@ -171,7 +171,7 @@ async function writeFile(host: Host, path: string, content: string, label: strin
     `cat > ${path} << 'XINITY_PROM_EOF'\n${content}\nXINITY_PROM_EOF`,
     `Write ${label}`,
   );
-  if (!result.success && !result.skipped) {
+  if (!result.success) {
     fail("Config", `Failed to write ${label}`);
     return false;
   }
@@ -309,7 +309,7 @@ export async function prometheusSetup(
     composeArgs(compose, COMPOSE_PATH, "up", "-d").join(" "),
     "Start Prometheus container",
   );
-  if (!upResult.success && !upResult.skipped) {
+  if (!upResult.success) {
     fail("Start", "Failed to start the Prometheus container");
     return undefined;
   }

--- a/packages/xinity-cli/src/lib/prometheus-setup.ts
+++ b/packages/xinity-cli/src/lib/prometheus-setup.ts
@@ -8,8 +8,8 @@
  * running as host processes on localhost. (Unrelated to the bridge-networked
  * deployment template, whose targets are in-stack.)
  */
-import * as p from "./clack.ts";
-import pc from "picocolors";
+import { log, note, spinner as clackSpinner, text } from "./clack.ts";
+import { bold, cyan, dim } from "picocolors";
 import { type Host } from "./host.ts";
 import { pass, fail, info, warn, promptOrUndefined } from "./output.ts";
 import { resolveComposeCmd, composeArgs, composeName, stackDir, dockerDaemonReady, tcpPortInUse } from "./docker-stack.ts";
@@ -190,8 +190,8 @@ export async function prometheusSetup(
   host: Host,
   dryRun: boolean,
 ): Promise<string | undefined> {
-  p.log.step(pc.bold("Prometheus metrics store setup"));
-  p.log.info(
+  log.step(bold("Prometheus metrics store setup"));
+  log.info(
     "Prometheus scrapes the gateway, dashboard, and daemon /metrics endpoints.\n" +
     "It runs as a Docker container and powers the live GPU overlay on the Compute page.",
   );
@@ -200,27 +200,27 @@ export async function prometheusSetup(
   const compose = await resolveComposeCmd(host);
   if (!compose) {
     warn("Docker", "Docker with Compose is required to run the monitoring stack, and was not found.");
-    p.log.info(
-      pc.dim("  This environment is not supported for CLI-managed Prometheus.\n") +
-      pc.dim("  Install Docker (https://docs.docker.com/engine/install/) and re-run,\n") +
-      pc.dim("  or run Prometheus yourself and point the dashboard at it via PROMETHEUS_URL."),
+    log.info(
+      dim("  This environment is not supported for CLI-managed Prometheus.\n") +
+      dim("  Install Docker (https://docs.docker.com/engine/install/) and re-run,\n") +
+      dim("  or run Prometheus yourself and point the dashboard at it via PROMETHEUS_URL."),
     );
     return undefined;
   }
   if (compose.docker === "docker" && !(await dockerDaemonReady(host))) {
     warn("Docker", "The Docker CLI is installed but the daemon is not reachable.");
-    p.log.info(
-      pc.dim("  Start Docker (e.g. `systemctl start docker`) or ensure your user can\n") +
-      pc.dim("  access the Docker socket (docker group), then re-run."),
+    log.info(
+      dim("  Start Docker (e.g. `systemctl start docker`) or ensure your user can\n") +
+      dim("  access the Docker socket (docker group), then re-run."),
     );
     return undefined;
   }
-  pass("Docker", `Using ${pc.cyan(composeName(compose))}`);
+  pass("Docker", `Using ${cyan(composeName(compose))}`);
 
   // ── Step 2: Prompt for configuration ────────────────────────────────────
-  p.log.step(pc.bold("Configure Prometheus"));
+  log.step(bold("Configure Prometheus"));
 
-  const portStr = await promptOrUndefined(p.text({
+  const portStr = await promptOrUndefined(text({
     message: "Prometheus port (bound to localhost)",
     placeholder: String(DEFAULT_PORT),
     defaultValue: String(DEFAULT_PORT),
@@ -243,7 +243,7 @@ export async function prometheusSetup(
     return undefined;
   };
 
-  const gatewayUrl = await promptOrUndefined(p.text({
+  const gatewayUrl = await promptOrUndefined(text({
     message: "Gateway base URL",
     placeholder: "http://localhost:4121",
     defaultValue: "http://localhost:4121",
@@ -251,7 +251,7 @@ export async function prometheusSetup(
   }));
   if (gatewayUrl === undefined) return undefined;
 
-  const dashboardUrl = await promptOrUndefined(p.text({
+  const dashboardUrl = await promptOrUndefined(text({
     message: "Dashboard base URL",
     placeholder: "http://localhost:5121",
     defaultValue: "http://localhost:5121",
@@ -265,14 +265,14 @@ export async function prometheusSetup(
   // Daemons are discovered dynamically from the dashboard, so there is no static
   // target list to maintain. Auth is optional: the SD endpoint is often left open
   // (internal only), while the daemon scrape is usually password-protected.
-  const sdAuthRaw = await promptOrUndefined(p.text({
+  const sdAuthRaw = await promptOrUndefined(text({
     message: "Dashboard METRICS_AUTH for the discovery request (user:pass, blank if none)",
     placeholder: "",
     defaultValue: "",
   }));
   if (sdAuthRaw === undefined) return undefined;
 
-  const daemonAuthRaw = await promptOrUndefined(p.text({
+  const daemonAuthRaw = await promptOrUndefined(text({
     message: "Daemon METRICS_AUTH for scraping daemons (user:pass, blank if none)",
     placeholder: "",
     defaultValue: "",
@@ -295,7 +295,7 @@ export async function prometheusSetup(
   // ── Step 3: Write the stack ─────────────────────────────────────────────
   if (dryRun) {
     info("Dry run", `Would write ${CONFIG_PATH} and ${COMPOSE_PATH}`);
-    info("Dry run", `Would run: ${pc.dim(composeArgs(compose, COMPOSE_PATH, "up", "-d").join(" "))}`);
+    info("Dry run", `Would run: ${dim(composeArgs(compose, COMPOSE_PATH, "up", "-d").join(" "))}`);
     return endpoint(port);
   }
 
@@ -314,7 +314,7 @@ export async function prometheusSetup(
     return undefined;
   }
 
-  const spinner = p.spinner();
+  const spinner = clackSpinner();
   spinner.start("Waiting for Prometheus to start…");
   const ready = await waitForPrometheusRunning(host, port);
   if (ready) {
@@ -329,19 +329,19 @@ export async function prometheusSetup(
   const promUrl = endpoint(port);
   const manageCmd = composeArgs(compose, COMPOSE_PATH).join(" ");
 
-  p.note(
+  note(
     [`PROMETHEUS_URL=${promUrl}`].join("\n"),
     "Add this to your dashboard env file to enable the compute GPU overlay",
   );
 
-  p.log.info(
+  log.info(
     `This stack is yours to manage. Files live in ${STACK_DIR}:\n` +
-    `  ${pc.cyan(`${manageCmd} restart`)}   (after editing ${CONFIG_PATH})\n` +
-    `  ${pc.cyan(`${manageCmd} down`)}      (stop and remove the container)`,
+    `  ${cyan(`${manageCmd} restart`)}   (after editing ${CONFIG_PATH})\n` +
+    `  ${cyan(`${manageCmd} down`)}      (stop and remove the container)`,
   );
 
-  p.log.info(
-    `Daemon targets are discovered from ${pc.cyan(daemonSdUrl)} and refresh automatically\n` +
+  log.info(
+    `Daemon targets are discovered from ${cyan(daemonSdUrl)} and refresh automatically\n` +
     `as nodes register or drop out, no edits or reloads needed.`,
   );
 

--- a/packages/xinity-cli/src/lib/prometheus-setup.ts
+++ b/packages/xinity-cli/src/lib/prometheus-setup.ts
@@ -12,6 +12,7 @@ import { log, note, spinner as clackSpinner, text } from "./clack.ts";
 import { bold, cyan, dim } from "picocolors";
 import { type Host } from "./host.ts";
 import { pass, fail, info, warn, promptOrUndefined } from "./output.ts";
+import { heredoc } from "./service.ts";
 import { resolveComposeCmd, composeArgs, composeName, stackDir, dockerDaemonReady, tcpPortInUse } from "./docker-stack.ts";
 
 // ─── Constants ───────────────────────────────────────────────────────────────
@@ -168,7 +169,7 @@ export function buildComposeFile(port: number, configPath: string): string {
 
 async function writeFile(host: Host, path: string, content: string, label: string): Promise<boolean> {
   const result = await host.withElevation(
-    `cat > ${path} << 'XINITY_PROM_EOF'\n${content}\nXINITY_PROM_EOF`,
+    `cat > ${path} ${heredoc("XINITY_PROM_EOF", content)}`,
     `Write ${label}`,
   );
   if (!result.success) {

--- a/packages/xinity-cli/src/lib/redis-setup.ts
+++ b/packages/xinity-cli/src/lib/redis-setup.ts
@@ -15,6 +15,19 @@ import { type Host, commandExistsOn, readSecrets } from "./host.ts";
 import { pass, fail, info, promptOrUndefined, reportElevationOutcome, warn } from "./output.ts";
 import { parseEnvString } from "./env-file.ts";
 import { SECRETS_DIR, ENV_DIR } from "./component-meta.ts";
+import type { ConnectionResult } from "./connectivity.ts";
+
+async function testRedisWithSpinner(url: string, host: Host): Promise<ConnectionResult> {
+  const { testRedisConnection } = await import("./connectivity.ts");
+  const spinner = p.spinner();
+  spinner.start("Testing Redis connection…");
+  const result = await testRedisConnection(url, host);
+  spinner.stop(result.success ? "Redis connection successful" : "Redis connection failed");
+  if (!result.success && result.error) {
+    p.log.error(pc.dim(result.error));
+  }
+  return result;
+}
 
 // ─── Package-manager definitions ────────────────────────────────────────────
 
@@ -344,15 +357,15 @@ export async function discoverRedisUrl(
   host: Host,
   dryRun: boolean,
 ): Promise<string | undefined> {
-  const { testRedisConnection } = await import("./connectivity.ts");
-
   // 1. Check stored secret
   const stored = await readSecrets(host, SECRETS_DIR, ["REDIS_URL"], "Read stored Redis URL");
   if (stored.secrets.REDIS_URL) {
     const url = stored.secrets.REDIS_URL;
     info("Redis connection", `Found stored URL: ${redactRedisUrl(url)}`);
-    const ok = await testRedisConnection(url, host);
-    if (ok) return url;
+    const result = await testRedisWithSpinner(url, host);
+    if (result.success) {
+      return url;
+    }
 
     // Stored URL is stale, offer to reconfigure
     const action = await p.select({
@@ -368,7 +381,7 @@ export async function discoverRedisUrl(
     if (action === "setup") {
       const newUrl = await redisSetup(host, dryRun);
       if (newUrl) {
-        await testRedisConnection(newUrl, host);
+        await testRedisWithSpinner(newUrl, host);
         if (!dryRun) await persistRedisUrl(host, newUrl);
       }
       return newUrl;
@@ -427,7 +440,7 @@ export async function discoverRedisUrl(
   if (choice === "setup") {
     const url = await redisSetup(host, dryRun);
     if (url) {
-      await testRedisConnection(url, host);
+      await testRedisWithSpinner(url, host);
       if (!dryRun) await persistRedisUrl(host, url);
     }
     return url;
@@ -443,9 +456,6 @@ export async function discoverRedisUrl(
  * Prompt for a Redis connection URL and test connectivity, allowing retries.
  */
 async function promptAndValidateRedisUrl(host: Host): Promise<string | undefined> {
-  const { testRedisConnection } = await import("./connectivity.ts");
-
-  // eslint-disable-next-line no-constant-condition
   while (true) {
     const value = await p.text({
       message: "REDIS_URL",
@@ -461,8 +471,10 @@ async function promptAndValidateRedisUrl(host: Host): Promise<string | undefined
       return undefined;
     }
 
-    const ok = await testRedisConnection(value, host);
-    if (ok) return value;
+    const result = await testRedisWithSpinner(value, host);
+    if (result.success) {
+      return value;
+    }
 
     const action = await p.select({
       message: "Could not connect to Redis.",
@@ -546,14 +558,12 @@ export async function redisSetup(host: Host, dryRun: boolean): Promise<string | 
  * normal discovery flow.
  */
 export async function infraRedis(host: Host, dryRun: boolean): Promise<string | undefined> {
-  const { testRedisConnection } = await import("./connectivity.ts");
-
   const stored = await readSecrets(host, SECRETS_DIR, ["REDIS_URL"], "Read stored Redis URL");
   if (stored.secrets.REDIS_URL) {
     const url = stored.secrets.REDIS_URL;
-    const ok = await testRedisConnection(url, host);
+    const result = await testRedisWithSpinner(url, host);
 
-    if (ok) {
+    if (result.success) {
       info("Redis connection", `Current: ${redactRedisUrl(url)}`);
       const action = await p.select({
         message: "Redis is configured and reachable.",
@@ -572,7 +582,7 @@ export async function infraRedis(host: Host, dryRun: boolean): Promise<string | 
       // setup: fall through to full setup
       const newUrl = await redisSetup(host, dryRun);
       if (newUrl) {
-        await testRedisConnection(newUrl, host);
+        await testRedisWithSpinner(newUrl, host);
         if (!dryRun) await persistRedisUrl(host, newUrl);
       }
       return newUrl;

--- a/packages/xinity-cli/src/lib/redis-setup.ts
+++ b/packages/xinity-cli/src/lib/redis-setup.ts
@@ -6,8 +6,8 @@
  * host. `applyRedisPlan` executes the decided commands and persists the URL.
  */
 import { randomBytes } from "crypto";
-import * as p from "./clack.ts";
-import pc from "picocolors";
+import { cancel, confirm, isCancel, log, note, password as passwordPrompt, select, spinner as clackSpinner, text } from "./clack.ts";
+import { bold, cyan, dim } from "picocolors";
 import { type Host, commandExistsOn, readSecrets } from "./host.ts";
 import { pass, fail, info, promptOrUndefined, reportElevationOutcome, warn } from "./output.ts";
 import { parseEnvString } from "./env-file.ts";
@@ -16,12 +16,12 @@ import type { ConnectionResult } from "./connectivity.ts";
 
 async function testRedisWithSpinner(url: string, host: Host): Promise<ConnectionResult> {
   const { testRedisConnection } = await import("./connectivity.ts");
-  const spinner = p.spinner();
+  const spinner = clackSpinner();
   spinner.start("Testing Redis connection…");
   const result = await testRedisConnection(url, host);
   spinner.stop(result.success ? "Redis connection successful" : "Redis connection failed");
   if (!result.success && result.error) {
-    p.log.error(pc.dim(result.error));
+    log.error(dim(result.error));
   }
   return result;
 }
@@ -206,23 +206,23 @@ export function describeRedisPlan(plan: RedisPlan): string[] {
 }
 
 async function waitForManualInstall(host: Host): Promise<boolean> {
-  p.note(
+  note(
     [
       "Please install Redis or Valkey using your system's package manager.",
       "Common commands:",
       "",
-      `  ${pc.dim("# Debian/Ubuntu")}`,
+      `  ${dim("# Debian/Ubuntu")}`,
       `  sudo apt install redis-server`,
-      `  ${pc.dim("# or")}`,
+      `  ${dim("# or")}`,
       `  sudo apt install valkey`,
       "",
-      `  ${pc.dim("# Fedora/RHEL")}`,
+      `  ${dim("# Fedora/RHEL")}`,
       `  sudo dnf install redis`,
       "",
-      `  ${pc.dim("# Arch Linux")}`,
+      `  ${dim("# Arch Linux")}`,
       `  sudo pacman -S redis`,
       "",
-      `  ${pc.dim("# macOS")}`,
+      `  ${dim("# macOS")}`,
       `  brew install redis`,
       "",
       "After installing, make sure the service is running.",
@@ -230,12 +230,12 @@ async function waitForManualInstall(host: Host): Promise<boolean> {
     "Manual installation required",
   );
 
-  const done = await p.confirm({
+  const done = await confirm({
     message: "Have you installed and started Redis/Valkey?",
     initialValue: false,
   });
 
-  if (p.isCancel(done) || !done) return false;
+  if (isCancel(done) || !done) return false;
 
   if (await isRedisRunning(host)) {
     pass("Redis", "Service is running");
@@ -243,27 +243,27 @@ async function waitForManualInstall(host: Host): Promise<boolean> {
   }
 
   warn("Redis", "Service does not appear to be running yet");
-  const continueAnyway = await p.confirm({
+  const continueAnyway = await confirm({
     message: "Continue anyway?",
     initialValue: false,
   });
-  return !p.isCancel(continueAnyway) && continueAnyway;
+  return !isCancel(continueAnyway) && continueAnyway;
 }
 
 // ─── Configuration ──────────────────────────────────────────────────────────
 
 /** Build a REDIS_URL from user input or defaults. Prompts only. */
 async function configureRedisUrl(): Promise<string | undefined> {
-  p.log.step(pc.bold("Configure Redis connection"));
+  log.step(bold("Configure Redis connection"));
 
-  const hostInput = await promptOrUndefined(p.text({
+  const hostInput = await promptOrUndefined(text({
     message: "Redis host",
     placeholder: "localhost",
     defaultValue: "localhost",
   }));
   if (hostInput === undefined) return undefined;
 
-  const portInput = await promptOrUndefined(p.text({
+  const portInput = await promptOrUndefined(text({
     message: "Redis port",
     placeholder: "6379",
     defaultValue: "6379",
@@ -276,7 +276,7 @@ async function configureRedisUrl(): Promise<string | undefined> {
   }));
   if (portInput === undefined) return undefined;
 
-  const setPassword = await promptOrUndefined(p.confirm({
+  const setPassword = await promptOrUndefined(confirm({
     message: "Set a password for Redis?",
     initialValue: false,
   }));
@@ -284,7 +284,7 @@ async function configureRedisUrl(): Promise<string | undefined> {
 
   let password: string | undefined;
   if (setPassword) {
-    const useGenerated = await promptOrUndefined(p.confirm({
+    const useGenerated = await promptOrUndefined(confirm({
       message: "Generate a random password?",
       initialValue: true,
     }));
@@ -292,9 +292,9 @@ async function configureRedisUrl(): Promise<string | undefined> {
 
     if (useGenerated) {
       password = generatePassword();
-      info("Password", `Generated: ${pc.cyan(password)}`);
+      info("Password", `Generated: ${cyan(password)}`);
     } else {
-      const pw = await promptOrUndefined(p.password({
+      const pw = await promptOrUndefined(passwordPrompt({
         message: "Redis password",
         validate: (val) => {
           if (!val || val.length < 4) return "Password must be at least 4 characters";
@@ -310,7 +310,7 @@ async function configureRedisUrl(): Promise<string | undefined> {
     ? `redis://:${encodeURIComponent(password)}@${hostInput}:${portInput}`
     : `redis://${hostInput}:${portInput}`;
 
-  p.note(url, "REDIS_URL");
+  note(url, "REDIS_URL");
 
   return url;
 }
@@ -359,7 +359,7 @@ export async function planRedis(host: Host): Promise<RedisPlan | undefined> {
     }
 
     // Stored URL is stale, offer to reconfigure
-    const action = await p.select({
+    const action = await select({
       message: "Stored Redis URL failed connectivity test.",
       options: [
         { value: "reenter", label: "Enter a new URL" },
@@ -367,7 +367,7 @@ export async function planRedis(host: Host): Promise<RedisPlan | undefined> {
         { value: "keep", label: "Use the stored URL anyway" },
       ],
     });
-    if (p.isCancel(action)) { p.cancel("Cancelled."); return undefined; }
+    if (isCancel(action)) { cancel("Cancelled."); return undefined; }
     if (action === "keep") return { url, persist: false };
     if (action === "setup") return planRedisSetup(host);
     const newUrl = await promptAndValidateRedisUrl(host);
@@ -396,7 +396,7 @@ export async function planRedis(host: Host): Promise<RedisPlan | undefined> {
   }
 
   // 4. No existing connection found, ask user how to proceed
-  const choice = await p.select({
+  const choice = await select({
     message: "No existing Redis connection found. Do you already have a Redis/Valkey instance?",
     options: [
       {
@@ -412,8 +412,8 @@ export async function planRedis(host: Host): Promise<RedisPlan | undefined> {
     ],
   });
 
-  if (p.isCancel(choice)) {
-    p.cancel("Cancelled.");
+  if (isCancel(choice)) {
+    cancel("Cancelled.");
     return undefined;
   }
 
@@ -429,7 +429,7 @@ export async function planRedis(host: Host): Promise<RedisPlan | undefined> {
  */
 async function promptAndValidateRedisUrl(host: Host): Promise<string | undefined> {
   while (true) {
-    const value = await p.text({
+    const value = await text({
       message: "REDIS_URL",
       placeholder: "redis://localhost:6379",
       validate: (val) => {
@@ -438,8 +438,8 @@ async function promptAndValidateRedisUrl(host: Host): Promise<string | undefined
         return undefined;
       },
     });
-    if (p.isCancel(value)) {
-      p.cancel("Cancelled.");
+    if (isCancel(value)) {
+      cancel("Cancelled.");
       return undefined;
     }
 
@@ -448,14 +448,14 @@ async function promptAndValidateRedisUrl(host: Host): Promise<string | undefined
       return value;
     }
 
-    const action = await p.select({
+    const action = await select({
       message: "Could not connect to Redis.",
       options: [
         { value: "retry", label: "Enter a different URL" },
         { value: "proceed", label: "Use this URL anyway" },
       ],
     });
-    if (p.isCancel(action) || action === "proceed") return value;
+    if (isCancel(action) || action === "proceed") return value;
   }
 }
 
@@ -465,7 +465,7 @@ async function promptAndValidateRedisUrl(host: Host): Promise<string | undefined
  * executes here; the decided commands run in `applyRedisPlan`.
  */
 async function planRedisSetup(host: Host): Promise<RedisPlan | undefined> {
-  p.log.step(pc.bold("Redis / Valkey setup"));
+  log.step(bold("Redis / Valkey setup"));
 
   // Step 1: Is Redis/Valkey installed?
   const variant = await detectVariant(host);
@@ -475,23 +475,23 @@ async function planRedisSetup(host: Host): Promise<RedisPlan | undefined> {
 
     const pm = await detectPackageManager(host);
     if (pm) {
-      info("Package manager", `Detected ${pc.cyan(pm.name)}`);
+      info("Package manager", `Detected ${cyan(pm.name)}`);
 
       // Let user choose between Redis and Valkey
-      const variantChoice = await p.select({
+      const variantChoice = await select({
         message: "Which variant would you like to install?",
         options: [
           { value: "redis" as const, label: "Redis", hint: "the original" },
           { value: "valkey" as const, label: "Valkey", hint: "community fork, fully compatible" },
         ],
       });
-      if (p.isCancel(variantChoice)) return undefined;
+      if (isCancel(variantChoice)) return undefined;
 
-      const proceed = await p.confirm({
-        message: `Install ${variantChoice} using ${pc.cyan(pm.name)}?`,
+      const proceed = await confirm({
+        message: `Install ${variantChoice} using ${cyan(pm.name)}?`,
         initialValue: true,
       });
-      if (p.isCancel(proceed) || !proceed) return undefined;
+      if (isCancel(proceed) || !proceed) return undefined;
 
       const url = await configureRedisUrl();
       if (!url) return undefined;
@@ -542,10 +542,10 @@ async function planRedisSetup(host: Host): Promise<RedisPlan | undefined> {
 
 function describeRedisPlanDryRun(plan: RedisPlan): void {
   if (plan.provision?.installCmd) {
-    info("Dry run", `Would install ${plan.provision.variant}: ${pc.dim(plan.provision.installCmd)}`);
+    info("Dry run", `Would install ${plan.provision.variant}: ${dim(plan.provision.installCmd)}`);
   }
   if (plan.provision?.startCmd) {
-    info("Dry run", `Would start ${plan.provision.variant}: ${pc.dim(plan.provision.startCmd)}`);
+    info("Dry run", `Would start ${plan.provision.variant}: ${dim(plan.provision.startCmd)}`);
   }
   if (plan.persist) {
     info("Dry run", `Would store REDIS_URL in ${SECRETS_DIR}`);
@@ -564,7 +564,7 @@ export async function infraRedis(host: Host, dryRun: boolean): Promise<string | 
   const storedUrl = stored.secrets.REDIS_URL;
   if (storedUrl && (await testRedisWithSpinner(storedUrl, host)).success) {
     info("Redis connection", `Current: ${redactRedisUrl(storedUrl)}`);
-    const action = await p.select({
+    const action = await select({
       message: "Redis is configured and reachable.",
       options: [
         { value: "keep", label: "Keep current configuration" },
@@ -572,7 +572,7 @@ export async function infraRedis(host: Host, dryRun: boolean): Promise<string | 
         { value: "setup", label: "Set up a new Redis instance" },
       ],
     });
-    if (p.isCancel(action) || action === "keep") return storedUrl;
+    if (isCancel(action) || action === "keep") return storedUrl;
     if (action === "reenter") {
       const newUrl = await promptAndValidateRedisUrl(host);
       plan = newUrl ? { url: newUrl, persist: true } : undefined;

--- a/packages/xinity-cli/src/lib/redis-setup.ts
+++ b/packages/xinity-cli/src/lib/redis-setup.ts
@@ -1,12 +1,9 @@
 /**
- * Interactive Redis/Valkey setup assistant for `xinity up redis`.
+ * Redis/Valkey discovery and setup, split into planning and apply halves.
  *
- * Guides the user through detecting, installing, starting, and
- * configuring a Redis or Valkey instance for the gateway's caching
- * and load-balancing state.
- *
- * All shell operations go through the Host interface so this works
- * identically for local and remote (--target-host) execution.
+ * `planRedis` finds or asks for a connection URL and, when the user opts
+ * into setup, decides the install/start commands, all without changing the
+ * host. `applyRedisPlan` executes the decided commands and persists the URL.
  */
 import { randomBytes } from "crypto";
 import * as p from "./clack.ts";
@@ -131,79 +128,81 @@ function startCommandFor(variant: RedisVariant, pm: PackageManager | undefined):
   return pm?.start[variant] ?? SYSTEMD_START_FALLBACK[variant];
 }
 
-/** Try to start the Redis/Valkey service. */
-async function startRedis(
+// ─── Plan / apply model ─────────────────────────────────────────────────────
+
+export interface RedisProvision {
+  variant: RedisVariant;
+  installCmd?: string;
+  startCmd?: string;
+  /** brew and similar: commands run as the regular user, not root. */
+  userIsSuper: boolean;
+}
+
+export interface RedisPlan {
+  url: string;
+  /** Store the URL into the secrets dir during apply. */
+  persist: boolean;
+  provision?: RedisProvision;
+}
+
+async function runProvisionCommand(
   host: Host,
-  variant: RedisVariant,
-  pm: PackageManager | undefined,
-  dryRun: boolean,
+  prov: RedisProvision,
+  cmd: string,
+  label: string,
+  messages: { success: string; failed: string },
 ): Promise<boolean> {
-  const startCmd = startCommandFor(variant, pm);
-
-  if (dryRun) {
-    info("Dry run", `Would start ${variant}: ${pc.dim(startCmd)}`);
-    return true;
-  }
-
-  if (pm?.userIsSuper) {
-    const res = await host.run(["sh", "-c", startCmd]);
+  if (prov.userIsSuper) {
+    const res = await host.run(["sh", "-c", cmd]);
     if (res.ok) {
-      pass(variant, "Service started");
+      pass(label, messages.success);
       return true;
     }
-    fail(variant, "Failed to start service");
+    fail(label, res.output || messages.failed);
     return false;
   }
 
-  const result = await host.withElevation(startCmd, `Start ${variant}`);
-  return reportElevationOutcome(result, variant, {
-    success: "Service started",
-    skipped: "Skipped starting the service",
-    failed: result.output || "Failed to start service",
+  const result = await host.withElevation(cmd, label);
+  return reportElevationOutcome(result, label, {
+    success: messages.success,
+    failed: result.output || messages.failed,
   });
 }
 
-// ─── Install flow ───────────────────────────────────────────────────────────
-
-async function installRedis(
-  host: Host,
-  variant: RedisVariant,
-  pm: PackageManager,
-  dryRun: boolean,
-): Promise<boolean> {
-  const installCmd = pm.install[variant];
-
-  const proceed = await p.confirm({
-    message: `Install ${variant} using ${pc.cyan(pm.name)}?`,
-    initialValue: true,
-  });
-  if (p.isCancel(proceed) || !proceed) return false;
-
-  if (dryRun) {
-    info("Dry run", `Would install ${variant}: ${pc.dim(installCmd)}`);
-    return true;
-  }
-
-  if (pm.userIsSuper) {
-    const spinner = p.spinner();
-    spinner.start(`Installing ${variant} via ${pm.name}…`);
-    const res = await host.run(["sh", "-c", installCmd]);
-    if (!res.ok) {
-      spinner.stop("Failed");
-      fail("Install", res.output);
+/** Execute a decided redis plan: install/start when planned, then persist the URL. */
+export async function applyRedisPlan(plan: RedisPlan, host: Host): Promise<boolean> {
+  const prov = plan.provision;
+  if (prov) {
+    if (prov.installCmd && !(await runProvisionCommand(host, prov, prov.installCmd, `Install ${prov.variant}`, {
+      success: `${prov.variant} installed`,
+      failed: "Installation failed",
+    }))) {
       return false;
     }
-    spinner.stop(`${variant} installed`);
-    pass("Install", `${variant} installed via ${pm.name}`);
-    return true;
+    if (prov.startCmd && !(await runProvisionCommand(host, prov, prov.startCmd, `Start ${prov.variant}`, {
+      success: "Service started",
+      failed: "Failed to start service",
+    }))) {
+      return false;
+    }
+    await testRedisWithSpinner(plan.url, host);
   }
 
-  const result = await host.withElevation(installCmd, `Install ${variant}`);
-  return reportElevationOutcome(result, "Install", {
-    success: `${variant} installed`,
-    skipped: "Skipped installation",
-    failed: result.output || "Installation failed",
-  });
+  if (plan.persist) await persistRedisUrl(host, plan.url);
+  return true;
+}
+
+/** Review lines for the redis actions in an `up all` plan (empty when nothing will change). */
+export function describeRedisPlan(plan: RedisPlan): string[] {
+  const lines: string[] = [];
+  if (plan.provision?.installCmd) lines.push(`  install: ${plan.provision.installCmd}`);
+  if (plan.provision?.startCmd) lines.push(`  start: ${plan.provision.startCmd}`);
+  if (plan.persist) lines.push(`  store REDIS_URL in ${SECRETS_DIR}`);
+  if (lines.length === 0) return [];
+  const head = plan.provision
+    ? `Provision ${plan.provision.variant} and store the connection URL`
+    : "Store the Redis connection URL";
+  return [head, ...lines];
 }
 
 async function waitForManualInstall(host: Host): Promise<boolean> {
@@ -253,11 +252,8 @@ async function waitForManualInstall(host: Host): Promise<boolean> {
 
 // ─── Configuration ──────────────────────────────────────────────────────────
 
-/** Build a REDIS_URL from user input or defaults. */
-async function configureRedisUrl(
-  host: Host,
-  dryRun: boolean,
-): Promise<string | undefined> {
+/** Build a REDIS_URL from user input or defaults. Prompts only. */
+async function configureRedisUrl(): Promise<string | undefined> {
   p.log.step(pc.bold("Configure Redis connection"));
 
   const hostInput = await promptOrUndefined(p.text({
@@ -341,22 +337,17 @@ async function persistRedisUrl(host: Host, url: string): Promise<void> {
     `mkdir -p '${SECRETS_DIR}' && chmod 700 '${SECRETS_DIR}'` +
     ` && printf '%s' '${escaped}' > '${SECRETS_DIR}/REDIS_URL' && chmod 600 '${SECRETS_DIR}/REDIS_URL'`,
     "Store Redis connection URL",
-    { sensitive: true },
   );
 }
 
 /**
- * Discover REDIS_URL from stored secrets, environment, or component configs.
- * If no existing URL is found, guides the user through an interactive
- * setup that can detect, install, and configure Redis/Valkey automatically.
- * Persists the result to the secrets directory for future runs.
+ * Planning half: discover REDIS_URL from stored secrets, environment, or
+ * component configs, or guide the user to a URL (optionally deciding an
+ * install). Reads and prompts only; `applyRedisPlan` makes the changes.
  *
- * Returns a Redis URL if setup completed, or `undefined` if the user cancelled.
+ * Returns undefined if the user cancelled.
  */
-export async function discoverRedisUrl(
-  host: Host,
-  dryRun: boolean,
-): Promise<string | undefined> {
+export async function planRedis(host: Host): Promise<RedisPlan | undefined> {
   // 1. Check stored secret
   const stored = await readSecrets(host, SECRETS_DIR, ["REDIS_URL"], "Read stored Redis URL");
   if (stored.secrets.REDIS_URL) {
@@ -364,7 +355,7 @@ export async function discoverRedisUrl(
     info("Redis connection", `Found stored URL: ${redactRedisUrl(url)}`);
     const result = await testRedisWithSpinner(url, host);
     if (result.success) {
-      return url;
+      return { url, persist: false };
     }
 
     // Stored URL is stale, offer to reconfigure
@@ -377,26 +368,16 @@ export async function discoverRedisUrl(
       ],
     });
     if (p.isCancel(action)) { p.cancel("Cancelled."); return undefined; }
-    if (action === "keep") return url;
-    if (action === "setup") {
-      const newUrl = await redisSetup(host, dryRun);
-      if (newUrl) {
-        await testRedisWithSpinner(newUrl, host);
-        if (!dryRun) await persistRedisUrl(host, newUrl);
-      }
-      return newUrl;
-    }
-    // reenter: fall through to promptAndValidateRedisUrl below
+    if (action === "keep") return { url, persist: false };
+    if (action === "setup") return planRedisSetup(host);
     const newUrl = await promptAndValidateRedisUrl(host);
-    if (newUrl && !dryRun) await persistRedisUrl(host, newUrl);
-    return newUrl;
+    return newUrl ? { url: newUrl, persist: true } : undefined;
   }
 
   // 2. Check environment variable
   if (process.env.REDIS_URL) {
     info("Redis connection", "Using REDIS_URL from environment");
-    if (!dryRun) await persistRedisUrl(host, process.env.REDIS_URL);
-    return process.env.REDIS_URL;
+    return { url: process.env.REDIS_URL, persist: true };
   }
 
   // 3. Check installed component env files on the target host
@@ -408,8 +389,7 @@ export async function discoverRedisUrl(
         const env = parseEnvString(content);
         if (env.REDIS_URL) {
           info("Redis connection", `Found in ${component}.env`);
-          if (!dryRun) await persistRedisUrl(host, env.REDIS_URL);
-          return env.REDIS_URL;
+          return { url: env.REDIS_URL, persist: true };
         }
       }
     }
@@ -437,19 +417,11 @@ export async function discoverRedisUrl(
     return undefined;
   }
 
-  if (choice === "setup") {
-    const url = await redisSetup(host, dryRun);
-    if (url) {
-      await testRedisWithSpinner(url, host);
-      if (!dryRun) await persistRedisUrl(host, url);
-    }
-    return url;
-  }
+  if (choice === "setup") return planRedisSetup(host);
 
   // Existing instance, prompt for URL then validate connectivity
   const url = await promptAndValidateRedisUrl(host);
-  if (url && !dryRun) await persistRedisUrl(host, url);
-  return url;
+  return url ? { url, persist: true } : undefined;
 }
 
 /**
@@ -488,11 +460,11 @@ async function promptAndValidateRedisUrl(host: Host): Promise<string | undefined
 }
 
 /**
- * Interactive Redis/Valkey setup flow.
- *
- * Returns a REDIS_URL if setup completed, or `undefined` if the user cancelled.
+ * Interactive setup planning: detect what is installed and running, decide
+ * the install/start commands, and prompt for the connection details. Nothing
+ * executes here; the decided commands run in `applyRedisPlan`.
  */
-export async function redisSetup(host: Host, dryRun: boolean): Promise<string | undefined> {
+async function planRedisSetup(host: Host): Promise<RedisPlan | undefined> {
   p.log.step(pc.bold("Redis / Valkey setup"));
 
   // Step 1: Is Redis/Valkey installed?
@@ -515,81 +487,107 @@ export async function redisSetup(host: Host, dryRun: boolean): Promise<string | 
       });
       if (p.isCancel(variantChoice)) return undefined;
 
-      const installed = await installRedis(host, variantChoice, pm, dryRun);
-      if (!installed) return undefined;
+      const proceed = await p.confirm({
+        message: `Install ${variantChoice} using ${pc.cyan(pm.name)}?`,
+        initialValue: true,
+      });
+      if (p.isCancel(proceed) || !proceed) return undefined;
 
-      const started = await startRedis(host, variantChoice, pm, dryRun);
-      if (!started) return undefined;
-
-      return configureRedisUrl(host, dryRun);
+      const url = await configureRedisUrl();
+      if (!url) return undefined;
+      return {
+        url,
+        persist: true,
+        provision: {
+          variant: variantChoice,
+          installCmd: pm.install[variantChoice],
+          startCmd: pm.start[variantChoice],
+          userIsSuper: pm.userIsSuper,
+        },
+      };
     }
 
-    // Unknown package manager
+    // Unknown package manager: the user installs by hand, we only verify.
     warn("Package manager", "Could not detect a supported package manager");
-    if (dryRun) {
-      info("Dry run", "Would ask user to install Redis/Valkey manually");
-      return configureRedisUrl(host, dryRun);
-    }
     const ready = await waitForManualInstall(host);
     if (!ready) return undefined;
 
-    return configureRedisUrl(host, dryRun);
+    const url = await configureRedisUrl();
+    return url ? { url, persist: true } : undefined;
   }
 
   // Step 2: Redis/Valkey is installed, is it running?
   if (await isRedisRunning(host)) {
     pass(variant, "Installed and running");
-    return configureRedisUrl(host, dryRun);
+    const url = await configureRedisUrl();
+    return url ? { url, persist: true } : undefined;
   }
 
   // Installed but not running
-  warn(variant, "Installed but not running");
+  warn(variant, "Installed but not running (will be started on apply)");
 
   const pm = await detectPackageManager(host);
-  const started = await startRedis(host, variant, pm, dryRun);
-  if (!started) return undefined;
+  const url = await configureRedisUrl();
+  if (!url) return undefined;
+  return {
+    url,
+    persist: true,
+    provision: {
+      variant,
+      startCmd: startCommandFor(variant, pm),
+      userIsSuper: pm?.userIsSuper ?? false,
+    },
+  };
+}
 
-  return configureRedisUrl(host, dryRun);
+function describeRedisPlanDryRun(plan: RedisPlan): void {
+  if (plan.provision?.installCmd) {
+    info("Dry run", `Would install ${plan.provision.variant}: ${pc.dim(plan.provision.installCmd)}`);
+  }
+  if (plan.provision?.startCmd) {
+    info("Dry run", `Would start ${plan.provision.variant}: ${pc.dim(plan.provision.startCmd)}`);
+  }
+  if (plan.persist) {
+    info("Dry run", `Would store REDIS_URL in ${SECRETS_DIR}`);
+  }
 }
 
 /**
- * Entry point for `xinity up infra-redis`. If a working connection already
- * exists, offers to keep it or reconfigure. Otherwise falls through to the
- * normal discovery flow.
+ * Entry point for `xinity up infra-redis`: plan, then immediately apply (or
+ * describe, on dry runs). If a working connection already exists, offers to
+ * keep it or reconfigure.
  */
 export async function infraRedis(host: Host, dryRun: boolean): Promise<string | undefined> {
+  let plan: RedisPlan | undefined;
+
   const stored = await readSecrets(host, SECRETS_DIR, ["REDIS_URL"], "Read stored Redis URL");
-  if (stored.secrets.REDIS_URL) {
-    const url = stored.secrets.REDIS_URL;
-    const result = await testRedisWithSpinner(url, host);
-
-    if (result.success) {
-      info("Redis connection", `Current: ${redactRedisUrl(url)}`);
-      const action = await p.select({
-        message: "Redis is configured and reachable.",
-        options: [
-          { value: "keep", label: "Keep current configuration" },
-          { value: "reenter", label: "Enter a different URL" },
-          { value: "setup", label: "Set up a new Redis instance" },
-        ],
-      });
-      if (p.isCancel(action) || action === "keep") return url;
-      if (action === "reenter") {
-        const newUrl = await promptAndValidateRedisUrl(host);
-        if (newUrl && !dryRun) await persistRedisUrl(host, newUrl);
-        return newUrl;
-      }
-      // setup: fall through to full setup
-      const newUrl = await redisSetup(host, dryRun);
-      if (newUrl) {
-        await testRedisWithSpinner(newUrl, host);
-        if (!dryRun) await persistRedisUrl(host, newUrl);
-      }
-      return newUrl;
+  const storedUrl = stored.secrets.REDIS_URL;
+  if (storedUrl && (await testRedisWithSpinner(storedUrl, host)).success) {
+    info("Redis connection", `Current: ${redactRedisUrl(storedUrl)}`);
+    const action = await p.select({
+      message: "Redis is configured and reachable.",
+      options: [
+        { value: "keep", label: "Keep current configuration" },
+        { value: "reenter", label: "Enter a different URL" },
+        { value: "setup", label: "Set up a new Redis instance" },
+      ],
+    });
+    if (p.isCancel(action) || action === "keep") return storedUrl;
+    if (action === "reenter") {
+      const newUrl = await promptAndValidateRedisUrl(host);
+      plan = newUrl ? { url: newUrl, persist: true } : undefined;
+    } else {
+      plan = await planRedisSetup(host);
     }
-
-    // Stored but not reachable, delegate to the stale-URL flow in discoverRedisUrl
+  } else {
+    // No stored URL, or stored but unreachable: planRedis owns the stale-URL flow.
+    plan = await planRedis(host);
   }
 
-  return discoverRedisUrl(host, dryRun);
+  if (!plan) return undefined;
+  if (dryRun) {
+    describeRedisPlanDryRun(plan);
+    return plan.url;
+  }
+  return (await applyRedisPlan(plan, host)) ? plan.url : undefined;
 }

--- a/packages/xinity-cli/src/lib/remote-host.ts
+++ b/packages/xinity-cli/src/lib/remote-host.ts
@@ -37,6 +37,23 @@ const FIRST_PRINTABLE_ASCII = 0x20;
 
 const DEFAULT_REDIS_PORT = "6379";
 const DEFAULT_POSTGRES_PORT = "5432";
+const DEFAULT_SMTP_PORT = "587";
+
+function defaultPortForProtocol(protocol: string): string {
+  switch (protocol) {
+    case "postgresql:":
+    case "postgres:":
+      return DEFAULT_POSTGRES_PORT;
+    case "redis:":
+    case "rediss:":
+      return DEFAULT_REDIS_PORT;
+    case "smtp:":
+    case "smtps:":
+      return DEFAULT_SMTP_PORT;
+    default:
+      throw new Error(`No default port for protocol "${protocol}"; specify an explicit port in the URL`);
+  }
+}
 
 /**
  * Read a password from the terminal with echo fully disabled.
@@ -383,7 +400,7 @@ export class RemoteHost implements Host {
     }
     const parsed = new URL(url);
     const remoteHost = parsed.hostname;
-    const remotePort = parsed.port || (parsed.protocol === "redis:" ? DEFAULT_REDIS_PORT : DEFAULT_POSTGRES_PORT);
+    const remotePort = parsed.port || defaultPortForProtocol(parsed.protocol);
 
     // SSH local-port forwarding needs us to pick a free local port before opening
     // the tunnel; SSH can pick one with "-L 0:..." but doesn't surface which port

--- a/packages/xinity-cli/src/lib/remote-host.ts
+++ b/packages/xinity-cli/src/lib/remote-host.ts
@@ -1,6 +1,6 @@
 import { createServer } from "net";
 import { hostname as osHostname } from "os";
-import { localRun, buildElevationMenu, confirmManualRun, type Host, type RunResult, type ElevationResult, type ElevationPolicy } from "./host.ts";
+import { localRun, type Host, type RunResult, type ElevationResult } from "./host.ts";
 import * as p from "./clack.ts";
 import pc from "picocolors";
 import { SudoSession, checkPasswordlessSudo } from "./sudo-session.ts";
@@ -147,7 +147,7 @@ export class RemoteHost implements Host {
 
   private sudoSession: SudoSession | null = null;
   private isRootCached: boolean | null = null;
-  private elevationPolicy: ElevationPolicy = null;
+  private elevationDenied = false;
 
   constructor(hostname: string) {
     this.hostname = hostname;
@@ -188,58 +188,39 @@ export class RemoteHost implements Host {
     return localRun(["ssh", ...this.ctrlArgs, this.hostname, command]);
   }
 
-  async withElevation(command: string, description: string, options?: { sensitive?: boolean }): Promise<ElevationResult> {
-    const sensitive = options?.sensitive ?? false;
-
+  private async isRoot(): Promise<boolean> {
     // Cache the root check so we don't run `id -u` on every call.
     if (this.isRootCached === null) {
       const whoami = await localRun(["ssh", ...this.ctrlArgs, this.hostname, "id -u"]);
       this.isRootCached = whoami.ok && whoami.output.trim() === "0";
     }
+    return this.isRootCached;
+  }
 
-    if (this.isRootCached) {
+  async prepareElevation(): Promise<boolean> {
+    if (await this.isRoot()) return true;
+    if (this.sudoSession?.isAlive) return true;
+    if (this.elevationDenied) return false;
+    p.log.info(pc.dim(`Root privileges on ${this.hostname} are required to inspect and configure it.`));
+    return (await this.ensureSudoSessionAndExecute("true")).success;
+  }
+
+  async withElevation(command: string, description: string): Promise<ElevationResult> {
+    if (await this.isRoot()) {
       const b64 = b64Cmd(command);
       const result = await localRun([
         "ssh", ...this.ctrlArgs, this.hostname,
         `echo '${b64}' | base64 -d | sh`,
       ]);
-      return { success: result.ok, output: result.output, skipped: false };
+      return { success: result.ok, output: result.output };
     }
 
-    // Apply remembered policy if set.
-    if (this.elevationPolicy === "sudo") {
-      p.log.step(pc.dim(description));
-      return this.executeViaSudoSession(command);
-    }
-    if (this.elevationPolicy === "manual" && !sensitive) {
-      p.log.step(pc.dim(description));
-      this.showManualCommand(command);
-      return confirmManualRun();
+    if (this.elevationDenied) {
+      return { success: false, output: "sudo authentication was declined" };
     }
 
-    // First time (or sensitive command with manual policy): show menu.
-    const action = await p.select({
-      message: `${pc.yellow(description)} requires elevated privileges on ${pc.cyan(this.hostname)}.`,
-      options: buildElevationMenu(sensitive),
-    });
-
-    if (p.isCancel(action)) {
-      p.cancel("Cancelled.");
-      return { success: false, output: "", skipped: true };
-    }
-
-    if (action === "sudo-all" || action === "sudo-once") {
-      if (action === "sudo-all") this.elevationPolicy = "sudo";
-      return this.ensureSudoSessionAndExecute(command);
-    }
-
-    if (action === "manual-all" || action === "manual-once") {
-      if (action === "manual-all") this.elevationPolicy = "manual";
-      this.showManualCommand(command);
-      return confirmManualRun();
-    }
-
-    return { success: false, output: "", skipped: true };
+    p.log.step(pc.dim(description));
+    return this.ensureSudoSessionAndExecute(command);
   }
 
   async dispose(): Promise<void> {
@@ -264,8 +245,8 @@ export class RemoteHost implements Host {
           p.log.success("Passwordless sudo detected.");
         } catch (err) {
           p.log.warn(`Failed to establish sudo session: ${(err as Error).message}`);
-          this.elevationPolicy = null;
-          return { success: false, output: "", skipped: false };
+          this.elevationDenied = true;
+          return { success: false, output: "" };
         }
       } else {
         // Prompt for password with up to 3 attempts. The fixed-length mask
@@ -279,7 +260,8 @@ export class RemoteHost implements Host {
           );
           if (input === null) {
             p.cancel("Cancelled.");
-            return { success: false, output: "", skipped: true };
+            this.elevationDenied = true;
+            return { success: false, output: "" };
           }
 
           try {
@@ -289,8 +271,8 @@ export class RemoteHost implements Host {
           } catch {
             if (attempt === MAX_ATTEMPTS) {
               p.log.error(`Failed to authenticate after ${MAX_ATTEMPTS} attempts.`);
-              this.elevationPolicy = null;
-              return { success: false, output: "", skipped: false };
+              this.elevationDenied = true;
+              return { success: false, output: "" };
             }
           }
         }
@@ -308,20 +290,12 @@ export class RemoteHost implements Host {
 
     try {
       const { exitCode, output } = await this.sudoSession.execute(command);
-      return { success: exitCode === 0, output, skipped: false };
+      return { success: exitCode === 0, output };
     } catch (err) {
       p.log.warn(`Sudo session error: ${(err as Error).message}`);
       this.sudoSession = null;
-      return { success: false, output: "", skipped: false };
+      return { success: false, output: "" };
     }
-  }
-
-  private showManualCommand(command: string): void {
-    const b64 = b64Cmd(command);
-    p.log.info(
-      `Run manually on ${pc.cyan(this.hostname)}:\n  ${pc.cyan(`echo '${b64}' | base64 -d | sudo sh`)}`,
-    );
-    p.log.info(`Or the equivalent plain command:\n  ${pc.dim(command.replace(/\n/g, "\n  "))}`);
   }
 
   async readFile(path: string): Promise<string | null> {

--- a/packages/xinity-cli/src/lib/remote-host.ts
+++ b/packages/xinity-cli/src/lib/remote-host.ts
@@ -1,6 +1,6 @@
 import { createServer } from "net";
 import { hostname as osHostname } from "os";
-import { localRun, type Host, type RunResult, type ElevationResult } from "./host.ts";
+import { localRun, type Host, type RunResult, type ElevationResult, type TunnelResult } from "./host.ts";
 import { cancel, log } from "./clack.ts";
 import { cyan, dim } from "picocolors";
 import { SudoSession, checkPasswordlessSudo } from "./sudo-session.ts";
@@ -394,11 +394,16 @@ export class RemoteHost implements Host {
     return raw;
   }
 
-  async openTunnel(url: string): Promise<{ localUrl: string; close: () => Promise<void> }> {
+  async openTunnel(url: string): Promise<TunnelResult> {
     if (this.isLocalhost) {
-      return { localUrl: url, close: async () => {} };
+      return { ok: true, localUrl: url, close: async () => {} };
     }
-    const parsed = new URL(url);
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
+      return { ok: false, error: `Invalid URL: ${url}` };
+    }
     const remoteHost = parsed.hostname;
     const remotePort = parsed.port || defaultPortForProtocol(parsed.protocol);
 
@@ -418,7 +423,7 @@ export class RemoteHost implements Host {
     ]);
 
     if (!fwdResult.ok) {
-      throw new Error(`SSH tunnel failed: ${fwdResult.output}`);
+      return { ok: false, error: `SSH tunnel failed: ${fwdResult.output}` };
     }
 
     // Rewrite the URL to point at the local forwarded port
@@ -428,6 +433,7 @@ export class RemoteHost implements Host {
     const localUrl = localParsed.toString();
 
     return {
+      ok: true,
       localUrl,
       close: async () => {
         // Cancel the specific forwarding via the control socket

--- a/packages/xinity-cli/src/lib/remote-host.ts
+++ b/packages/xinity-cli/src/lib/remote-host.ts
@@ -1,8 +1,8 @@
 import { createServer } from "net";
 import { hostname as osHostname } from "os";
 import { localRun, type Host, type RunResult, type ElevationResult } from "./host.ts";
-import * as p from "./clack.ts";
-import pc from "picocolors";
+import { cancel, log } from "./clack.ts";
+import { cyan, dim } from "picocolors";
 import { SudoSession, checkPasswordlessSudo } from "./sudo-session.ts";
 import { quoteShellArg, quoteShellArgv } from "common-env";
 
@@ -201,7 +201,7 @@ export class RemoteHost implements Host {
     if (await this.isRoot()) return true;
     if (this.sudoSession?.isAlive) return true;
     if (this.elevationDenied) return false;
-    p.log.info(pc.dim(`Root privileges on ${this.hostname} are required to inspect and configure it.`));
+    log.info(dim(`Root privileges on ${this.hostname} are required to inspect and configure it.`));
     return (await this.ensureSudoSessionAndExecute("true")).success;
   }
 
@@ -219,7 +219,7 @@ export class RemoteHost implements Host {
       return { success: false, output: "sudo authentication was declined" };
     }
 
-    p.log.step(pc.dim(description));
+    log.step(dim(description));
     return this.ensureSudoSessionAndExecute(command);
   }
 
@@ -242,9 +242,9 @@ export class RemoteHost implements Host {
       if (passwordless) {
         try {
           this.sudoSession = await SudoSession.create(this.ctrlArgs, this.hostname, "");
-          p.log.success("Passwordless sudo detected.");
+          log.success("Passwordless sudo detected.");
         } catch (err) {
-          p.log.warn(`Failed to establish sudo session: ${(err as Error).message}`);
+          log.warn(`Failed to establish sudo session: ${(err as Error).message}`);
           this.elevationDenied = true;
           return { success: false, output: "" };
         }
@@ -255,22 +255,22 @@ export class RemoteHost implements Host {
         for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
           const input = await readSudoPassword(
             attempt === 1
-              ? `Sudo password for ${pc.cyan(this.hostname)}: `
+              ? `Sudo password for ${cyan(this.hostname)}: `
               : `Wrong password. Try again (${attempt}/${MAX_ATTEMPTS}): `,
           );
           if (input === null) {
-            p.cancel("Cancelled.");
+            cancel("Cancelled.");
             this.elevationDenied = true;
             return { success: false, output: "" };
           }
 
           try {
             this.sudoSession = await SudoSession.create(this.ctrlArgs, this.hostname, input);
-            p.log.success("Sudo session established.");
+            log.success("Sudo session established.");
             break;
           } catch {
             if (attempt === MAX_ATTEMPTS) {
-              p.log.error(`Failed to authenticate after ${MAX_ATTEMPTS} attempts.`);
+              log.error(`Failed to authenticate after ${MAX_ATTEMPTS} attempts.`);
               this.elevationDenied = true;
               return { success: false, output: "" };
             }
@@ -292,7 +292,7 @@ export class RemoteHost implements Host {
       const { exitCode, output } = await this.sudoSession.execute(command);
       return { success: exitCode === 0, output };
     } catch (err) {
-      p.log.warn(`Sudo session error: ${(err as Error).message}`);
+      log.warn(`Sudo session error: ${(err as Error).message}`);
       this.sudoSession = null;
       return { success: false, output: "" };
     }
@@ -419,12 +419,18 @@ export class RemoteHost implements Host {
   }
 }
 
+/** yargs descriptor for the single-host selector, declared per command that supports it. */
+export const TARGET_HOST_OPTION = {
+  describe: "SSH host to operate on (any valid ssh bind_address or host alias)",
+  type: "string",
+} as const;
+
 export async function connectHost(hostname?: string): Promise<RemoteHost> {
   const target = hostname || "localhost";
   const host = new RemoteHost(target);
   await host.connect();
   if (hostname) {
-    p.log.success(`Connected to ${pc.cyan(target)}`);
+    log.success(`Connected to ${cyan(target)}`);
   }
   return host;
 }

--- a/packages/xinity-cli/src/lib/remote-host.ts
+++ b/packages/xinity-cli/src/lib/remote-host.ts
@@ -59,7 +59,7 @@ async function readSudoPassword(prompt: string): Promise<string | null> {
     }
     process.stdin.resume();
 
-    let buf = "";
+    const rawBytes: number[] = [];
     let resolved = false;
 
     const finish = (value: string | null) => {
@@ -80,12 +80,18 @@ async function readSudoPassword(prompt: string): Promise<string | null> {
           return finish(null);
         }
         if (byte === CARRIAGE_RETURN || byte === LINE_FEED) {
-          return finish(buf);
+          return finish(Buffer.from(rawBytes).toString("utf-8"));
         }
         if (byte === DEL || byte === BACKSPACE) {
-          buf = buf.slice(0, -1);
+          // Pop one UTF-8 character: strip continuation bytes (10xxxxxx), then the leading byte
+          while (rawBytes.length > 0 && (rawBytes[rawBytes.length - 1]! & 0xC0) === 0x80) {
+            rawBytes.pop();
+          }
+          if (rawBytes.length > 0) {
+            rawBytes.pop();
+          }
         } else if (byte >= FIRST_PRINTABLE_ASCII) {
-          buf += String.fromCharCode(byte);
+          rawBytes.push(byte);
         }
       }
     };

--- a/packages/xinity-cli/src/lib/remote-host.ts
+++ b/packages/xinity-cli/src/lib/remote-host.ts
@@ -1,5 +1,6 @@
 import { createServer } from "net";
-import { localRun, localRunInteractive, buildElevationMenu, confirmManualRun, type Host, type RunResult, type ElevationResult, type ElevationPolicy } from "./host.ts";
+import { hostname as osHostname } from "os";
+import { localRun, buildElevationMenu, confirmManualRun, type Host, type RunResult, type ElevationResult, type ElevationPolicy } from "./host.ts";
 import * as p from "./clack.ts";
 import pc from "picocolors";
 import { SudoSession, checkPasswordlessSudo } from "./sudo-session.ts";
@@ -125,11 +126,23 @@ function b64Cmd(command: string): string {
   return Buffer.from(command).toString("base64");
 }
 
+const LOCALHOST_NAMES = new Set(["localhost", "127.0.0.1", "::1"]);
+
+function detectLocalhost(hostname: string): boolean {
+  if (LOCALHOST_NAMES.has(hostname)) {
+    return true;
+  }
+  try {
+    return hostname === osHostname();
+  } catch {
+    return false;
+  }
+}
+
 export class RemoteHost implements Host {
-  readonly isRemote = true;
   private readonly hostname: string;
+  private readonly isLocalhost: boolean;
   private readonly socket: string;
-  /** SSH args that enable ControlMaster reuse. Inserted before the host. */
   private readonly ctrlArgs: string[];
 
   private sudoSession: SudoSession | null = null;
@@ -138,6 +151,7 @@ export class RemoteHost implements Host {
 
   constructor(hostname: string) {
     this.hostname = hostname;
+    this.isLocalhost = detectLocalhost(hostname);
     this.socket = socketPath(hostname);
     this.ctrlArgs = [
       "-o", "ControlMaster=auto",
@@ -330,6 +344,9 @@ export class RemoteHost implements Host {
   }
 
   async uploadFile(localPath: string, destPath: string): Promise<string> {
+    if (this.isLocalhost) {
+      return localPath;
+    }
     const result = await localRun([
       "scp",
       "-o", `ControlPath=${this.socket}`,
@@ -381,6 +398,9 @@ export class RemoteHost implements Host {
   }
 
   async openTunnel(url: string): Promise<{ localUrl: string; close: () => Promise<void> }> {
+    if (this.isLocalhost) {
+      return { localUrl: url, close: async () => {} };
+    }
     const parsed = new URL(url);
     const remoteHost = parsed.hostname;
     const remotePort = parsed.port || (parsed.protocol === "redis:" ? DEFAULT_REDIS_PORT : DEFAULT_POSTGRES_PORT);
@@ -425,9 +445,12 @@ export class RemoteHost implements Host {
   }
 }
 
-export async function connectRemoteHost(hostname: string): Promise<RemoteHost> {
-  const remote = new RemoteHost(hostname);
-  await remote.connect();
-  p.log.success(`Connected to ${pc.cyan(hostname)}`);
-  return remote;
+export async function connectHost(hostname?: string): Promise<RemoteHost> {
+  const target = hostname || "localhost";
+  const host = new RemoteHost(target);
+  await host.connect();
+  if (hostname) {
+    p.log.success(`Connected to ${pc.cyan(target)}`);
+  }
+  return host;
 }

--- a/packages/xinity-cli/src/lib/remote-probe.ts
+++ b/packages/xinity-cli/src/lib/remote-probe.ts
@@ -134,8 +134,6 @@ function buildProbeScript(
  */
 export function createCachedHost(realHost: Host, state: RemoteState): Host {
   return {
-    isRemote: realHost.isRemote,
-
     run(args: string[]): Promise<RunResult> {
       // Intercept `systemctl is-active <unit>` and `uname -s`
       if (args[0] === "systemctl" && args[1] === "is-active" && args[2]) {

--- a/packages/xinity-cli/src/lib/remote-probe.ts
+++ b/packages/xinity-cli/src/lib/remote-probe.ts
@@ -183,6 +183,7 @@ export function createCachedHost(realHost: Host, state: RemoteState): Host {
     },
 
     withElevation: realHost.withElevation.bind(realHost),
+    prepareElevation: realHost.prepareElevation.bind(realHost),
     uploadFile: realHost.uploadFile.bind(realHost),
     downloadFile: realHost.downloadFile.bind(realHost),
     verifySha256: realHost.verifySha256.bind(realHost),

--- a/packages/xinity-cli/src/lib/search-list.ts
+++ b/packages/xinity-cli/src/lib/search-list.ts
@@ -55,6 +55,28 @@ function strip(text: string): string {
 // removes them together with the trailing newline the prompt base emits.
 const ERASE_FINAL_FRAME = "\x1b[1A\x1b[J";
 
+/**
+ * Shared submit/cancel frame; null while the prompt is still active.
+ * Cancel messaging belongs to the caller; announcing it here too would
+ * read as two cancellations.
+ */
+function settledFrame(
+  state: string,
+  opts: { message: string; transient?: boolean },
+  summary: () => string,
+): string | null {
+  if (state !== "cancel" && state !== "submit") {
+    return null;
+  }
+  if (opts.transient) {
+    return dim("◇");
+  }
+  if (state === "cancel") {
+    return `${dim("◇")}  ${opts.message}`;
+  }
+  return `${dim("◇")}  ${opts.message}\n${dim(S_BAR)}  ${dim(summary())}`;
+}
+
 async function eraseWhenTransient<T>(result: Promise<T>, transient: boolean | undefined): Promise<T> {
   const value = await result;
   if (transient) {
@@ -108,9 +130,10 @@ function run<Value>(opts: {
   let cursor = 0;
 
   // Filtering runs on every keystroke and render; precompute the searchable
-  // text once and reuse one filtered array per query value.
+  // text once and reuse one filtered array per query value. Only string
+  // values add search text; objects would all match "object".
   const searchable = opts.options.map(
-    (o) => `${strip(o.label)} ${o.hint ?? ""} ${String(o.value)}`.toLowerCase(),
+    (o) => `${strip(o.label)} ${o.hint ?? ""} ${typeof o.value === "string" ? o.value : ""}`.toLowerCase(),
   );
   let filteredCache = opts.options;
   let filteredForQuery = "";
@@ -210,19 +233,11 @@ function run<Value>(opts: {
     const state = prompt.state;
     const list = filtered();
 
-    // Cancel messaging belongs to the caller; announcing it here too would
-    // read as two cancellations.
-    if (state === "cancel" || state === "submit") {
-      if (opts.transient) {
-        return dim("◇");
-      }
-      if (state === "cancel") {
-        return `${dim("◇")}  ${opts.message}`;
-      }
-      const summary = opts.multiple
-        ? dim(`${selected.size} selected`)
-        : dim(strip(opts.options.find((o) => o.value === currentValue())?.label ?? ""));
-      return `${dim("◇")}  ${opts.message}\n${dim(S_BAR)}  ${summary}`;
+    const settled = settledFrame(state, opts, () => opts.multiple
+      ? `${selected.size} selected`
+      : strip(opts.options.find((o) => o.value === currentValue())?.label ?? ""));
+    if (settled !== null) {
+      return settled;
     }
 
     const symbol = state === "error" ? yellow("▲") : cyan("◆");
@@ -273,16 +288,9 @@ export function listSelect<Value>(opts: ListSelectOptions<Value>): Promise<Value
   const prompt = new Prompt<Value>({
     output: OUT,
     render: () => {
-      const state = prompt.state;
-      if (state === "cancel" || state === "submit") {
-        if (opts.transient) {
-          return dim("◇");
-        }
-        if (state === "cancel") {
-          return `${dim("◇")}  ${opts.message}`;
-        }
-        const label = strip(opts.options[cursor]?.label ?? "");
-        return `${dim("◇")}  ${opts.message}\n${dim(S_BAR)}  ${dim(label)}`;
+      const settled = settledFrame(prompt.state, opts, () => strip(opts.options[cursor]?.label ?? ""));
+      if (settled !== null) {
+        return settled;
       }
       return [
         `${cyan("◆")}  ${opts.message}`,

--- a/packages/xinity-cli/src/lib/search-list.ts
+++ b/packages/xinity-cli/src/lib/search-list.ts
@@ -1,12 +1,19 @@
 /**
- * Searchable list prompts with two explicit focus zones: a search bar and
- * the option list. Typing only ever edits the search while it is focused;
- * Down (or Tab) moves focus into the list, where arrows navigate, space
- * toggles (multiselect), and printable keys do nothing. Up from the first
- * row returns to the search bar.
+ * List prompts built on @clack/core's Prompt base, which supplies raw-mode
+ * input, frame diffing, and cancel handling; the key model and rendering
+ * live here.
  *
- * Built on @clack/core's Prompt base, which supplies raw-mode input, frame
- * diffing, and cancel handling; the key model and rendering live here.
+ * searchSelect/searchMultiselect have two explicit focus zones: a search bar
+ * and the option list. Typing only ever edits the search while it is focused;
+ * Down (or Tab) moves focus into the list, where arrows navigate, space
+ * toggles (multiselect), and printable keys do nothing. Navigation wraps:
+ * Up from the search bar lands on the last row, Down from the last row
+ * returns to the search bar.
+ *
+ * listSelect is a plain wrap-around select in the same visual style.
+ *
+ * Transient prompts erase themselves after resolving, so menu loops render
+ * in place instead of accumulating a line per selection in the scrollback.
  */
 import { Prompt } from "@clack/core";
 import { cyan, dim, green, inverse, yellow } from "picocolors";
@@ -22,9 +29,13 @@ interface SharedOptions<Value> {
   options: SearchListOption<Value>[];
   /** Rows visible at once; overflow is windowed with "… n more" markers. */
   maxItems?: number;
+  /** Erase the prompt once it resolves instead of leaving a summary line. */
+  transient?: boolean;
 }
 
 export type SearchSelectOptions<Value> = SharedOptions<Value>;
+
+export type ListSelectOptions<Value> = SharedOptions<Value>;
 
 export interface SearchMultiselectOptions<Value> extends SharedOptions<Value> {
   initialValues?: Value[];
@@ -40,10 +51,52 @@ function strip(text: string): string {
   return text.replace(/\[[0-9;]*m/g, "");
 }
 
+// Transient final frames are exactly one line; one row up plus erase-down
+// removes them together with the trailing newline the prompt base emits.
+const ERASE_FINAL_FRAME = "\x1b[1A\x1b[J";
+
+async function eraseWhenTransient<T>(result: Promise<T>, transient: boolean | undefined): Promise<T> {
+  const value = await result;
+  if (transient) {
+    OUT.write(ERASE_FINAL_FRAME);
+  }
+  return value;
+}
+
+function listRows<Value>(
+  bar: string,
+  list: SearchListOption<Value>[],
+  cursor: number,
+  maxItems: number,
+  marker: (option: SearchListOption<Value>, isCursor: boolean) => string,
+): string[] {
+  const windowStart = Math.max(0, Math.min(
+    Math.max(0, cursor) - Math.floor(maxItems / 2),
+    list.length - maxItems,
+  ));
+  const windowEnd = Math.min(list.length, windowStart + maxItems);
+  const rows: string[] = [];
+  if (windowStart > 0) {
+    rows.push(`${bar}  ${dim(`… ${windowStart} more`)}`);
+  }
+  for (let i = windowStart; i < windowEnd; i++) {
+    const option = list[i]!;
+    const isCursor = i === cursor;
+    const pointer = isCursor ? cyan("❯") : " ";
+    const hint = option.hint && isCursor ? ` ${dim(`(${option.hint})`)}` : "";
+    rows.push(`${bar}  ${pointer} ${marker(option, isCursor)} ${option.label}${hint}`);
+  }
+  if (windowEnd < list.length) {
+    rows.push(`${bar}  ${dim(`… ${list.length - windowEnd} more`)}`);
+  }
+  return rows;
+}
+
 function run<Value>(opts: {
   message: string;
   options: SearchListOption<Value>[];
   maxItems?: number;
+  transient?: boolean;
   multiple: boolean;
   initialValues?: Value[];
   required?: boolean;
@@ -71,7 +124,9 @@ function run<Value>(opts: {
   };
 
   const currentValue = () => {
-    if (opts.multiple) return [...selected];
+    if (opts.multiple) {
+      return [...selected];
+    }
     const list = filtered();
     return (mode === "list" ? list[cursor] : list[0])?.value;
   };
@@ -103,9 +158,14 @@ function run<Value>(opts: {
         cursor = 0;
       } else if (cursor < list.length - 1) {
         cursor++;
+      } else {
+        mode = "search";
       }
     } else if (direction === "up" || direction === "left") {
-      if (mode === "list" && cursor === 0) {
+      if (mode === "search" && list.length > 0) {
+        mode = "list";
+        cursor = list.length - 1;
+      } else if (mode === "list" && cursor === 0) {
         mode = "search";
       } else if (mode === "list") {
         cursor--;
@@ -130,7 +190,9 @@ function run<Value>(opts: {
       sync();
       return;
     }
-    if (mode !== "search") return;
+    if (mode !== "search") {
+      return;
+    }
     if (key?.name === "backspace") {
       query = query.slice(0, -1);
       cursor = 0;
@@ -150,10 +212,13 @@ function run<Value>(opts: {
 
     // Cancel messaging belongs to the caller; announcing it here too would
     // read as two cancellations.
-    if (state === "cancel") {
-      return `${dim("◇")}  ${opts.message}`;
-    }
-    if (state === "submit") {
+    if (state === "cancel" || state === "submit") {
+      if (opts.transient) {
+        return dim("◇");
+      }
+      if (state === "cancel") {
+        return `${dim("◇")}  ${opts.message}`;
+      }
       const summary = opts.multiple
         ? dim(`${selected.size} selected`)
         : dim(strip(opts.options.find((o) => o.value === currentValue())?.label ?? ""));
@@ -172,28 +237,11 @@ function run<Value>(opts: {
     if (list.length === 0) {
       lines.push(`${bar}  ${dim("No matches")}`);
     } else {
-      const windowStart = Math.max(0, Math.min(
-        (mode === "list" ? cursor : 0) - Math.floor(maxItems / 2),
-        list.length - maxItems,
-      ));
-      const windowEnd = Math.min(list.length, windowStart + maxItems);
-
-      if (windowStart > 0) {
-        lines.push(`${bar}  ${dim(`… ${windowStart} more`)}`);
-      }
-      for (let i = windowStart; i < windowEnd; i++) {
-        const option = list[i]!;
-        const isCursor = mode === "list" && i === cursor;
-        const marker = opts.multiple
+      lines.push(...listRows(bar, list, mode === "list" ? cursor : -1, maxItems, (option, isCursor) =>
+        opts.multiple
           ? (selected.has(option.value) ? green("◼") : dim("◻"))
-          : (isCursor ? green("●") : dim("○"));
-        const pointer = isCursor ? cyan("❯") : " ";
-        const hint = option.hint && isCursor ? ` ${dim(`(${option.hint})`)}` : "";
-        lines.push(`${bar}  ${pointer} ${marker} ${option.label}${hint}`);
-      }
-      if (windowEnd < list.length) {
-        lines.push(`${bar}  ${dim(`… ${list.length - windowEnd} more`)}`);
-      }
+          : (isCursor ? green("●") : dim("○")),
+      ));
     }
 
     if (state === "error") {
@@ -204,7 +252,10 @@ function run<Value>(opts: {
     return lines.join("\n");
   };
 
-  return prompt.prompt() as unknown as Promise<Value | Value[] | symbol>;
+  return eraseWhenTransient(
+    prompt.prompt() as unknown as Promise<Value | Value[] | symbol>,
+    opts.transient,
+  );
 }
 
 export function searchSelect<Value>(opts: SearchSelectOptions<Value>): Promise<Value | symbol> {
@@ -213,4 +264,45 @@ export function searchSelect<Value>(opts: SearchSelectOptions<Value>): Promise<V
 
 export function searchMultiselect<Value>(opts: SearchMultiselectOptions<Value>): Promise<Value[] | symbol> {
   return run({ ...opts, multiple: true }) as Promise<Value[] | symbol>;
+}
+
+export function listSelect<Value>(opts: ListSelectOptions<Value>): Promise<Value | symbol> {
+  const maxItems = Math.max(3, opts.maxItems ?? 12);
+  let cursor = 0;
+
+  const prompt = new Prompt<Value>({
+    output: OUT,
+    render: () => {
+      const state = prompt.state;
+      if (state === "cancel" || state === "submit") {
+        if (opts.transient) {
+          return dim("◇");
+        }
+        if (state === "cancel") {
+          return `${dim("◇")}  ${opts.message}`;
+        }
+        const label = strip(opts.options[cursor]?.label ?? "");
+        return `${dim("◇")}  ${opts.message}\n${dim(S_BAR)}  ${dim(label)}`;
+      }
+      return [
+        `${cyan("◆")}  ${opts.message}`,
+        ...listRows(cyan(S_BAR), opts.options, cursor, maxItems,
+          (_, isCursor) => (isCursor ? green("●") : dim("○"))),
+        cyan(S_END),
+      ].join("\n");
+    },
+  }, false);
+
+  prompt.on("cursor", (direction) => {
+    const last = opts.options.length - 1;
+    if (direction === "up" || direction === "left") {
+      cursor = cursor === 0 ? last : cursor - 1;
+    } else if (direction === "down" || direction === "right") {
+      cursor = cursor === last ? 0 : cursor + 1;
+    }
+    prompt.value = opts.options[cursor]?.value;
+  });
+  prompt.value = opts.options[cursor]?.value;
+
+  return eraseWhenTransient(prompt.prompt() as unknown as Promise<Value | symbol>, opts.transient);
 }

--- a/packages/xinity-cli/src/lib/search-list.ts
+++ b/packages/xinity-cli/src/lib/search-list.ts
@@ -1,0 +1,216 @@
+/**
+ * Searchable list prompts with two explicit focus zones: a search bar and
+ * the option list. Typing only ever edits the search while it is focused;
+ * Down (or Tab) moves focus into the list, where arrows navigate, space
+ * toggles (multiselect), and printable keys do nothing. Up from the first
+ * row returns to the search bar.
+ *
+ * Built on @clack/core's Prompt base, which supplies raw-mode input, frame
+ * diffing, and cancel handling; the key model and rendering live here.
+ */
+import { Prompt } from "@clack/core";
+import { cyan, dim, green, inverse, yellow } from "picocolors";
+
+export interface SearchListOption<Value> {
+  value: Value;
+  label: string;
+  hint?: string;
+}
+
+interface SharedOptions<Value> {
+  message: string;
+  options: SearchListOption<Value>[];
+  /** Rows visible at once; overflow is windowed with "… n more" markers. */
+  maxItems?: number;
+}
+
+export type SearchSelectOptions<Value> = SharedOptions<Value>;
+
+export interface SearchMultiselectOptions<Value> extends SharedOptions<Value> {
+  initialValues?: Value[];
+  required?: boolean;
+}
+
+const OUT = process.stderr;
+const S_BAR = "│";
+const S_END = "└";
+
+function strip(text: string): string {
+  // eslint-disable-next-line no-control-regex
+  return text.replace(/\[[0-9;]*m/g, "");
+}
+
+function run<Value>(opts: {
+  message: string;
+  options: SearchListOption<Value>[];
+  maxItems?: number;
+  multiple: boolean;
+  initialValues?: Value[];
+  required?: boolean;
+}): Promise<Value | Value[] | symbol> {
+  const maxItems = Math.max(3, opts.maxItems ?? 12);
+  const selected = new Set<Value>(opts.initialValues ?? []);
+  let query = "";
+  let mode: "search" | "list" = "search";
+  let cursor = 0;
+
+  // Filtering runs on every keystroke and render; precompute the searchable
+  // text once and reuse one filtered array per query value.
+  const searchable = opts.options.map(
+    (o) => `${strip(o.label)} ${o.hint ?? ""} ${String(o.value)}`.toLowerCase(),
+  );
+  let filteredCache = opts.options;
+  let filteredForQuery = "";
+  const filtered = () => {
+    if (query !== filteredForQuery) {
+      const q = query.toLowerCase();
+      filteredCache = q ? opts.options.filter((_, i) => searchable[i]!.includes(q)) : opts.options;
+      filteredForQuery = query;
+    }
+    return filteredCache;
+  };
+
+  const currentValue = () => {
+    if (opts.multiple) return [...selected];
+    const list = filtered();
+    return (mode === "list" ? list[cursor] : list[0])?.value;
+  };
+
+  const prompt = new Prompt<Value | Value[]>({
+    output: OUT,
+    validate: () => {
+      if (opts.multiple && opts.required && selected.size === 0) {
+        return "Select at least one option (Down to enter the list, space to toggle)";
+      }
+      if (!opts.multiple && currentValue() === undefined) {
+        return "Nothing matches the search";
+      }
+      return undefined;
+    },
+    render: () => renderFrame(),
+  }, false);
+
+  const sync = () => {
+    prompt.value = currentValue();
+  };
+  sync();
+
+  prompt.on("cursor", (direction) => {
+    const list = filtered();
+    if (direction === "down" || direction === "right") {
+      if (mode === "search") {
+        mode = "list";
+        cursor = 0;
+      } else if (cursor < list.length - 1) {
+        cursor++;
+      }
+    } else if (direction === "up" || direction === "left") {
+      if (mode === "list" && cursor === 0) {
+        mode = "search";
+      } else if (mode === "list") {
+        cursor--;
+      }
+    } else if (direction === "space" && mode === "list" && opts.multiple) {
+      const option = list[cursor];
+      if (option) {
+        if (selected.has(option.value)) {
+          selected.delete(option.value);
+        } else {
+          selected.add(option.value);
+        }
+      }
+    }
+    sync();
+  });
+
+  prompt.on("key", (char: string | undefined, key: { name?: string; ctrl?: boolean } | undefined) => {
+    if (key?.name === "tab") {
+      mode = mode === "search" ? "list" : "search";
+      cursor = 0;
+      sync();
+      return;
+    }
+    if (mode !== "search") return;
+    if (key?.name === "backspace") {
+      query = query.slice(0, -1);
+      cursor = 0;
+      sync();
+      return;
+    }
+    if (char && char.length === 1 && !key?.ctrl && key?.name !== "return" && char >= " ") {
+      query += char;
+      cursor = 0;
+      sync();
+    }
+  });
+
+  const renderFrame = (): string => {
+    const state = prompt.state;
+    const list = filtered();
+
+    // Cancel messaging belongs to the caller; announcing it here too would
+    // read as two cancellations.
+    if (state === "cancel") {
+      return `${dim("◇")}  ${opts.message}`;
+    }
+    if (state === "submit") {
+      const summary = opts.multiple
+        ? dim(`${selected.size} selected`)
+        : dim(strip(opts.options.find((o) => o.value === currentValue())?.label ?? ""));
+      return `${dim("◇")}  ${opts.message}\n${dim(S_BAR)}  ${summary}`;
+    }
+
+    const symbol = state === "error" ? yellow("▲") : cyan("◆");
+    const bar = state === "error" ? yellow(S_BAR) : cyan(S_BAR);
+    const lines: string[] = [`${symbol}  ${opts.message}`];
+
+    const counter = query ? dim(`  ${list.length}/${opts.options.length}`) : "";
+    lines.push(mode === "search"
+      ? `${bar}  ${cyan("Search:")} ${query}${inverse(" ")}${counter}`
+      : `${bar}  ${dim(`Search: ${query || "(Up to focus, then type)"}`)}${counter}`);
+
+    if (list.length === 0) {
+      lines.push(`${bar}  ${dim("No matches")}`);
+    } else {
+      const windowStart = Math.max(0, Math.min(
+        (mode === "list" ? cursor : 0) - Math.floor(maxItems / 2),
+        list.length - maxItems,
+      ));
+      const windowEnd = Math.min(list.length, windowStart + maxItems);
+
+      if (windowStart > 0) {
+        lines.push(`${bar}  ${dim(`… ${windowStart} more`)}`);
+      }
+      for (let i = windowStart; i < windowEnd; i++) {
+        const option = list[i]!;
+        const isCursor = mode === "list" && i === cursor;
+        const marker = opts.multiple
+          ? (selected.has(option.value) ? green("◼") : dim("◻"))
+          : (isCursor ? green("●") : dim("○"));
+        const pointer = isCursor ? cyan("❯") : " ";
+        const hint = option.hint && isCursor ? ` ${dim(`(${option.hint})`)}` : "";
+        lines.push(`${bar}  ${pointer} ${marker} ${option.label}${hint}`);
+      }
+      if (windowEnd < list.length) {
+        lines.push(`${bar}  ${dim(`… ${list.length - windowEnd} more`)}`);
+      }
+    }
+
+    if (state === "error") {
+      lines.push(`${yellow(S_END)}  ${yellow(prompt.error)}`);
+    } else {
+      lines.push(`${cyan(S_END)}`);
+    }
+    return lines.join("\n");
+  };
+
+  return prompt.prompt() as unknown as Promise<Value | Value[] | symbol>;
+}
+
+export function searchSelect<Value>(opts: SearchSelectOptions<Value>): Promise<Value | symbol> {
+  return run({ ...opts, multiple: false }) as Promise<Value | symbol>;
+}
+
+export function searchMultiselect<Value>(opts: SearchMultiselectOptions<Value>): Promise<Value[] | symbol> {
+  return run({ ...opts, multiple: true }) as Promise<Value[] | symbol>;
+}

--- a/packages/xinity-cli/src/lib/seaweedfs-setup.ts
+++ b/packages/xinity-cli/src/lib/seaweedfs-setup.ts
@@ -9,8 +9,8 @@
  * identically for local and remote (--target-host) execution.
  */
 import { randomBytes, createHmac } from "crypto";
-import * as p from "./clack.ts";
-import pc from "picocolors";
+import { confirm, isCancel, log, note, password, spinner as clackSpinner, text } from "./clack.ts";
+import { bold, cyan, dim } from "picocolors";
 import { type Host, commandExistsOn } from "./host.ts";
 import { pass, fail, info, promptOrUndefined, warn } from "./output.ts";
 import { BIN_DIR, ENV_DIR, UNIT_DIR } from "./component-meta.ts";
@@ -44,7 +44,7 @@ function generateSecret(length = 40): string {
 }
 
 async function promptOrGenerateS3Credentials(): Promise<{ accessKeyId: string; secretAccessKey: string } | undefined> {
-  const useGenerated = await promptOrUndefined(p.confirm({
+  const useGenerated = await promptOrUndefined(confirm({
     message: "Generate random S3 credentials?",
     initialValue: true,
   }));
@@ -53,14 +53,14 @@ async function promptOrGenerateS3Credentials(): Promise<{ accessKeyId: string; s
   if (useGenerated) {
     const accessKeyId = generateKey();
     const secretAccessKey = generateSecret();
-    info("Access key", pc.cyan(accessKeyId));
-    info("Secret key", pc.cyan(secretAccessKey));
+    info("Access key", cyan(accessKeyId));
+    info("Secret key", cyan(secretAccessKey));
     return { accessKeyId, secretAccessKey };
   }
 
-  const accessKeyId = await promptOrUndefined(p.text({ message: "Access key ID" }));
+  const accessKeyId = await promptOrUndefined(text({ message: "Access key ID" }));
   if (accessKeyId === undefined) return undefined;
-  const secretAccessKey = await promptOrUndefined(p.password({ message: "Secret access key" }));
+  const secretAccessKey = await promptOrUndefined(password({ message: "Secret access key" }));
   if (secretAccessKey === undefined) return undefined;
   return { accessKeyId, secretAccessKey };
 }
@@ -117,17 +117,17 @@ async function downloadWeed(host: Host, dataDir: string, dryRun: boolean): Promi
     return false;
   }
 
-  const spinner = p.spinner();
+  const spinner = clackSpinner();
   spinner.start("Fetching latest SeaweedFS release…");
   const version = await fetchLatestVersion(host);
-  spinner.stop(version ? `Latest version: ${pc.cyan(version)}` : "Could not fetch latest, will use default");
+  spinner.stop(version ? `Latest version: ${cyan(version)}` : "Could not fetch latest, will use default");
 
   const tag = version ?? "3.75";
   const assetName = `linux_${arch}_large_disk.tar.gz`;
   const downloadUrl = `${SEAWEEDFS_GITHUB}/releases/download/${tag}/${assetName}`;
 
   if (dryRun) {
-    info("Dry run", `Would download: ${pc.dim(downloadUrl)}`);
+    info("Dry run", `Would download: ${dim(downloadUrl)}`);
     info("Dry run", `Would extract weed binary to ${WEED_BIN}`);
     return true;
   }
@@ -261,7 +261,7 @@ async function startAndWait(host: Host, dryRun: boolean): Promise<boolean> {
     return false;
   }
 
-  const spinner = p.spinner();
+  const spinner = clackSpinner();
   spinner.start("Waiting for SeaweedFS to start…");
   const ready = await waitForSeaweedFSRunning(host);
   if (ready) {
@@ -282,7 +282,7 @@ async function createBucket(
   dryRun: boolean,
 ): Promise<boolean> {
   if (dryRun) {
-    info("Dry run", `Would create S3 bucket: ${pc.cyan(bucket)}`);
+    info("Dry run", `Would create S3 bucket: ${cyan(bucket)}`);
     return true;
   }
 
@@ -304,7 +304,7 @@ async function createBucket(
     }
   }
 
-  pass("Bucket", `Created bucket: ${pc.cyan(bucket)}`);
+  pass("Bucket", `Created bucket: ${cyan(bucket)}`);
   return true;
 }
 
@@ -319,8 +319,8 @@ export async function seaweedfsSetup(
   host: Host,
   dryRun: boolean,
 ): Promise<SeaweedFSCredentials | undefined> {
-  p.log.step(pc.bold("SeaweedFS object store setup"));
-  p.log.info(
+  log.step(bold("SeaweedFS object store setup"));
+  log.info(
     "SeaweedFS provides S3-compatible object storage for multimodal image data.\n" +
     "It runs as a single binary with no external dependencies.",
   );
@@ -332,27 +332,27 @@ export async function seaweedfsSetup(
   if (alreadyInstalled) {
     pass("SeaweedFS", "Already installed");
   } else {
-    const proceed = await p.confirm({
+    const proceed = await confirm({
       message: "Download and install SeaweedFS?",
       initialValue: true,
     });
-    if (p.isCancel(proceed) || !proceed) return undefined;
+    if (isCancel(proceed) || !proceed) return undefined;
 
     const downloaded = await downloadWeed(host, "/var/lib/xinity-ai-seaweedfs/data", dryRun);
     if (!downloaded) return undefined;
   }
 
   // ── Step 2: Prompt for configuration ────────────────────────────────────
-  p.log.step(pc.bold("Configure SeaweedFS"));
+  log.step(bold("Configure SeaweedFS"));
 
-  const dataDir = await promptOrUndefined(p.text({
+  const dataDir = await promptOrUndefined(text({
     message: "Data directory",
     placeholder: "/var/lib/xinity-ai-seaweedfs/data",
     defaultValue: "/var/lib/xinity-ai-seaweedfs/data",
   }));
   if (dataDir === undefined) return undefined;
 
-  const bucket = await promptOrUndefined(p.text({
+  const bucket = await promptOrUndefined(text({
     message: "S3 bucket name",
     placeholder: "xinity-media",
     defaultValue: "xinity-media",
@@ -385,7 +385,7 @@ export async function seaweedfsSetup(
     bucket,
   };
 
-  p.note(
+  note(
     [
       `S3_ENDPOINT=${credentials.endpoint}`,
       `S3_ACCESS_KEY_ID=${credentials.accessKeyId}`,

--- a/packages/xinity-cli/src/lib/seaweedfs-setup.ts
+++ b/packages/xinity-cli/src/lib/seaweedfs-setup.ts
@@ -151,7 +151,7 @@ async function downloadWeed(host: Host, dataDir: string, dryRun: boolean): Promi
     `tar -xzf ${tmpTar} -C ${BIN_DIR} weed 2>/dev/null || tar -xzf ${tmpTar} -C /tmp && mv /tmp/weed ${WEED_BIN}`,
     "Extract weed binary",
   );
-  if (!extractResult.success && !extractResult.skipped) {
+  if (!extractResult.success) {
     fail("Extract", "Failed to extract weed binary from archive");
     return false;
   }
@@ -194,7 +194,7 @@ async function writeS3Config(
     "Write SeaweedFS S3 config",
   );
 
-  if (!result.success && !result.skipped) {
+  if (!result.success) {
     fail("Config", "Failed to write S3 identity config");
     return false;
   }
@@ -237,7 +237,7 @@ async function installSystemdUnit(
     "Install SeaweedFS systemd unit",
   );
 
-  if (!result.success && !result.skipped) {
+  if (!result.success) {
     fail("Systemd", "Failed to install unit file");
     return false;
   }
@@ -256,7 +256,7 @@ async function startAndWait(host: Host, dryRun: boolean): Promise<boolean> {
     `systemctl enable --now ${SEAWEEDFS_UNIT}`,
     "Start SeaweedFS",
   );
-  if (!startResult.success && !startResult.skipped) {
+  if (!startResult.success) {
     fail("Start", "Failed to start SeaweedFS");
     return false;
   }

--- a/packages/xinity-cli/src/lib/seaweedfs-setup.ts
+++ b/packages/xinity-cli/src/lib/seaweedfs-setup.ts
@@ -13,6 +13,7 @@ import { confirm, isCancel, log, note, password, spinner as clackSpinner, text }
 import { bold, cyan, dim } from "picocolors";
 import { type Host, commandExistsOn } from "./host.ts";
 import { pass, fail, info, promptOrUndefined, warn } from "./output.ts";
+import { heredoc } from "./service.ts";
 import { BIN_DIR, ENV_DIR, UNIT_DIR } from "./component-meta.ts";
 
 // ─── Constants ───────────────────────────────────────────────────────────────
@@ -190,7 +191,7 @@ async function writeS3Config(
 
   await host.withElevation(`mkdir -p ${ENV_DIR}`, "Create config directory");
   const result = await host.withElevation(
-    `cat > ${S3_CONFIG_PATH} << 'SEAWEEDFS_CONFIG_EOF'\n${config}\nSEAWEEDFS_CONFIG_EOF`,
+    `cat > ${S3_CONFIG_PATH} ${heredoc("SEAWEEDFS_CONFIG_EOF", config)}`,
     "Write SeaweedFS S3 config",
   );
 
@@ -233,7 +234,7 @@ async function installSystemdUnit(
 
   const unitPath = `${UNIT_DIR}/${SEAWEEDFS_UNIT}`;
   const result = await host.withElevation(
-    `cat > ${unitPath} << 'UNIT_EOF'\n${unitContent}\nUNIT_EOF\nsystemctl daemon-reload`,
+    `cat > ${unitPath} ${heredoc("UNIT_EOF", unitContent)}\nsystemctl daemon-reload`,
     "Install SeaweedFS systemd unit",
   );
 

--- a/packages/xinity-cli/src/lib/service.ts
+++ b/packages/xinity-cli/src/lib/service.ts
@@ -143,6 +143,12 @@ export async function* startService(component: Component, host: Host): AsyncGene
 export async function* restartService(component: Component, host: Host): AsyncGenerator<StepEvent, boolean> {
   const unit = unitName(component);
   if (!(await isUnitActiveOn(host, unit))) {
+    const status = await getUnitStatusOn(host, unit);
+    yield { type: "fail", label: "Service", detail: `${unit} is ${status} (cannot restart)` };
+    const journal = await collectJournalLines(host, unit);
+    if (journal) {
+      yield { type: "log", message: journal };
+    }
     return false;
   }
 

--- a/packages/xinity-cli/src/lib/service.ts
+++ b/packages/xinity-cli/src/lib/service.ts
@@ -1,7 +1,7 @@
 import { type Component, ENV_DIR, SECRETS_DIR, UNIT_DIR } from "./component-meta.ts";
 import { serializeEnvFile } from "./env-file.ts";
 import { generateUnit, getComponentConfig, unitName, type UnitConfig } from "./systemd.ts";
-import { type Host, createLocalHost, isUnitActiveOn, getUnitStatusOn } from "./host.ts";
+import { type Host, isUnitActiveOn, getUnitStatusOn } from "./host.ts";
 import type { StepEvent } from "./step-event.ts";
 
 export interface ServiceResult {
@@ -21,7 +21,7 @@ export async function writeEnvConfig(
   component: Component,
   config: Record<string, string>,
   secrets: Record<string, string>,
-  host: Host = createLocalHost(),
+  host: Host,
 ): Promise<ServiceResult> {
   const envContent = serializeEnvFile(applyEnvDerivations(component, config));
   const envPath = `${ENV_DIR}/${component}.env`;
@@ -51,7 +51,7 @@ export async function writeEnvConfig(
 export async function writeSystemdUnit(
   component: Component,
   secretKeys: string[],
-  host: Host = createLocalHost(),
+  host: Host,
 ): Promise<ServiceResult> {
   const baseConfig = getComponentConfig(component);
   const config: UnitConfig = { ...baseConfig, secretKeys };

--- a/packages/xinity-cli/src/lib/service.ts
+++ b/packages/xinity-cli/src/lib/service.ts
@@ -6,7 +6,6 @@ import type { StepEvent } from "./step-event.ts";
 
 export interface ServiceResult {
   success: boolean;
-  skipped?: boolean;
   error?: string;
 }
 
@@ -17,30 +16,51 @@ function applyEnvDerivations(component: Component, config: Record<string, string
   return config;
 }
 
+// The build*Command helpers return the exact root shell commands the apply
+// runs; the review phase's script dump emits the same strings verbatim.
+
+export function buildEnvWriteCommand(component: Component, config: Record<string, string>): string {
+  const envContent = serializeEnvFile(applyEnvDerivations(component, config));
+  const envPath = `${ENV_DIR}/${component}.env`;
+  return `mkdir -p ${ENV_DIR} && cat > ${envPath} << 'ENVEOF'\n${envContent}ENVEOF\nchmod 644 ${envPath}`;
+}
+
+export function buildSecretsWriteCommand(secrets: Record<string, string>): string | null {
+  if (Object.keys(secrets).length === 0) return null;
+  const cmds = [`mkdir -p ${SECRETS_DIR}`, `chmod 700 ${SECRETS_DIR}`];
+  for (const [key, value] of Object.entries(secrets)) {
+    cmds.push(`printf '%s' '${value.replace(/'/g, "'\\''")}' > ${SECRETS_DIR}/${key}`);
+    cmds.push(`chmod 600 ${SECRETS_DIR}/${key}`);
+  }
+  return cmds.join(" && ");
+}
+
+export function buildUnitWriteCommand(component: Component, secretKeys: string[]): string {
+  const baseConfig = getComponentConfig(component);
+  const config: UnitConfig = { ...baseConfig, secretKeys };
+  const unitContent = generateUnit(config);
+  const unitPath = `${UNIT_DIR}/${unitName(component)}`;
+  return `cat > ${unitPath} << 'UNITEOF'\n${unitContent}UNITEOF\nsystemctl daemon-reload`;
+}
+
 export async function writeEnvConfig(
   component: Component,
   config: Record<string, string>,
   secrets: Record<string, string>,
   host: Host,
 ): Promise<ServiceResult> {
-  const envContent = serializeEnvFile(applyEnvDerivations(component, config));
-  const envPath = `${ENV_DIR}/${component}.env`;
   let result = await host.withElevation(
-    `mkdir -p ${ENV_DIR} && cat > ${envPath} << 'ENVEOF'\n${envContent}ENVEOF\nchmod 644 ${envPath}`,
+    buildEnvWriteCommand(component, config),
     `Write ${component} configuration`,
   );
-  if (!result.success && !result.skipped) {
+  if (!result.success) {
     return { success: false, error: result.output };
   }
 
-  if (Object.keys(secrets).length > 0) {
-    const cmds = [`mkdir -p ${SECRETS_DIR}`, `chmod 700 ${SECRETS_DIR}`];
-    for (const [key, value] of Object.entries(secrets)) {
-      cmds.push(`printf '%s' '${value.replace(/'/g, "'\\''")}' > ${SECRETS_DIR}/${key}`);
-      cmds.push(`chmod 600 ${SECRETS_DIR}/${key}`);
-    }
-    result = await host.withElevation(cmds.join(" && "), "Write secrets", { sensitive: true });
-    if (!result.success && !result.skipped) {
+  const secretsCommand = buildSecretsWriteCommand(secrets);
+  if (secretsCommand) {
+    result = await host.withElevation(secretsCommand, "Write secrets");
+    if (!result.success) {
       return { success: false, error: result.output };
     }
   }
@@ -53,22 +73,13 @@ export async function writeSystemdUnit(
   secretKeys: string[],
   host: Host,
 ): Promise<ServiceResult> {
-  const baseConfig = getComponentConfig(component);
-  const config: UnitConfig = { ...baseConfig, secretKeys };
-
-  const unitContent = generateUnit(config);
-  const unitPath = `${UNIT_DIR}/${unitName(component)}`;
-
   const result = await host.withElevation(
-    `cat > ${unitPath} << 'UNITEOF'\n${unitContent}UNITEOF\nsystemctl daemon-reload`,
+    buildUnitWriteCommand(component, secretKeys),
     `Install ${component} systemd unit`,
   );
 
-  if (!result.success && !result.skipped) {
+  if (!result.success) {
     return { success: false, error: result.output };
-  }
-  if (result.skipped) {
-    return { success: false, skipped: true };
   }
 
   return { success: true };
@@ -106,11 +117,8 @@ export async function* startService(component: Component, host: Host): AsyncGene
     `Enable and start ${unit}`,
   );
 
-  if (!result.success && !result.skipped) {
+  if (!result.success) {
     yield { type: "fail", label: "Service", detail: result.output };
-    return false;
-  }
-  if (result.skipped) {
     return false;
   }
 
@@ -146,9 +154,7 @@ export async function* restartService(component: Component, host: Host): AsyncGe
   );
 
   if (!result.success) {
-    if (!result.skipped) {
-      yield { type: "fail", label: "Service", detail: result.output };
-    }
+    yield { type: "fail", label: "Service", detail: result.output };
     return false;
   }
 

--- a/packages/xinity-cli/src/lib/service.ts
+++ b/packages/xinity-cli/src/lib/service.ts
@@ -19,10 +19,15 @@ function applyEnvDerivations(component: Component, config: Record<string, string
 // The build*Command helpers return the exact root shell commands the apply
 // runs; the review phase's script dump emits the same strings verbatim.
 
+export function heredoc(tag: string, content: string): string {
+  const sentinel = `${tag}_${Math.random().toString(16).slice(2, 10)}`;
+  return `<< '${sentinel}'\n${content}\n${sentinel}`;
+}
+
 export function buildEnvWriteCommand(component: Component, config: Record<string, string>): string {
   const envContent = serializeEnvFile(applyEnvDerivations(component, config));
   const envPath = `${ENV_DIR}/${component}.env`;
-  return `mkdir -p ${ENV_DIR} && cat > ${envPath} << 'ENVEOF'\n${envContent}ENVEOF\nchmod 644 ${envPath}`;
+  return `mkdir -p ${ENV_DIR} && cat > ${envPath} ${heredoc("ENVEOF", envContent)}\nchmod 644 ${envPath}`;
 }
 
 export function buildSecretsWriteCommand(secrets: Record<string, string>): string | null {
@@ -40,7 +45,7 @@ export function buildUnitWriteCommand(component: Component, secretKeys: string[]
   const config: UnitConfig = { ...baseConfig, secretKeys };
   const unitContent = generateUnit(config);
   const unitPath = `${UNIT_DIR}/${unitName(component)}`;
-  return `cat > ${unitPath} << 'UNITEOF'\n${unitContent}UNITEOF\nsystemctl daemon-reload`;
+  return `cat > ${unitPath} ${heredoc("UNITEOF", unitContent)}\nsystemctl daemon-reload`;
 }
 
 export async function writeEnvConfig(

--- a/packages/xinity-cli/src/lib/service.ts
+++ b/packages/xinity-cli/src/lib/service.ts
@@ -1,18 +1,14 @@
-/**
- * Service lifecycle management for Xinity systemd services.
- *
- * Handles writing env configuration, starting, stopping, and restarting
- * services. Used both by the install orchestrator and standalone by
- * the configure command.
- */
-import * as p from "./clack.ts";
-import pc from "picocolors";
-
 import { type Component, ENV_DIR, SECRETS_DIR, UNIT_DIR } from "./component-meta.ts";
 import { serializeEnvFile } from "./env-file.ts";
 import { generateUnit, getComponentConfig, unitName, type UnitConfig } from "./systemd.ts";
-import { pass, fail, info, elevationHardFailed } from "./output.ts";
 import { type Host, createLocalHost, isUnitActiveOn, getUnitStatusOn } from "./host.ts";
+import type { StepEvent } from "./step-event.ts";
+
+export interface ServiceResult {
+  success: boolean;
+  skipped?: boolean;
+  error?: string;
+}
 
 function applyEnvDerivations(component: Component, config: Record<string, string>): Record<string, string> {
   if (component === "dashboard" && config.ORIGIN) {
@@ -21,45 +17,42 @@ function applyEnvDerivations(component: Component, config: Record<string, string
   return config;
 }
 
-/** Write component env config and secret files to disk via host elevation. */
 export async function writeEnvConfig(
   component: Component,
   config: Record<string, string>,
   secrets: Record<string, string>,
   host: Host = createLocalHost(),
-): Promise<boolean> {
+): Promise<ServiceResult> {
   const envContent = serializeEnvFile(applyEnvDerivations(component, config));
   const envPath = `${ENV_DIR}/${component}.env`;
   let result = await host.withElevation(
     `mkdir -p ${ENV_DIR} && cat > ${envPath} << 'ENVEOF'\n${envContent}ENVEOF\nchmod 644 ${envPath}`,
     `Write ${component} configuration`,
   );
-  if (elevationHardFailed(result, "Config")) return false;
+  if (!result.success && !result.skipped) {
+    return { success: false, error: result.output };
+  }
 
   if (Object.keys(secrets).length > 0) {
     const cmds = [`mkdir -p ${SECRETS_DIR}`, `chmod 700 ${SECRETS_DIR}`];
     for (const [key, value] of Object.entries(secrets)) {
-      // Use printf to avoid newline interpretation issues
       cmds.push(`printf '%s' '${value.replace(/'/g, "'\\''")}' > ${SECRETS_DIR}/${key}`);
       cmds.push(`chmod 600 ${SECRETS_DIR}/${key}`);
     }
     result = await host.withElevation(cmds.join(" && "), "Write secrets", { sensitive: true });
-    if (elevationHardFailed(result, "Secrets")) return false;
+    if (!result.success && !result.skipped) {
+      return { success: false, error: result.output };
+    }
   }
 
-  pass("Config", "Environment configured");
-  return true;
+  return { success: true };
 }
 
-/**
- * Generate the systemd unit for a component and write it to /etc/systemd/system,
- * then daemon-reload. 
- */
 export async function writeSystemdUnit(
   component: Component,
   secretKeys: string[],
   host: Host = createLocalHost(),
-): Promise<boolean> {
+): Promise<ServiceResult> {
   const baseConfig = getComponentConfig(component);
   const config: UnitConfig = { ...baseConfig, secretKeys };
 
@@ -71,18 +64,19 @@ export async function writeSystemdUnit(
     `Install ${component} systemd unit`,
   );
 
-  if (elevationHardFailed(result, "Systemd")) return false;
-  if (result.skipped) return false;
+  if (!result.success && !result.skipped) {
+    return { success: false, error: result.output };
+  }
+  if (result.skipped) {
+    return { success: false, skipped: true };
+  }
 
-  pass("Systemd", `Unit installed at ${unitPath}`);
-  return true;
+  return { success: true };
 }
 
-/** Stop a running service. No-op if not active. */
 export async function stopService(component: Component, host: Host): Promise<void> {
   const unit = unitName(component);
   if (await isUnitActiveOn(host, unit)) {
-    info("Service", `Stopping ${unit}…`);
     await host.withElevation(`systemctl stop ${unit}`, `Stop ${unit}`);
   }
 }
@@ -90,71 +84,61 @@ export async function stopService(component: Component, host: Host): Promise<voi
 const UNIT_ACTIVE_POLL_INTERVAL_MS = 500;
 const UNIT_ACTIVE_POLL_ATTEMPTS = 10;
 
-async function waitForUnitActive(host: Host, unit: string): Promise<boolean> {
+export async function waitForUnitActive(host: Host, unit: string): Promise<boolean> {
   for (let i = 0; i < UNIT_ACTIVE_POLL_ATTEMPTS; i++) {
     await Bun.sleep(UNIT_ACTIVE_POLL_INTERVAL_MS);
-    if (await isUnitActiveOn(host, unit)) return true;
+    if (await isUnitActiveOn(host, unit)) {
+      return true;
+    }
   }
   return false;
 }
 
-async function reportUnitFailure(host: Host, unit: string, contextSuffix: string): Promise<void> {
-  const status = await getUnitStatusOn(host, unit);
-  fail("Service", `${unit} is ${status}${contextSuffix}`);
+async function collectJournalLines(host: Host, unit: string): Promise<string | null> {
   const journal = await host.run(["journalctl", "-u", unit, "--no-pager", "-n", "20"]);
-  if (journal.ok) {
-    p.log.info(pc.dim(journal.output));
-  }
+  return journal.ok ? journal.output : null;
 }
 
-async function awaitUnitActiveWithSpinner(
-  host: Host,
-  unit: string,
-  messages: { pending: string; succeeded: string; failed: string },
-): Promise<boolean> {
-  const spinner = p.spinner();
-  spinner.start(messages.pending);
-  if (await waitForUnitActive(host, unit)) {
-    spinner.stop(messages.succeeded);
-    return true;
-  }
-  spinner.stop(messages.failed);
-  return false;
-}
-
-/** Enable and start a service, wait for it to stabilize. */
-export async function startService(component: Component, host: Host): Promise<boolean> {
+export async function* startService(component: Component, host: Host): AsyncGenerator<StepEvent, boolean> {
   const unit = unitName(component);
   const result = await host.withElevation(
     `systemctl enable --now ${unit}`,
     `Enable and start ${unit}`,
   );
 
-  if (elevationHardFailed(result, "Service")) return false;
-  if (result.skipped) return false;
+  if (!result.success && !result.skipped) {
+    yield { type: "fail", label: "Service", detail: result.output };
+    return false;
+  }
+  if (result.skipped) {
+    return false;
+  }
 
-  const active = await awaitUnitActiveWithSpinner(host, unit, {
-    pending: "Waiting for service to start…",
-    succeeded: "Service running",
-    failed: "Service failed to start",
-  });
+  yield { type: "spinner", id: "service-start", message: "Waiting for service to start…" };
+  const active = await waitForUnitActive(host, unit);
+  yield { type: "spinner", id: "service-start", message: active ? "Service running" : "Service failed to start", done: true };
+
   if (active) {
-    pass("Service", `${unit} is active`);
+    yield { type: "pass", label: "Service", detail: `${unit} is active` };
     return true;
   }
-  await reportUnitFailure(host, unit, "");
+
+  const status = await getUnitStatusOn(host, unit);
+  yield { type: "fail", label: "Service", detail: `${unit} is ${status}` };
+  const journal = await collectJournalLines(host, unit);
+  if (journal) {
+    yield { type: "log", message: journal };
+  }
   return false;
 }
 
-/**
- * Restart a running service so it picks up new configuration.
- * No-op if the service unit is not currently active.
- */
-export async function restartService(component: Component, host: Host): Promise<boolean> {
+export async function* restartService(component: Component, host: Host): AsyncGenerator<StepEvent, boolean> {
   const unit = unitName(component);
-  if (!(await isUnitActiveOn(host, unit))) return false;
+  if (!(await isUnitActiveOn(host, unit))) {
+    return false;
+  }
 
-  info("Service", `Restarting ${unit} to apply new configuration…`);
+  yield { type: "info", label: "Service", detail: `Restarting ${unit} to apply new configuration…` };
 
   const result = await host.withElevation(
     `systemctl restart ${unit}`,
@@ -162,19 +146,26 @@ export async function restartService(component: Component, host: Host): Promise<
   );
 
   if (!result.success) {
-    if (!result.skipped) fail("Service", result.output);
+    if (!result.skipped) {
+      yield { type: "fail", label: "Service", detail: result.output };
+    }
     return false;
   }
 
-  const active = await awaitUnitActiveWithSpinner(host, unit, {
-    pending: "Waiting for service to restart…",
-    succeeded: "Service restarted",
-    failed: "Service failed to restart",
-  });
+  yield { type: "spinner", id: "service-restart", message: "Waiting for service to restart…" };
+  const active = await waitForUnitActive(host, unit);
+  yield { type: "spinner", id: "service-restart", message: active ? "Service restarted" : "Service failed to restart", done: true };
+
   if (active) {
-    pass("Service", `${unit} restarted with new configuration`);
+    yield { type: "pass", label: "Service", detail: `${unit} restarted with new configuration` };
     return true;
   }
-  await reportUnitFailure(host, unit, " after restart");
+
+  const status = await getUnitStatusOn(host, unit);
+  yield { type: "fail", label: "Service", detail: `${unit} is ${status} after restart` };
+  const journal = await collectJournalLines(host, unit);
+  if (journal) {
+    yield { type: "log", message: journal };
+  }
   return false;
 }

--- a/packages/xinity-cli/src/lib/stack-layers.ts
+++ b/packages/xinity-cli/src/lib/stack-layers.ts
@@ -1,15 +1,16 @@
 /**
- * The one place that knows how each stack layer is edited: what its base
- * (the layers below) is, which keys are hidden or marked for review, and
- * where the result is stored. `stack init`, `stack edit`, and the lazy
- * editors inside `stack up` all go through these.
+ * The one place that knows how each stack layer is edited: which keys are
+ * hidden or marked for review, and where the result is stored. `stack init`,
+ * `stack edit`, and the lazy editors inside `stack up` all go through these.
  */
-import { type Component, ENV_SCHEMAS, getAutoDefaults } from "./component-meta.ts";
+import type { z } from "zod";
+import { type Component, ENV_SCHEMAS } from "./component-meta.ts";
 import { menuEditEnv, flattenBundle } from "./env-prompt.ts";
 import {
   type StackDefinition, type FleetDefinition,
   STACK_SHARED_SCHEMA, STACK_SHARED_KEYS,
   applySharedResult, sharedHiddenKeys, diffFromLayer,
+  componentLayerBase, fleetLayerBase, getHost, saveStack,
 } from "./stack.ts";
 
 // Host-local defaults that are almost always wrong for a multi-host stack;
@@ -19,20 +20,24 @@ const STACK_ATTENTION_KEYS: Partial<Record<Component, string[]>> = {
   dashboard: ["ORIGIN", "GATEWAY_URL"],
 };
 
-export function componentLayerBase(stack: StackDefinition, component: Component): Record<string, string> {
-  return { ...getAutoDefaults(component), ...stack.env, ...stack.secrets };
-}
-
-export function componentLayerSeed(stack: StackDefinition, component: Component): Record<string, string> {
-  return { ...componentLayerBase(stack, component), ...(stack.componentEnv[component] ?? {}) };
-}
-
-export function fleetLayerBase(stack: StackDefinition): Record<string, string> {
-  return componentLayerSeed(stack, "daemon");
-}
-
-export function fleetLayerSeed(stack: StackDefinition, fleet: FleetDefinition): Record<string, string> {
-  return { ...fleetLayerBase(stack), ...(fleet.envOverrides ?? {}) };
+export async function menuEditLayer(opts: {
+  schema: z.ZodObject<any>;
+  inherited: Record<string, string>;
+  own: Record<string, string>;
+  attentionKeys?: Set<string>;
+  hiddenKeys?: Set<string>;
+  message?: string;
+}): Promise<Record<string, string> | null> {
+  const result = await menuEditEnv(opts.schema, { ...opts.inherited, ...opts.own }, {
+    attentionKeys: opts.attentionKeys,
+    hiddenKeys: opts.hiddenKeys,
+    inherited: opts.inherited,
+    message: opts.message,
+  });
+  if (result === null) {
+    return null;
+  }
+  return diffFromLayer(flattenBundle(result), opts.inherited);
 }
 
 /** Returns false when the user cancelled; nothing is stored then. */
@@ -53,16 +58,18 @@ export async function editComponentLayer(
   component: Component,
   message = `${component} settings (stack-wide)`,
 ): Promise<boolean> {
-  const base = componentLayerBase(stack, component);
-  const result = await menuEditEnv(ENV_SCHEMAS[component], componentLayerSeed(stack, component), {
+  const overrides = await menuEditLayer({
+    schema: ENV_SCHEMAS[component],
+    inherited: componentLayerBase(stack, component),
+    own: stack.componentEnv[component] ?? {},
     attentionKeys: new Set(STACK_ATTENTION_KEYS[component] ?? []),
     hiddenKeys: STACK_SHARED_KEYS,
     message,
   });
-  if (result === null) {
+  if (overrides === null) {
     return false;
   }
-  stack.componentEnv[component] = diffFromLayer(flattenBundle(result), base);
+  stack.componentEnv[component] = overrides;
   return true;
 }
 
@@ -71,14 +78,40 @@ export async function editFleetLayer(
   fleet: FleetDefinition,
   message = `Daemon settings for fleet "${fleet.name}"`,
 ): Promise<boolean> {
-  const base = fleetLayerBase(stack);
-  const result = await menuEditEnv(ENV_SCHEMAS.daemon, fleetLayerSeed(stack, fleet), {
+  const overrides = await menuEditLayer({
+    schema: ENV_SCHEMAS.daemon,
+    inherited: fleetLayerBase(stack),
+    own: fleet.envOverrides ?? {},
     hiddenKeys: STACK_SHARED_KEYS,
     message,
   });
-  if (result === null) {
+  if (overrides === null) {
     return false;
   }
-  fleet.envOverrides = diffFromLayer(flattenBundle(result), base);
+  fleet.envOverrides = overrides;
   return true;
+}
+
+export async function editHostLayer(
+  stack: StackDefinition,
+  address: string,
+  component: Component,
+  inherited: Record<string, string>,
+): Promise<Record<string, string> | null> {
+  const overrides = await menuEditLayer({
+    schema: ENV_SCHEMAS[component],
+    inherited,
+    own: {},
+    hiddenKeys: STACK_SHARED_KEYS,
+    message: `${component} settings for ${address} (saved as host overrides)`,
+  });
+  if (overrides === null) {
+    return null;
+  }
+  const host = getHost(stack, address);
+  if (host && Object.keys(overrides).length > 0) {
+    host.envOverrides = { ...host.envOverrides, ...overrides };
+    saveStack(stack);
+  }
+  return overrides;
 }

--- a/packages/xinity-cli/src/lib/stack-layers.ts
+++ b/packages/xinity-cli/src/lib/stack-layers.ts
@@ -98,19 +98,19 @@ export async function editHostLayer(
   component: Component,
   inherited: Record<string, string>,
 ): Promise<Record<string, string> | null> {
+  const host = getHost(stack, address);
   const overrides = await menuEditLayer({
     schema: ENV_SCHEMAS[component],
     inherited,
-    own: {},
+    own: host?.envOverrides ?? {},
     hiddenKeys: STACK_SHARED_KEYS,
     message: `${component} settings for ${address} (saved as host overrides)`,
   });
   if (overrides === null) {
     return null;
   }
-  const host = getHost(stack, address);
-  if (host && Object.keys(overrides).length > 0) {
-    host.envOverrides = { ...host.envOverrides, ...overrides };
+  if (host) {
+    host.envOverrides = overrides;
     saveStack(stack);
   }
   return overrides;

--- a/packages/xinity-cli/src/lib/stack-layers.ts
+++ b/packages/xinity-cli/src/lib/stack-layers.ts
@@ -1,0 +1,84 @@
+/**
+ * The one place that knows how each stack layer is edited: what its base
+ * (the layers below) is, which keys are hidden or marked for review, and
+ * where the result is stored. `stack init`, `stack edit`, and the lazy
+ * editors inside `stack up` all go through these.
+ */
+import { type Component, ENV_SCHEMAS, getAutoDefaults } from "./component-meta.ts";
+import { menuEditEnv, flattenBundle } from "./env-prompt.ts";
+import {
+  type StackDefinition, type FleetDefinition,
+  STACK_SHARED_SCHEMA, STACK_SHARED_KEYS,
+  applySharedResult, sharedHiddenKeys, diffFromLayer,
+} from "./stack.ts";
+
+// Host-local defaults that are almost always wrong for a multi-host stack;
+// marked in the editors so they get looked at instead of skipped.
+const STACK_ATTENTION_KEYS: Partial<Record<Component, string[]>> = {
+  gateway: ["HOST"],
+  dashboard: ["ORIGIN", "GATEWAY_URL"],
+};
+
+export function componentLayerBase(stack: StackDefinition, component: Component): Record<string, string> {
+  return { ...getAutoDefaults(component), ...stack.env, ...stack.secrets };
+}
+
+export function componentLayerSeed(stack: StackDefinition, component: Component): Record<string, string> {
+  return { ...componentLayerBase(stack, component), ...(stack.componentEnv[component] ?? {}) };
+}
+
+export function fleetLayerBase(stack: StackDefinition): Record<string, string> {
+  return componentLayerSeed(stack, "daemon");
+}
+
+export function fleetLayerSeed(stack: StackDefinition, fleet: FleetDefinition): Record<string, string> {
+  return { ...fleetLayerBase(stack), ...(fleet.envOverrides ?? {}) };
+}
+
+/** Returns false when the user cancelled; nothing is stored then. */
+export async function editSharedLayer(stack: StackDefinition, message = "Shared stack settings"): Promise<boolean> {
+  const result = await menuEditEnv(STACK_SHARED_SCHEMA, { ...stack.env, ...stack.secrets }, {
+    hiddenKeys: sharedHiddenKeys(stack),
+    message,
+  });
+  if (result === null) {
+    return false;
+  }
+  applySharedResult(stack, result);
+  return true;
+}
+
+export async function editComponentLayer(
+  stack: StackDefinition,
+  component: Component,
+  message = `${component} settings (stack-wide)`,
+): Promise<boolean> {
+  const base = componentLayerBase(stack, component);
+  const result = await menuEditEnv(ENV_SCHEMAS[component], componentLayerSeed(stack, component), {
+    attentionKeys: new Set(STACK_ATTENTION_KEYS[component] ?? []),
+    hiddenKeys: STACK_SHARED_KEYS,
+    message,
+  });
+  if (result === null) {
+    return false;
+  }
+  stack.componentEnv[component] = diffFromLayer(flattenBundle(result), base);
+  return true;
+}
+
+export async function editFleetLayer(
+  stack: StackDefinition,
+  fleet: FleetDefinition,
+  message = `Daemon settings for fleet "${fleet.name}"`,
+): Promise<boolean> {
+  const base = fleetLayerBase(stack);
+  const result = await menuEditEnv(ENV_SCHEMAS.daemon, fleetLayerSeed(stack, fleet), {
+    hiddenKeys: STACK_SHARED_KEYS,
+    message,
+  });
+  if (result === null) {
+    return false;
+  }
+  fleet.envOverrides = diffFromLayer(flattenBundle(result), base);
+  return true;
+}

--- a/packages/xinity-cli/src/lib/stack-layers.ts
+++ b/packages/xinity-cli/src/lib/stack-layers.ts
@@ -9,7 +9,7 @@ import { menuEditEnv, flattenBundle } from "./env-prompt.ts";
 import {
   type StackDefinition, type FleetDefinition,
   STACK_SHARED_SCHEMA, STACK_SHARED_KEYS,
-  applySharedResult, sharedHiddenKeys, diffFromLayer,
+  applySharedResult, diffFromLayer,
   componentLayerBase, fleetLayerBase, getHost, saveStack,
 } from "./stack.ts";
 
@@ -43,7 +43,6 @@ export async function menuEditLayer(opts: {
 /** Returns false when the user cancelled; nothing is stored then. */
 export async function editSharedLayer(stack: StackDefinition, message = "Shared stack settings"): Promise<boolean> {
   const result = await menuEditEnv(STACK_SHARED_SCHEMA, { ...stack.env, ...stack.secrets }, {
-    hiddenKeys: sharedHiddenKeys(stack),
     message,
   });
   if (result === null) {

--- a/packages/xinity-cli/src/lib/stack-plan.ts
+++ b/packages/xinity-cli/src/lib/stack-plan.ts
@@ -29,7 +29,7 @@ import {
 } from "./stack.ts";
 import { editSharedLayer, editComponentLayer, editFleetLayer, editHostLayer } from "./stack-layers.ts";
 import { loadStackState, findOrphanHosts, markHostManaged, unmarkHostManaged } from "./stack-state.ts";
-import { connectHosts, connectElevated, disposeAll } from "./multi-host.ts";
+import { connectHosts, connectElevated, disposeAll, mapBounded, HOST_CONCURRENCY } from "./multi-host.ts";
 
 export const COMPONENT_ORDER: Component[] = ["infoserver", "gateway", "dashboard", "daemon"];
 
@@ -289,6 +289,15 @@ async function planStack(
 
 // ─── Review ─────────────────────────────────────────────────────────────────
 
+function hostPlanBodyKey(hp: StackHostPlan): string {
+  return JSON.stringify({
+    f: hp.foreignStack, e: hp.evacuate, g: hp.forget,
+    r: hp.removals.map((r) => [r.component, r.version]),
+    a: hp.actions.map((a) => describeComponentAction(a)),
+    m: hp.membership,
+  });
+}
+
 function renderStackPlan(plan: StackPlan): void {
   log.step(bold("Planned actions"));
   let step = 1;
@@ -297,7 +306,19 @@ function renderStackPlan(plan: StackPlan): void {
   } else if (plan.migration) {
     log.info(dim(`Database migrations already applied for ${plan.migration.targetTag}`));
   }
-  for (const hostPlan of plan.hostPlans) {
+
+  const groups = new Map<string, { addresses: string[]; hostPlan: StackHostPlan }>();
+  for (const hp of plan.hostPlans) {
+    const key = hostPlanBodyKey(hp);
+    const g = groups.get(key);
+    if (g) {
+      g.addresses.push(hp.address);
+    } else {
+      groups.set(key, { addresses: [hp.address], hostPlan: hp });
+    }
+  }
+
+  for (const { addresses, hostPlan } of groups.values()) {
     const lines: string[] = [];
     if (hostPlan.foreignStack) {
       lines.push(yellow(`⚠ Marked as belonging to stack "${hostPlan.foreignStack}"; this stack will claim it`));
@@ -325,7 +346,10 @@ function renderStackPlan(plan: StackPlan): void {
     if (hostPlan.evacuate) {
       lines.push(`${step++}. Clear stack membership and stop managing this host`);
     }
-    note(lines.join("\n"), cyan(hostPlan.address));
+    const label = addresses.length === 1
+      ? addresses[0]!
+      : `${addresses.join(", ")} (${addresses.length} hosts)`;
+    note(lines.join("\n"), cyan(label));
   }
 }
 
@@ -412,20 +436,19 @@ async function applyStackPlan(
     saveStack(stack);
   }
 
-  let failures = 0;
-  for (const hostPlan of plan.hostPlans) {
-    if (hostPlan.forget) {
-      unmarkHostManaged(stack.name, hostPlan.address);
-      continue;
+  for (const hp of plan.hostPlans) {
+    if (hp.forget) {
+      unmarkHostManaged(stack.name, hp.address);
+    } else if (!hp.evacuate) {
+      markHostManaged(stack.name, hp.address);
     }
+  }
+
+  const active = plan.hostPlans.filter((p) => !p.forget);
+  const hostResults = await mapBounded(active, HOST_CONCURRENCY, async (hostPlan) => {
     heading(hostPlan.address);
     const host = (hosts.get(hostPlan.address) ?? orphanHosts.get(hostPlan.address))!;
-    if (!hostPlan.evacuate) {
-      markHostManaged(stack.name, hostPlan.address);
-    }
     let hostFailures = 0;
-    // Strays go first: a component moving between roles could otherwise
-    // collide with its replacement over ports or paths.
     for (const removal of hostPlan.removals) {
       const result = await removeComponentCollapsed({ component: removal.component, host });
       if (!result.success) {
@@ -447,8 +470,13 @@ async function applyStackPlan(
     if (hostPlan.membership) {
       await saveStackMembership(hostPlan.membership, host);
     }
-    // A failed evacuation stays in the state so the next up retries it.
+    return { hostPlan, hostFailures };
+  });
+
+  let failures = 0;
+  for (const { hostPlan, hostFailures } of hostResults) {
     if (hostPlan.evacuate && hostFailures === 0) {
+      const host = (hosts.get(hostPlan.address) ?? orphanHosts.get(hostPlan.address))!;
       await saveStackMembership(null, host);
       unmarkHostManaged(stack.name, hostPlan.address);
     }

--- a/packages/xinity-cli/src/lib/stack-plan.ts
+++ b/packages/xinity-cli/src/lib/stack-plan.ts
@@ -1,0 +1,341 @@
+/**
+ * Stack deployments: collect → review → gate → apply across all hosts.
+ *
+ * Config is resolved from the stack's layers; whatever a layer is missing is
+ * collected ONCE at the right level (stack-wide per component type, per
+ * fleet for daemons, per host only as a last resort) through the menu
+ * editor, and saved back into the stack so it is never asked again.
+ * The plan phase reads and prompts only; hosts change after the gate.
+ */
+import { cancel, log, note } from "./clack.ts";
+import { bold, cyan, dim } from "picocolors";
+import { type Component, ENV_SCHEMAS } from "./component-meta.ts";
+import { type Host, isUnitActiveOn } from "./host.ts";
+import { heading, warn, fail, pass } from "./output.ts";
+import { unitName } from "./systemd.ts";
+import { fetchRelease } from "./github.ts";
+import { resolveVersion, applyComponentAction } from "./installer.ts";
+import { removeComponentCollapsed } from "./install-remove.ts";
+import { readManifest } from "./manifest.ts";
+import { dbHint, runMigrations } from "./migrator.ts";
+import { connectHost } from "./remote-host.ts";
+import { type ComponentAction, describeComponentAction, buildComponentAction, reviewGate } from "./up-plan.ts";
+import { analyzeEnvSchema, splitValuesByCategory, menuEditEnv, readExistingEnvState, diffEnv, missingRequiredFields, flattenBundle } from "./env-prompt.ts";
+import {
+  type StackDefinition, type StackHost, type FleetDefinition,
+  resolveEnv, diffFromLayer, saveStack, getHost, hostLabel,
+  STACK_SHARED_KEYS, STACK_SHARED_SCHEMA,
+} from "./stack.ts";
+import { editSharedLayer, editComponentLayer, editFleetLayer, componentLayerSeed, fleetLayerSeed } from "./stack-layers.ts";
+import { connectHosts, disposeAll } from "./multi-host.ts";
+
+export const COMPONENT_ORDER: Component[] = ["infoserver", "gateway", "dashboard", "daemon"];
+
+interface Deployment {
+  host: StackHost;
+  components: Component[];
+}
+
+interface StackHostPlan {
+  address: string;
+  /** Installed on the host but not tracked by the stack; removed before anything else. */
+  removals: { component: Component; version?: string }[];
+  actions: ComponentAction[];
+}
+
+function selectDeployments(stack: StackDefinition): Deployment[] {
+  const deployments: Deployment[] = [];
+  for (const host of stack.hosts) {
+    const components = COMPONENT_ORDER.filter((c) => host.components.includes(c));
+    if (components.length > 0) {
+      deployments.push({ host, components });
+    }
+  }
+  return deployments;
+}
+
+/** An in-stack infoserver's URL is derived from its host, not asked for. */
+function deriveInfoserverUrl(stack: StackDefinition): void {
+  if (stack.env.INFOSERVER_URL) return;
+  const infoHost = stack.hosts.find((h) => h.components.includes("infoserver"));
+  if (!infoHost) return;
+  const hostname = infoHost.address === "local"
+    ? "localhost"
+    : (infoHost.address.split("@").pop() ?? infoHost.address);
+  const port = stack.componentEnv.infoserver?.PORT ?? "8090";
+  stack.env.INFOSERVER_URL = `http://${hostname}:${port}`;
+  log.info(`INFOSERVER_URL derived from the stack's infoserver host: ${cyan(stack.env.INFOSERVER_URL)}`);
+}
+
+/**
+ * Make sure every involved component type is fully configured at the
+ * highest level: the type's stack-wide layer, and per fleet for daemons.
+ * Opens the menu editor only on first configuration or when required
+ * values are missing; edits are stored as diffs against the layer below.
+ */
+async function ensureStackLevelConfig(stack: StackDefinition, deployments: Deployment[]): Promise<boolean> {
+  // Shared keys added after the stack was created (or by CLI upgrades) get
+  // backfilled here, at their owning layer, before any component editor.
+  if (missingRequiredFields(analyzeEnvSchema(STACK_SHARED_SCHEMA), { ...stack.env, ...stack.secrets }).length > 0) {
+    heading("shared settings");
+    if (!(await editSharedLayer(stack, "Shared stack settings (new required values)"))) {
+      return false;
+    }
+    saveStack(stack);
+  }
+
+  const involvedTypes = COMPONENT_ORDER.filter((c) => deployments.some((d) => d.components.includes(c)));
+  const daemonAddresses = deployments
+    .filter((d) => d.components.includes("daemon"))
+    .map((d) => d.host.address);
+  const fleetOf = new Map<string, FleetDefinition>();
+  for (const fleet of stack.fleets) {
+    for (const addr of fleet.hosts) {
+      fleetOf.set(addr, fleet);
+    }
+  }
+
+  for (const component of involvedTypes) {
+    // Daemon config lives on fleets; the stack-wide layer only matters for
+    // daemon hosts that belong to no fleet.
+    if (component === "daemon" && daemonAddresses.every((addr) => fleetOf.has(addr))) {
+      continue;
+    }
+    const missing = missingRequiredFields(analyzeEnvSchema(ENV_SCHEMAS[component]), componentLayerSeed(stack, component));
+    if (stack.componentEnv[component] === undefined || missing.length > 0) {
+      heading(component);
+      if (!(await editComponentLayer(stack, component, `${component} settings (stack-wide, saved to the stack)`))) {
+        return false;
+      }
+      saveStack(stack);
+    }
+  }
+
+  const involvedFleets = [...new Set(daemonAddresses.map((addr) => fleetOf.get(addr)).filter((f): f is FleetDefinition => f !== undefined))];
+  for (const fleet of involvedFleets) {
+    const missing = missingRequiredFields(analyzeEnvSchema(ENV_SCHEMAS.daemon), fleetLayerSeed(stack, fleet));
+    if (fleet.envOverrides === undefined || missing.length > 0) {
+      heading(`daemon · fleet ${fleet.name}`);
+      if (!(await editFleetLayer(stack, fleet, `Daemon settings for fleet "${fleet.name}" (saved to the fleet)`))) {
+        return false;
+      }
+      saveStack(stack);
+    }
+  }
+
+  return true;
+}
+
+/** Returns null when version resolution fails or the user cancels a per-host prompt. */
+async function planHostComponent(
+  stack: StackDefinition,
+  component: Component,
+  address: string,
+  host: Host,
+  targetVersion: string,
+): Promise<ComponentAction | null> {
+  const version = await resolveVersion(component, targetVersion, host);
+  if (version.status === "failed") return null;
+
+  const fields = analyzeEnvSchema(ENV_SCHEMAS[component]);
+  const { existingConfig, existingSecrets } = await readExistingEnvState(component, host);
+  const resolved = resolveEnv(stack, component, address);
+  // The stack is declarative: its layers win over whatever is on disk, while
+  // values the stack does not manage (a hand-set MACHINE_NAME) persist.
+  let merged: Record<string, string> = { ...existingConfig, ...existingSecrets, ...resolved };
+
+  const missing = missingRequiredFields(fields, merged);
+  if (missing.length > 0) {
+    const result = await menuEditEnv(ENV_SCHEMAS[component], merged, {
+      hiddenKeys: STACK_SHARED_KEYS,
+      message: `${component} settings for ${address} (saved as host overrides)`,
+    });
+    if (result === null) return null;
+    const overrides = diffFromLayer(flattenBundle(result), merged);
+    const stackHost = getHost(stack, address);
+    if (stackHost && Object.keys(overrides).length > 0) {
+      stackHost.envOverrides = { ...stackHost.envOverrides, ...overrides };
+      saveStack(stack);
+    }
+    merged = { ...merged, ...overrides };
+  }
+
+  const env = splitValuesByCategory(fields, merged);
+  return buildComponentAction({
+    component,
+    hardReset: false,
+    serviceRunning: await isUnitActiveOn(host, unitName(component)),
+    env,
+    envChanges: diffEnv({ config: existingConfig, secrets: existingSecrets }, env),
+  }, version, host);
+}
+
+function renderStackPlan(plans: StackHostPlan[], firstStep: number): void {
+  let step = firstStep;
+  for (const plan of plans) {
+    const lines: string[] = [];
+    for (const removal of plan.removals) {
+      lines.push(`${step++}. Remove ${cyan(removal.component)}${removal.version ? ` ${removal.version}` : ""}`);
+      lines.push(dim("   installed on the host but not part of this stack"));
+    }
+    for (const action of plan.actions) {
+      const [head, ...rest] = describeComponentAction(action);
+      lines.push(`${step++}. ${head}`);
+      for (const line of rest) {
+        lines.push(dim(`   ${line}`));
+      }
+    }
+    note(lines.join("\n"), cyan(plan.address));
+  }
+}
+
+/**
+ * The shared engine behind `stack up` and `fleet up`: collect everything,
+ * review one plan, gate once, then apply host by host.
+ * Returns false when something failed (as opposed to a clean abort).
+ */
+export async function runStackFlow(
+  stack: StackDefinition,
+  opts: { targetVersion: string },
+): Promise<boolean> {
+  const deployments = selectDeployments(stack);
+  const migrateUrl = stack.secrets.DB_CONNECTION_URL ?? stack.env.DB_CONNECTION_URL;
+
+  if (deployments.length === 0 && !migrateUrl) {
+    warn("Stack", "Nothing to deploy (no matching hosts with components)");
+    return true;
+  }
+
+  if (deployments.length > 0) {
+    log.info(bold("Hosts:"));
+    for (const d of deployments) {
+      log.info(`  ${hostLabel(d.host)}: ${d.components.map((c) => cyan(c)).join(", ")}`);
+    }
+  } else {
+    log.info(dim(`No hosts defined yet; planning database migrations only. Add hosts with: xinity stack edit ${stack.name}`));
+  }
+
+  let targetTag: string | null = null;
+  if (migrateUrl) {
+    try {
+      targetTag = (await fetchRelease(opts.targetVersion)).tagName;
+    } catch (err) {
+      fail("Release", (err as Error).message);
+      return false;
+    }
+  }
+  const migrationsPending = migrateUrl !== undefined && targetTag !== stack.dbMigratedVersion;
+
+  const hosts = deployments.length > 0
+    ? await connectHosts(deployments.map((d) => d.host.address))
+    : new Map<string, Host>();
+  if (!hosts) return false;
+
+  let localFallback: Host | null = null;
+  try {
+    deriveInfoserverUrl(stack);
+    if (!(await ensureStackLevelConfig(stack, deployments))) {
+      cancel("Cancelled, nothing was changed on the hosts.");
+      return true;
+    }
+
+    const plans: StackHostPlan[] = [];
+    for (const d of deployments) {
+      const host = hosts.get(d.host.address)!;
+
+      const manifest = await readManifest(host);
+      const removals = COMPONENT_ORDER
+        .filter((c) => manifest.components[c] && !d.host.components.includes(c))
+        .map((c) => ({ component: c, version: manifest.components[c]?.version }));
+
+      const actions: ComponentAction[] = [];
+      for (const component of d.components) {
+        const action = await planHostComponent(stack, component, d.host.address, host, opts.targetVersion);
+        if (!action) return false;
+        actions.push(action);
+      }
+      plans.push({ address: d.host.address, removals, actions });
+    }
+
+    log.step(bold("Planned actions"));
+    let firstStep = 1;
+    if (migrationsPending) {
+      log.info(`${firstStep++}. Apply database migrations from release ${targetTag} to ${dbHint(migrateUrl!)}`);
+    } else if (migrateUrl) {
+      log.info(dim(`Database migrations already applied for ${targetTag}`));
+    }
+    renderStackPlan(plans, firstStep);
+
+    const nothingToDo = plans.every(
+      (plan) => plan.removals.length === 0 && plan.actions.every((a) => a.kind === "none"),
+    );
+    if (!migrationsPending && nothingToDo) {
+      pass("Stack", "Everything is current and configured; nothing to apply");
+      return true;
+    }
+
+    if (!(await reviewGate())) return true;
+
+    if (migrationsPending) {
+      heading("database");
+      // Migrations run through any stack host's tunnel; without hosts the
+      // database must be reachable from this machine directly.
+      let migrationHost: Host | undefined = hosts.values().next().value;
+      if (!migrationHost) {
+        localFallback = await connectHost();
+        migrationHost = localFallback;
+      }
+      const result = await runMigrations({
+        connectionUrl: migrateUrl!,
+        targetVersion: opts.targetVersion,
+        dryRun: false,
+        host: migrationHost,
+        persist: false,
+      });
+      if (!result.success) {
+        for (const err of result.errors) {
+          fail("Migrations", err);
+        }
+        return false;
+      }
+      stack.dbMigratedVersion = targetTag!;
+      saveStack(stack);
+    }
+
+    let failures = 0;
+    for (const plan of plans) {
+      heading(plan.address);
+      const host = hosts.get(plan.address)!;
+      // Strays go first: a component moving between roles could otherwise
+      // collide with its replacement over ports or paths.
+      for (const removal of plan.removals) {
+        const result = await removeComponentCollapsed({ component: removal.component, host });
+        if (!result.success) {
+          failures++;
+          for (const err of result.errors) {
+            fail(removal.component, err);
+          }
+        }
+      }
+      for (const action of plan.actions) {
+        const result = await applyComponentAction(action, host);
+        if (!result.success) {
+          failures++;
+          for (const err of result.errors) {
+            fail(action.component, err);
+          }
+        }
+      }
+    }
+
+    if (failures > 0) {
+      warn("Stack", `${failures} component action(s) failed; see above`);
+      return false;
+    }
+    pass("Stack", deployments.length > 0 ? "All hosts applied successfully" : "Database migrations applied");
+    return true;
+  } finally {
+    await disposeAll(hosts);
+    await localFallback?.dispose();
+  }
+}

--- a/packages/xinity-cli/src/lib/stack-plan.ts
+++ b/packages/xinity-cli/src/lib/stack-plan.ts
@@ -7,7 +7,7 @@
  * editor, and saved back into the stack so it is never asked again.
  * The plan phase reads and prompts only; hosts change after the gate.
  */
-import { cancel, log, note } from "./clack.ts";
+import { cancel, confirm, isCancel, log, note } from "./clack.ts";
 import { bold, cyan, dim, yellow } from "picocolors";
 import { type Component, ENV_SCHEMAS, INFOSERVER_DEFAULT_PORT } from "./component-meta.ts";
 import { type Host, isUnitActiveOn } from "./host.ts";
@@ -397,6 +397,22 @@ async function renderStackPlanScript(stack: StackDefinition, plan: StackPlan): P
   return sections.join("\n");
 }
 
+async function confirmForeignClaims(plan: StackPlan): Promise<boolean> {
+  const foreignClaims = plan.hostPlans.filter((p) => p.foreignStack);
+  if (foreignClaims.length === 0) {
+    return true;
+  }
+  const message = foreignClaims.length === 1
+    ? `${foreignClaims[0]!.address} belongs to stack "${foreignClaims[0]!.foreignStack}". Claim it for this stack?`
+    : `${foreignClaims.length} hosts belong to other stacks. Claim them for this stack?`;
+  const ok = await confirm({ message, initialValue: false });
+  if (isCancel(ok) || !ok) {
+    cancel("Aborted, nothing was changed.");
+    return false;
+  }
+  return true;
+}
+
 // ─── Apply ──────────────────────────────────────────────────────────────────
 
 async function applyStackPlan(
@@ -552,6 +568,10 @@ export async function runStackFlow(
       log.info(yellow("Dry run, stopping before apply."));
       return true;
     }
+    if (!(await confirmForeignClaims(plan))) {
+      return true;
+    }
+
     if (!(await reviewGate(() => renderStackPlanScript(stack, plan)))) {
       return true;
     }

--- a/packages/xinity-cli/src/lib/stack-plan.ts
+++ b/packages/xinity-cli/src/lib/stack-plan.ts
@@ -15,7 +15,7 @@ import { heading, warn, fail, pass } from "./output.ts";
 import { unitName } from "./systemd.ts";
 import { fetchRelease } from "./github.ts";
 import { resolveVersion, applyComponentAction } from "./installer.ts";
-import { removeComponentCollapsed } from "./install-remove.ts";
+import { removeComponent } from "./install-remove.ts";
 import { readManifest, saveStackMembership, type StackMembership } from "./manifest.ts";
 import { describeMigrationStep, migrationScriptComment, runMigrations } from "./migrator.ts";
 import { connectHost } from "./remote-host.ts";
@@ -29,7 +29,9 @@ import {
 } from "./stack.ts";
 import { editSharedLayer, editComponentLayer, editFleetLayer, editHostLayer } from "./stack-layers.ts";
 import { loadStackState, findOrphanHosts, markHostManaged, unmarkHostManaged } from "./stack-state.ts";
-import { connectHosts, connectElevated, disposeAll } from "./multi-host.ts";
+import { connectHosts, connectElevated, disposeAll, mapBounded, HOST_CONCURRENCY } from "./multi-host.ts";
+import { collectSteps } from "./step-runner.ts";
+import { createMultiProgress, createDoneGuard } from "./multi-progress.ts";
 
 export const COMPONENT_ORDER: Component[] = ["infoserver", "gateway", "dashboard", "daemon"];
 
@@ -461,50 +463,70 @@ async function applyStackPlan(
   }
 
   const active = plan.hostPlans.filter((p) => !p.forget);
-  const hostResults: { hostPlan: StackHostPlan; hostFailures: number }[] = [];
-  for (const hostPlan of active) {
-    heading(hostPlan.address);
-    const host = (hosts.get(hostPlan.address) ?? orphanHosts.get(hostPlan.address))!;
-    let hostFailures = 0;
-    for (const removal of hostPlan.removals) {
-      const result = await removeComponentCollapsed({ component: removal.component, host });
-      if (!result.success) {
-        hostFailures++;
-        for (const err of result.errors) {
-          fail(removal.component, err);
-        }
-      }
-    }
-    for (const action of hostPlan.actions) {
-      const result = await applyComponentAction(action, host);
-      if (!result.success) {
-        hostFailures++;
-        for (const err of result.errors) {
-          fail(action.component, err);
-        }
-      }
-    }
-    if (hostPlan.membership) {
-      await saveStackMembership(hostPlan.membership, host);
-    }
-    hostResults.push({ hostPlan, hostFailures });
-  }
 
-  let failures = 0;
-  for (const { hostPlan, hostFailures } of hostResults) {
-    if (hostPlan.evacuate && hostFailures === 0) {
+  if (active.length > 0) {
+    const multi = createMultiProgress({
+      message: `Applying to ${active.length} host${active.length === 1 ? "" : "s"}`,
+      slots: active.map((p) => p.address),
+    });
+
+    const hostResults = await mapBounded(active, HOST_CONCURRENCY, async (hostPlan) => {
       const host = (hosts.get(hostPlan.address) ?? orphanHosts.get(hostPlan.address))!;
-      await saveStackMembership(null, host);
-      unmarkHostManaged(stack.name, hostPlan.address);
-    }
-    failures += hostFailures;
-  }
+      const slot = multi.slot(hostPlan.address);
+      const guard = createDoneGuard(slot);
+      const errors: { component: string; messages: string[] }[] = [];
+      for (const removal of hostPlan.removals) {
+        slot.update(`removing ${removal.component}`);
+        const { result } = await collectSteps(removeComponent({ component: removal.component, host }));
+        if (!result.success) {
+          errors.push({ component: removal.component, messages: result.errors });
+        }
+      }
+      for (const action of hostPlan.actions) {
+        slot.update(`${action.component}: preparing`);
+        const result = await applyComponentAction(action, host, "rollback", guard);
+        if (!result.success) {
+          errors.push({ component: action.component, messages: result.errors });
+        }
+      }
+      if (hostPlan.membership) {
+        await saveStackMembership(hostPlan.membership, host);
+      }
+      if (errors.length > 0) {
+        slot.fail(`${errors.length} component(s) failed`);
+      } else {
+        slot.done(hostPlan.evacuate ? "evacuated" : "applied");
+      }
+      return { hostPlan, errors };
+    });
 
-  if (failures > 0) {
-    warn("Stack", `${failures} component action(s) failed; see above`);
-    return false;
-  }
-  if (plan.hostPlans.some((p) => !p.forget)) {
+    multi.done();
+
+    for (const { hostPlan, errors } of hostResults) {
+      if (errors.length > 0) {
+        heading(hostPlan.address);
+        for (const { component, messages } of errors) {
+          for (const msg of messages) {
+            fail(component, msg);
+          }
+        }
+      }
+    }
+
+    let failures = 0;
+    for (const { hostPlan, errors } of hostResults) {
+      if (hostPlan.evacuate && errors.length === 0) {
+        const host = (hosts.get(hostPlan.address) ?? orphanHosts.get(hostPlan.address))!;
+        await saveStackMembership(null, host);
+        unmarkHostManaged(stack.name, hostPlan.address);
+      }
+      failures += errors.length;
+    }
+
+    if (failures > 0) {
+      warn("Stack", `${failures} component action(s) failed; see above`);
+      return false;
+    }
     pass("Stack", "All hosts applied successfully");
   } else if (plan.migration?.pending) {
     pass("Stack", "Database migrations applied");

--- a/packages/xinity-cli/src/lib/stack-plan.ts
+++ b/packages/xinity-cli/src/lib/stack-plan.ts
@@ -23,7 +23,7 @@ import { type ComponentAction, describeComponentAction, buildComponentAction, re
 import { analyzeEnvSchema, splitValuesByCategory, readExistingEnvState, diffEnv, missingRequiredFields } from "./env-prompt.ts";
 import {
   type StackDefinition, type StackHost, type FleetDefinition,
-  resolveEnv, saveStack, getFleetForHost, hostLabel, validateStack,
+  resolveEnv, saveStack, getFleetForHost, hostLabel,
   componentLayerSeed, fleetLayerSeed,
   STACK_SHARED_SCHEMA,
 } from "./stack.ts";
@@ -507,15 +507,6 @@ export async function runStackFlow(
   stack: StackDefinition,
   opts: { targetVersion: string; dryRun?: boolean },
 ): Promise<boolean> {
-  const validationErrors = validateStack(stack);
-  if (validationErrors.length > 0) {
-    for (const error of validationErrors) {
-      fail(error.field, error.message);
-    }
-    fail("Stack", `The definition is invalid; fix it with: xinity stack edit ${stack.name}`);
-    return false;
-  }
-
   const deployments = selectDeployments(stack);
   const orphanCandidates = findOrphanHosts(loadStackState(stack.name), stack);
 

--- a/packages/xinity-cli/src/lib/stack-plan.ts
+++ b/packages/xinity-cli/src/lib/stack-plan.ts
@@ -96,9 +96,15 @@ function deriveInfoserverUrl(stack: StackDefinition): void {
     ? "localhost"
     : (infoHost.address.split("@").pop() ?? infoHost.address);
   const port = stack.componentEnv.infoserver?.PORT ?? INFOSERVER_DEFAULT_PORT;
-  const url = `http://${hostname}:${port}`;
-  stack.derivedEnv = { ...stack.derivedEnv, INFOSERVER_URL: url };
-  log.info(`INFOSERVER_URL derived from the stack's infoserver host: ${cyan(url)}`);
+  const raw = `http://${hostname}:${port}`;
+  try {
+    new URL(raw);
+  } catch {
+    warn("INFOSERVER_URL", `could not derive a valid URL from host address "${infoHost.address}"`);
+    return;
+  }
+  stack.derivedEnv = { ...stack.derivedEnv, INFOSERVER_URL: raw };
+  log.info(`INFOSERVER_URL derived from the stack's infoserver host: ${cyan(raw)}`);
 }
 
 /**
@@ -521,6 +527,7 @@ async function applyStackPlan(
       return false;
     }
     pass("Stack", "All hosts applied successfully");
+    log.info(dim(`Run ${bold(`xinity stack doctor ${stack.name}`)} to verify all services are healthy`));
   } else if (plan.migration?.pending) {
     pass("Stack", "Database migrations applied");
   } else {

--- a/packages/xinity-cli/src/lib/stack-plan.ts
+++ b/packages/xinity-cli/src/lib/stack-plan.ts
@@ -19,7 +19,7 @@ import { removeComponentCollapsed } from "./install-remove.ts";
 import { readManifest, saveStackMembership, type StackMembership } from "./manifest.ts";
 import { dbHint, runMigrations } from "./migrator.ts";
 import { connectHost } from "./remote-host.ts";
-import { type ComponentAction, describeComponentAction, buildComponentAction, reviewGate } from "./up-plan.ts";
+import { type ComponentAction, describeComponentAction, buildComponentAction, reviewGate, scriptComponentSection } from "./up-plan.ts";
 import { analyzeEnvSchema, splitValuesByCategory, readExistingEnvState, diffEnv, missingRequiredFields } from "./env-prompt.ts";
 import {
   type StackDefinition, type StackHost, type FleetDefinition,
@@ -49,7 +49,26 @@ interface StackHostPlan {
   foreignStack?: string;
   /** Host left the definition; after the removals its membership marker and state entry are cleared. */
   evacuate?: boolean;
+  /** Reason the host needs no work and only its state entry is dropped. */
+  forget?: string;
 }
+
+export interface StackPlan {
+  targetVersion: string;
+  migration: { url: string; targetTag: string; pending: boolean } | null;
+  hostPlans: StackHostPlan[];
+}
+
+type StackPlanOutcome =
+  | { status: "planned"; plan: StackPlan }
+  | { status: "cancelled" }
+  | { status: "failed" };
+
+function stackMigrateUrl(stack: StackDefinition): string | undefined {
+  return stack.secrets.DB_CONNECTION_URL ?? stack.env.DB_CONNECTION_URL;
+}
+
+// ─── Collect ────────────────────────────────────────────────────────────────
 
 function selectDeployments(stack: StackDefinition): Deployment[] {
   const deployments: Deployment[] = [];
@@ -172,45 +191,296 @@ async function planHostComponent(
   }, version, host);
 }
 
-function renderStackPlan(plans: StackHostPlan[], firstStep: number): void {
-  let step = firstStep;
-  for (const plan of plans) {
-    const lines: string[] = [];
-    if (plan.foreignStack) {
-      lines.push(yellow(`⚠ Marked as belonging to stack "${plan.foreignStack}"; this stack will claim it`));
+/**
+ * Collect the full plan: evacuations for hosts that left the definition,
+ * stack-level config (prompting where required values are missing), then
+ * per-host component actions. Nothing on the hosts or in the state file
+ * changes here; connections made to orphans are added to orphanHosts so
+ * the apply phase reuses them and the caller disposes them.
+ */
+async function planStack(
+  stack: StackDefinition,
+  targetVersion: string,
+  deployments: Deployment[],
+  orphanCandidates: string[],
+  hosts: Map<string, Host>,
+  orphanHosts: Map<string, Host>,
+): Promise<StackPlanOutcome> {
+  const migrateUrl = stackMigrateUrl(stack);
+  let migration: StackPlan["migration"] = null;
+  if (migrateUrl) {
+    try {
+      const targetTag = (await fetchRelease(targetVersion)).tagName;
+      migration = { url: migrateUrl, targetTag, pending: targetTag !== stack.dbMigratedVersion };
+    } catch (err) {
+      fail("Release", (err as Error).message);
+      return { status: "failed" };
     }
-    if (plan.evacuate) {
+  }
+
+  const hostPlans: StackHostPlan[] = [];
+  const untracked = (address: string, forget: string): void => {
+    hostPlans.push({ address, removals: [], actions: [], membership: null, forget });
+  };
+
+  // Hosts the state says we manage but the definition no longer lists get
+  // evacuated: everything on them is removed. Unreachable ones are
+  // forgotten; a host another stack has since claimed is left to it.
+  for (const address of orphanCandidates) {
+    const connection = await connectElevated(address);
+    if ("failed" in connection) {
+      if (connection.failed === "declined") {
+        log.error(connection.message);
+        return { status: "failed" };
+      }
+      untracked(address, "no longer in the stack and unreachable");
+      continue;
+    }
+    const host = connection.host;
+    orphanHosts.set(address, host);
+    const manifest = await readManifest(host);
+    if (manifest.stack && manifest.stack.name !== stack.name) {
+      untracked(address, `now belongs to stack "${manifest.stack.name}"`);
+      continue;
+    }
+    const removals = COMPONENT_ORDER
+      .filter((c) => manifest.components[c])
+      .map((c) => ({ component: c, version: manifest.components[c]?.version }));
+    if (removals.length === 0 && !manifest.stack) {
+      untracked(address, "nothing is installed");
+      continue;
+    }
+    hostPlans.push({ address, removals, actions: [], membership: null, evacuate: true });
+  }
+
+  deriveInfoserverUrl(stack);
+  if (!(await ensureStackLevelConfig(stack, deployments))) {
+    return { status: "cancelled" };
+  }
+
+  for (const d of deployments) {
+    const host = hosts.get(d.host.address)!;
+    const manifest = await readManifest(host);
+    const removals = COMPONENT_ORDER
+      .filter((c) => manifest.components[c] && !d.host.components.includes(c))
+      .map((c) => ({ component: c, version: manifest.components[c]?.version }));
+
+    const fleetName = getFleetForHost(stack, d.host.address)?.name;
+    const marked = manifest.stack;
+    const membership: StackMembership | null =
+      marked?.name === stack.name && marked.fleet === fleetName
+        ? null
+        : { name: stack.name, ...(fleetName ? { fleet: fleetName } : {}) };
+    const foreignStack = marked && marked.name !== stack.name ? marked.name : undefined;
+
+    const actions: ComponentAction[] = [];
+    for (const component of d.components) {
+      const action = await planHostComponent(stack, component, d.host.address, host, targetVersion);
+      if (!action) {
+        return { status: "failed" };
+      }
+      actions.push(action);
+    }
+    hostPlans.push({ address: d.host.address, removals, actions, membership, foreignStack });
+  }
+
+  return { status: "planned", plan: { targetVersion, migration, hostPlans } };
+}
+
+// ─── Review ─────────────────────────────────────────────────────────────────
+
+function renderStackPlan(plan: StackPlan): void {
+  log.step(bold("Planned actions"));
+  let step = 1;
+  if (plan.migration?.pending) {
+    log.info(`${step++}. Apply database migrations from release ${plan.migration.targetTag} to ${dbHint(plan.migration.url)}`);
+  } else if (plan.migration) {
+    log.info(dim(`Database migrations already applied for ${plan.migration.targetTag}`));
+  }
+  for (const hostPlan of plan.hostPlans) {
+    const lines: string[] = [];
+    if (hostPlan.foreignStack) {
+      lines.push(yellow(`⚠ Marked as belonging to stack "${hostPlan.foreignStack}"; this stack will claim it`));
+    }
+    if (hostPlan.evacuate) {
       lines.push(yellow("⚠ No longer in the stack definition; everything managed here will be removed"));
     }
-    for (const removal of plan.removals) {
+    if (hostPlan.forget) {
+      lines.push(`${step++}. Stop tracking this host (${hostPlan.forget})`);
+    }
+    for (const removal of hostPlan.removals) {
       lines.push(`${step++}. Remove ${cyan(removal.component)}${removal.version ? ` ${removal.version}` : ""}`);
       lines.push(dim("   installed on the host but not part of this stack"));
     }
-    for (const action of plan.actions) {
+    for (const action of hostPlan.actions) {
       const [head, ...rest] = describeComponentAction(action);
       lines.push(`${step++}. ${head}`);
       for (const line of rest) {
         lines.push(dim(`   ${line}`));
       }
     }
-    if (plan.membership) {
-      lines.push(`${step++}. Record stack membership: ${cyan(plan.membership.name)}${plan.membership.fleet ? ` · fleet ${cyan(plan.membership.fleet)}` : ""}`);
+    if (hostPlan.membership) {
+      lines.push(`${step++}. Record stack membership: ${cyan(hostPlan.membership.name)}${hostPlan.membership.fleet ? ` · fleet ${cyan(hostPlan.membership.fleet)}` : ""}`);
     }
-    if (plan.evacuate) {
+    if (hostPlan.evacuate) {
       lines.push(`${step++}. Clear stack membership and stop managing this host`);
     }
-    note(lines.join("\n"), cyan(plan.address));
+    note(lines.join("\n"), cyan(hostPlan.address));
   }
 }
 
+function stackPlanIsEmpty(plan: StackPlan): boolean {
+  return !plan.migration?.pending && plan.hostPlans.every(
+    (p) => p.removals.length === 0 && p.membership === null && !p.evacuate && !p.forget && p.actions.every((a) => a.kind === "none"),
+  );
+}
+
+const SCRIPT_HEADER = [
+  "#!/usr/bin/env bash",
+  "# Equivalent script for the reviewed actions; each section runs as root on the named host.",
+  "# WARNING: contains configuration secrets in plain text.",
+  "set -euo pipefail",
+  "",
+];
+
 /**
- * The shared engine behind `stack up` and `fleet up`: collect everything,
- * review one plan, gate once, then apply host by host.
+ * Bash script reproducing the plan's per-host component actions. Steps the
+ * CLI performs itself (migrations, membership markers, the state file) have
+ * no bash equivalent and appear as comments.
+ */
+async function renderStackPlanScript(stack: StackDefinition, plan: StackPlan): Promise<string> {
+  const sections: string[] = [...SCRIPT_HEADER];
+  if (plan.migration?.pending) {
+    sections.push(
+      "# Database migrations run inside the CLI (drizzle migrator, no bash equivalent):",
+      `#   xinity stack up ${stack.name}`,
+      "",
+    );
+  }
+  for (const hostPlan of plan.hostPlans) {
+    sections.push(`# ════ ${hostPlan.address} ════`);
+    if (hostPlan.forget) {
+      sections.push(`# only its state entry is dropped (${hostPlan.forget}); nothing runs here`, "");
+      continue;
+    }
+    for (const removal of hostPlan.removals) {
+      sections.push(`# remove ${removal.component}: no bash equivalent; run: xinity rm ${removal.component} --target-host ${hostPlan.address}`);
+    }
+    for (const action of hostPlan.actions) {
+      sections.push(...(await scriptComponentSection(action)));
+    }
+    if (hostPlan.membership || hostPlan.evacuate) {
+      sections.push("# the stack membership marker in the host manifest is maintained by the CLI");
+    }
+    sections.push("");
+  }
+  return sections.join("\n");
+}
+
+// ─── Apply ──────────────────────────────────────────────────────────────────
+
+async function applyStackPlan(
+  stack: StackDefinition,
+  plan: StackPlan,
+  hosts: Map<string, Host>,
+  orphanHosts: Map<string, Host>,
+): Promise<boolean> {
+  if (plan.migration?.pending) {
+    heading("database");
+    // Migrations run through any stack host's tunnel; without hosts the
+    // database must be reachable from this machine directly.
+    let migrationHost: Host | undefined = hosts.values().next().value;
+    let localFallback: Host | null = null;
+    if (!migrationHost) {
+      localFallback = await connectHost();
+      migrationHost = localFallback;
+    }
+    try {
+      const result = await runMigrations({
+        connectionUrl: plan.migration.url,
+        targetVersion: plan.targetVersion,
+        dryRun: false,
+        host: migrationHost,
+        persist: false,
+      });
+      if (!result.success) {
+        for (const err of result.errors) {
+          fail("Migrations", err);
+        }
+        return false;
+      }
+    } finally {
+      await localFallback?.dispose();
+    }
+    stack.dbMigratedVersion = plan.migration.targetTag;
+    saveStack(stack);
+  }
+
+  let failures = 0;
+  for (const hostPlan of plan.hostPlans) {
+    if (hostPlan.forget) {
+      unmarkHostManaged(stack.name, hostPlan.address);
+      continue;
+    }
+    heading(hostPlan.address);
+    const host = (hosts.get(hostPlan.address) ?? orphanHosts.get(hostPlan.address))!;
+    if (!hostPlan.evacuate) {
+      markHostManaged(stack.name, hostPlan.address);
+    }
+    let hostFailures = 0;
+    // Strays go first: a component moving between roles could otherwise
+    // collide with its replacement over ports or paths.
+    for (const removal of hostPlan.removals) {
+      const result = await removeComponentCollapsed({ component: removal.component, host });
+      if (!result.success) {
+        hostFailures++;
+        for (const err of result.errors) {
+          fail(removal.component, err);
+        }
+      }
+    }
+    for (const action of hostPlan.actions) {
+      const result = await applyComponentAction(action, host);
+      if (!result.success) {
+        hostFailures++;
+        for (const err of result.errors) {
+          fail(action.component, err);
+        }
+      }
+    }
+    if (hostPlan.membership) {
+      await saveStackMembership(hostPlan.membership, host);
+    }
+    // A failed evacuation stays in the state so the next up retries it.
+    if (hostPlan.evacuate && hostFailures === 0) {
+      await saveStackMembership(null, host);
+      unmarkHostManaged(stack.name, hostPlan.address);
+    }
+    failures += hostFailures;
+  }
+
+  if (failures > 0) {
+    warn("Stack", `${failures} component action(s) failed; see above`);
+    return false;
+  }
+  if (plan.hostPlans.some((p) => !p.forget)) {
+    pass("Stack", "All hosts applied successfully");
+  } else if (plan.migration?.pending) {
+    pass("Stack", "Database migrations applied");
+  } else {
+    pass("Stack", "Stack state updated");
+  }
+  return true;
+}
+
+/**
+ * The shared engine behind `stack up`: collect everything, review one plan,
+ * gate once (or stop there on a dry run), then apply host by host.
  * Returns false when something failed (as opposed to a clean abort).
  */
 export async function runStackFlow(
   stack: StackDefinition,
-  opts: { targetVersion: string },
+  opts: { targetVersion: string; dryRun?: boolean },
 ): Promise<boolean> {
   const validationErrors = validateStack(stack);
   if (validationErrors.length > 0) {
@@ -222,10 +492,9 @@ export async function runStackFlow(
   }
 
   const deployments = selectDeployments(stack);
-  const migrateUrl = stack.secrets.DB_CONNECTION_URL ?? stack.env.DB_CONNECTION_URL;
   const orphanCandidates = findOrphanHosts(loadStackState(stack.name), stack);
 
-  if (deployments.length === 0 && !migrateUrl && orphanCandidates.length === 0) {
+  if (deployments.length === 0 && !stackMigrateUrl(stack) && orphanCandidates.length === 0) {
     warn("Stack", "Nothing to deploy (no matching hosts with components)");
     return true;
   }
@@ -239,17 +508,6 @@ export async function runStackFlow(
     log.info(dim(`No hosts defined yet; planning database migrations only. Add hosts with: xinity stack edit ${stack.name}`));
   }
 
-  let targetTag: string | null = null;
-  if (migrateUrl) {
-    try {
-      targetTag = (await fetchRelease(opts.targetVersion)).tagName;
-    } catch (err) {
-      fail("Release", (err as Error).message);
-      return false;
-    }
-  }
-  const migrationsPending = migrateUrl !== undefined && targetTag !== stack.dbMigratedVersion;
-
   const hosts = deployments.length > 0
     ? await connectHosts(deployments.map((d) => d.host.address))
     : new Map<string, Host>();
@@ -258,168 +516,33 @@ export async function runStackFlow(
   }
 
   const orphanHosts = new Map<string, Host>();
-  let localFallback: Host | null = null;
   try {
-    const plans: StackHostPlan[] = [];
-
-    // Hosts the state says we manage but the definition no longer lists get
-    // evacuated: everything on them is removed. Unreachable ones are
-    // forgotten; a host another stack has since claimed is left to it.
-    for (const address of orphanCandidates) {
-      const connection = await connectElevated(address);
-      if ("failed" in connection) {
-        if (connection.failed === "declined") {
-          log.error(connection.message);
-          return false;
-        }
-        warn(address, "No longer in the stack and unreachable; forgetting it");
-        unmarkHostManaged(stack.name, address);
-        continue;
-      }
-      const host = connection.host;
-      orphanHosts.set(address, host);
-      const manifest = await readManifest(host);
-      if (manifest.stack && manifest.stack.name !== stack.name) {
-        log.info(`${address} is no longer in this stack and now belongs to "${manifest.stack.name}"; leaving it untouched`);
-        unmarkHostManaged(stack.name, address);
-        continue;
-      }
-      const removals = COMPONENT_ORDER
-        .filter((c) => manifest.components[c])
-        .map((c) => ({ component: c, version: manifest.components[c]?.version }));
-      if (removals.length === 0 && !manifest.stack) {
-        unmarkHostManaged(stack.name, address);
-        continue;
-      }
-      plans.push({ address, removals, actions: [], membership: null, evacuate: true });
+    const outcome = await planStack(stack, opts.targetVersion, deployments, orphanCandidates, hosts, orphanHosts);
+    if (outcome.status === "failed") {
+      return false;
     }
-
-    deriveInfoserverUrl(stack);
-    if (!(await ensureStackLevelConfig(stack, deployments))) {
+    if (outcome.status === "cancelled") {
       cancel("Cancelled, nothing was changed on the hosts.");
       return true;
     }
 
-    for (const d of deployments) {
-      const host = hosts.get(d.host.address)!;
-      markHostManaged(stack.name, d.host.address);
-
-      const manifest = await readManifest(host);
-      const removals = COMPONENT_ORDER
-        .filter((c) => manifest.components[c] && !d.host.components.includes(c))
-        .map((c) => ({ component: c, version: manifest.components[c]?.version }));
-
-      const fleetName = getFleetForHost(stack, d.host.address)?.name;
-      const marked = manifest.stack;
-      const membership: StackMembership | null =
-        marked?.name === stack.name && marked.fleet === fleetName
-          ? null
-          : { name: stack.name, ...(fleetName ? { fleet: fleetName } : {}) };
-      const foreignStack = marked && marked.name !== stack.name ? marked.name : undefined;
-
-      const actions: ComponentAction[] = [];
-      for (const component of d.components) {
-        const action = await planHostComponent(stack, component, d.host.address, host, opts.targetVersion);
-        if (!action) {
-          return false;
-        }
-        actions.push(action);
-      }
-      plans.push({ address: d.host.address, removals, actions, membership, foreignStack });
-    }
-
-    log.step(bold("Planned actions"));
-    let firstStep = 1;
-    if (migrationsPending) {
-      log.info(`${firstStep++}. Apply database migrations from release ${targetTag} to ${dbHint(migrateUrl!)}`);
-    } else if (migrateUrl) {
-      log.info(dim(`Database migrations already applied for ${targetTag}`));
-    }
-    renderStackPlan(plans, firstStep);
-
-    const nothingToDo = plans.every(
-      (plan) => plan.removals.length === 0 && plan.membership === null && !plan.evacuate && plan.actions.every((a) => a.kind === "none"),
-    );
-    if (!migrationsPending && nothingToDo) {
+    const plan = outcome.plan;
+    renderStackPlan(plan);
+    if (stackPlanIsEmpty(plan)) {
       pass("Stack", "Everything is current and configured; nothing to apply");
       return true;
     }
-
-    if (!(await reviewGate())) {
+    if (opts.dryRun) {
+      log.info(yellow("Dry run, stopping before apply."));
+      return true;
+    }
+    if (!(await reviewGate(() => renderStackPlanScript(stack, plan)))) {
       return true;
     }
 
-    if (migrationsPending) {
-      heading("database");
-      // Migrations run through any stack host's tunnel; without hosts the
-      // database must be reachable from this machine directly.
-      let migrationHost: Host | undefined = hosts.values().next().value;
-      if (!migrationHost) {
-        localFallback = await connectHost();
-        migrationHost = localFallback;
-      }
-      const result = await runMigrations({
-        connectionUrl: migrateUrl!,
-        targetVersion: opts.targetVersion,
-        dryRun: false,
-        host: migrationHost,
-        persist: false,
-      });
-      if (!result.success) {
-        for (const err of result.errors) {
-          fail("Migrations", err);
-        }
-        return false;
-      }
-      stack.dbMigratedVersion = targetTag!;
-      saveStack(stack);
-    }
-
-    let failures = 0;
-    for (const plan of plans) {
-      heading(plan.address);
-      const host = (hosts.get(plan.address) ?? orphanHosts.get(plan.address))!;
-      let hostFailures = 0;
-      // Strays go first: a component moving between roles could otherwise
-      // collide with its replacement over ports or paths.
-      for (const removal of plan.removals) {
-        const result = await removeComponentCollapsed({ component: removal.component, host });
-        if (!result.success) {
-          hostFailures++;
-          for (const err of result.errors) {
-            fail(removal.component, err);
-          }
-        }
-      }
-      for (const action of plan.actions) {
-        const result = await applyComponentAction(action, host);
-        if (!result.success) {
-          hostFailures++;
-          for (const err of result.errors) {
-            fail(action.component, err);
-          }
-        }
-      }
-      if (plan.membership) {
-        await saveStackMembership(plan.membership, host);
-      }
-      // A failed evacuation stays in the state so the next up retries it.
-      if (plan.evacuate && hostFailures === 0) {
-        await saveStackMembership(null, host);
-        unmarkHostManaged(stack.name, plan.address);
-      }
-      failures += hostFailures;
-    }
-
-    if (failures > 0) {
-      warn("Stack", `${failures} component action(s) failed; see above`);
-      return false;
-    }
-    pass("Stack", plans.length > 0 ? "All hosts applied successfully" : "Database migrations applied");
-    return true;
+    return await applyStackPlan(stack, plan, hosts, orphanHosts);
   } finally {
     await disposeAll(hosts);
     await disposeAll(orphanHosts);
-    await localFallback?.dispose();
   }
 }

--- a/packages/xinity-cli/src/lib/stack-plan.ts
+++ b/packages/xinity-cli/src/lib/stack-plan.ts
@@ -126,6 +126,13 @@ async function ensureStackLevelConfig(stack: StackDefinition, deployments: Deplo
     .filter((d) => d.components.includes("daemon"))
     .map((d) => d.host.address);
 
+  const fleetlessDaemons = daemonAddresses.filter((addr) => getFleetForHost(stack, addr) === null);
+  if (fleetlessDaemons.length > 0) {
+    const hosts = fleetlessDaemons.join(", ");
+    warn("Fleet", `${fleetlessDaemons.length === 1 ? "daemon host is" : "daemon hosts are"} not in a fleet: ${hosts}`);
+    log.info(dim(`Group daemons into fleets via ${bold(`xinity stack edit ${stack.name}`)} to manage configuration per pool`));
+  }
+
   for (const component of involvedTypes) {
     if (component === "daemon" && daemonAddresses.every((addr) => getFleetForHost(stack, addr) !== null)) {
       continue;

--- a/packages/xinity-cli/src/lib/stack-plan.ts
+++ b/packages/xinity-cli/src/lib/stack-plan.ts
@@ -9,7 +9,7 @@
  */
 import { cancel, log, note } from "./clack.ts";
 import { bold, cyan, dim, yellow } from "picocolors";
-import { type Component, ENV_SCHEMAS } from "./component-meta.ts";
+import { type Component, ENV_SCHEMAS, INFOSERVER_DEFAULT_PORT } from "./component-meta.ts";
 import { type Host, isUnitActiveOn } from "./host.ts";
 import { heading, warn, fail, pass } from "./output.ts";
 import { unitName } from "./systemd.ts";
@@ -17,7 +17,7 @@ import { fetchRelease } from "./github.ts";
 import { resolveVersion, applyComponentAction } from "./installer.ts";
 import { removeComponentCollapsed } from "./install-remove.ts";
 import { readManifest, saveStackMembership, type StackMembership } from "./manifest.ts";
-import { dbHint, runMigrations } from "./migrator.ts";
+import { describeMigrationStep, migrationScriptComment, runMigrations } from "./migrator.ts";
 import { connectHost } from "./remote-host.ts";
 import { type ComponentAction, describeComponentAction, buildComponentAction, reviewGate, scriptComponentSection } from "./up-plan.ts";
 import { analyzeEnvSchema, splitValuesByCategory, readExistingEnvState, diffEnv, missingRequiredFields } from "./env-prompt.ts";
@@ -93,7 +93,7 @@ function deriveInfoserverUrl(stack: StackDefinition): void {
   const hostname = infoHost.address === "local"
     ? "localhost"
     : (infoHost.address.split("@").pop() ?? infoHost.address);
-  const port = stack.componentEnv.infoserver?.PORT ?? "8090";
+  const port = stack.componentEnv.infoserver?.PORT ?? INFOSERVER_DEFAULT_PORT;
   const url = `http://${hostname}:${port}`;
   stack.derivedEnv = { ...stack.derivedEnv, INFOSERVER_URL: url };
   log.info(`INFOSERVER_URL derived from the stack's infoserver host: ${cyan(url)}`);
@@ -293,7 +293,7 @@ function renderStackPlan(plan: StackPlan): void {
   log.step(bold("Planned actions"));
   let step = 1;
   if (plan.migration?.pending) {
-    log.info(`${step++}. Apply database migrations from release ${plan.migration.targetTag} to ${dbHint(plan.migration.url)}`);
+    log.info(`${step++}. ${describeMigrationStep(plan.migration.targetTag, plan.migration.url)}`);
   } else if (plan.migration) {
     log.info(dim(`Database migrations already applied for ${plan.migration.targetTag}`));
   }
@@ -351,11 +351,7 @@ const SCRIPT_HEADER = [
 async function renderStackPlanScript(stack: StackDefinition, plan: StackPlan): Promise<string> {
   const sections: string[] = [...SCRIPT_HEADER];
   if (plan.migration?.pending) {
-    sections.push(
-      "# Database migrations run inside the CLI (drizzle migrator, no bash equivalent):",
-      `#   xinity stack up ${stack.name}`,
-      "",
-    );
+    sections.push(...migrationScriptComment(`xinity stack up ${stack.name}`));
   }
   for (const hostPlan of plan.hostPlans) {
     sections.push(`# ════ ${hostPlan.address} ════`);

--- a/packages/xinity-cli/src/lib/stack-plan.ts
+++ b/packages/xinity-cli/src/lib/stack-plan.ts
@@ -108,14 +108,11 @@ function deriveInfoserverUrl(stack: StackDefinition): void {
  * values are missing; edits are stored as diffs against the layer below.
  */
 async function ensureStackLevelConfig(stack: StackDefinition, deployments: Deployment[]): Promise<boolean> {
-  // Shared keys added after the stack was created (or by CLI upgrades) get
-  // backfilled here, at their owning layer, before any component editor.
   if (missingRequiredFields(analyzeEnvSchema(STACK_SHARED_SCHEMA), { ...stack.env, ...stack.secrets }).length > 0) {
     heading("shared settings");
     if (!(await editSharedLayer(stack, "Shared stack settings (new required values)"))) {
       return false;
     }
-    saveStack(stack);
   }
 
   const involvedTypes = COMPONENT_ORDER.filter((c) => deployments.some((d) => d.components.includes(c)));
@@ -124,8 +121,6 @@ async function ensureStackLevelConfig(stack: StackDefinition, deployments: Deplo
     .map((d) => d.host.address);
 
   for (const component of involvedTypes) {
-    // Daemon config lives on fleets; the stack-wide layer only matters for
-    // daemon hosts that belong to no fleet.
     if (component === "daemon" && daemonAddresses.every((addr) => getFleetForHost(stack, addr) !== null)) {
       continue;
     }
@@ -135,7 +130,6 @@ async function ensureStackLevelConfig(stack: StackDefinition, deployments: Deplo
       if (!(await editComponentLayer(stack, component, `${component} settings (stack-wide, saved to the stack)`))) {
         return false;
       }
-      saveStack(stack);
     }
   }
 
@@ -147,7 +141,6 @@ async function ensureStackLevelConfig(stack: StackDefinition, deployments: Deplo
       if (!(await editFleetLayer(stack, fleet, `Daemon settings for fleet "${fleet.name}" (saved to the fleet)`))) {
         return false;
       }
-      saveStack(stack);
     }
   }
 
@@ -598,6 +591,7 @@ export async function runStackFlow(
       return true;
     }
 
+    saveStack(stack);
     return await applyStackPlan(stack, plan, hosts, orphanHosts);
   } finally {
     await disposeAll(hosts);

--- a/packages/xinity-cli/src/lib/stack-plan.ts
+++ b/packages/xinity-cli/src/lib/stack-plan.ts
@@ -29,7 +29,7 @@ import {
 } from "./stack.ts";
 import { editSharedLayer, editComponentLayer, editFleetLayer, editHostLayer } from "./stack-layers.ts";
 import { loadStackState, findOrphanHosts, markHostManaged, unmarkHostManaged } from "./stack-state.ts";
-import { connectHosts, connectElevated, disposeAll, mapBounded, HOST_CONCURRENCY } from "./multi-host.ts";
+import { connectHosts, connectElevated, disposeAll } from "./multi-host.ts";
 
 export const COMPONENT_ORDER: Component[] = ["infoserver", "gateway", "dashboard", "daemon"];
 
@@ -445,7 +445,8 @@ async function applyStackPlan(
   }
 
   const active = plan.hostPlans.filter((p) => !p.forget);
-  const hostResults = await mapBounded(active, HOST_CONCURRENCY, async (hostPlan) => {
+  const hostResults: { hostPlan: StackHostPlan; hostFailures: number }[] = [];
+  for (const hostPlan of active) {
     heading(hostPlan.address);
     const host = (hosts.get(hostPlan.address) ?? orphanHosts.get(hostPlan.address))!;
     let hostFailures = 0;
@@ -470,8 +471,8 @@ async function applyStackPlan(
     if (hostPlan.membership) {
       await saveStackMembership(hostPlan.membership, host);
     }
-    return { hostPlan, hostFailures };
-  });
+    hostResults.push({ hostPlan, hostFailures });
+  }
 
   let failures = 0;
   for (const { hostPlan, hostFailures } of hostResults) {

--- a/packages/xinity-cli/src/lib/stack-plan.ts
+++ b/packages/xinity-cli/src/lib/stack-plan.ts
@@ -8,7 +8,7 @@
  * The plan phase reads and prompts only; hosts change after the gate.
  */
 import { cancel, log, note } from "./clack.ts";
-import { bold, cyan, dim } from "picocolors";
+import { bold, cyan, dim, yellow } from "picocolors";
 import { type Component, ENV_SCHEMAS } from "./component-meta.ts";
 import { type Host, isUnitActiveOn } from "./host.ts";
 import { heading, warn, fail, pass } from "./output.ts";
@@ -16,18 +16,20 @@ import { unitName } from "./systemd.ts";
 import { fetchRelease } from "./github.ts";
 import { resolveVersion, applyComponentAction } from "./installer.ts";
 import { removeComponentCollapsed } from "./install-remove.ts";
-import { readManifest } from "./manifest.ts";
+import { readManifest, saveStackMembership, type StackMembership } from "./manifest.ts";
 import { dbHint, runMigrations } from "./migrator.ts";
 import { connectHost } from "./remote-host.ts";
 import { type ComponentAction, describeComponentAction, buildComponentAction, reviewGate } from "./up-plan.ts";
-import { analyzeEnvSchema, splitValuesByCategory, menuEditEnv, readExistingEnvState, diffEnv, missingRequiredFields, flattenBundle } from "./env-prompt.ts";
+import { analyzeEnvSchema, splitValuesByCategory, readExistingEnvState, diffEnv, missingRequiredFields } from "./env-prompt.ts";
 import {
   type StackDefinition, type StackHost, type FleetDefinition,
-  resolveEnv, diffFromLayer, saveStack, getHost, hostLabel,
-  STACK_SHARED_KEYS, STACK_SHARED_SCHEMA,
+  resolveEnv, saveStack, getFleetForHost, hostLabel, validateStack,
+  componentLayerSeed, fleetLayerSeed,
+  STACK_SHARED_SCHEMA,
 } from "./stack.ts";
-import { editSharedLayer, editComponentLayer, editFleetLayer, componentLayerSeed, fleetLayerSeed } from "./stack-layers.ts";
-import { connectHosts, disposeAll } from "./multi-host.ts";
+import { editSharedLayer, editComponentLayer, editFleetLayer, editHostLayer } from "./stack-layers.ts";
+import { loadStackState, findOrphanHosts, markHostManaged, unmarkHostManaged } from "./stack-state.ts";
+import { connectHosts, connectElevated, disposeAll } from "./multi-host.ts";
 
 export const COMPONENT_ORDER: Component[] = ["infoserver", "gateway", "dashboard", "daemon"];
 
@@ -41,6 +43,12 @@ interface StackHostPlan {
   /** Installed on the host but not tracked by the stack; removed before anything else. */
   removals: { component: Component; version?: string }[];
   actions: ComponentAction[];
+  /** Set when the host's manifest doesn't yet record this stack/fleet ownership. */
+  membership: StackMembership | null;
+  /** Name in the host's manifest when it belongs to a different stack. */
+  foreignStack?: string;
+  /** Host left the definition; after the removals its membership marker and state entry are cleared. */
+  evacuate?: boolean;
 }
 
 function selectDeployments(stack: StackDefinition): Deployment[] {
@@ -54,17 +62,22 @@ function selectDeployments(stack: StackDefinition): Deployment[] {
   return deployments;
 }
 
-/** An in-stack infoserver's URL is derived from its host, not asked for. */
+/** An in-stack infoserver's URL is derived from its host, not asked for. An explicit stack env value wins. */
 function deriveInfoserverUrl(stack: StackDefinition): void {
-  if (stack.env.INFOSERVER_URL) return;
+  if (stack.env.INFOSERVER_URL) {
+    return;
+  }
   const infoHost = stack.hosts.find((h) => h.components.includes("infoserver"));
-  if (!infoHost) return;
+  if (!infoHost) {
+    return;
+  }
   const hostname = infoHost.address === "local"
     ? "localhost"
     : (infoHost.address.split("@").pop() ?? infoHost.address);
   const port = stack.componentEnv.infoserver?.PORT ?? "8090";
-  stack.env.INFOSERVER_URL = `http://${hostname}:${port}`;
-  log.info(`INFOSERVER_URL derived from the stack's infoserver host: ${cyan(stack.env.INFOSERVER_URL)}`);
+  const url = `http://${hostname}:${port}`;
+  stack.derivedEnv = { ...stack.derivedEnv, INFOSERVER_URL: url };
+  log.info(`INFOSERVER_URL derived from the stack's infoserver host: ${cyan(url)}`);
 }
 
 /**
@@ -88,17 +101,11 @@ async function ensureStackLevelConfig(stack: StackDefinition, deployments: Deplo
   const daemonAddresses = deployments
     .filter((d) => d.components.includes("daemon"))
     .map((d) => d.host.address);
-  const fleetOf = new Map<string, FleetDefinition>();
-  for (const fleet of stack.fleets) {
-    for (const addr of fleet.hosts) {
-      fleetOf.set(addr, fleet);
-    }
-  }
 
   for (const component of involvedTypes) {
     // Daemon config lives on fleets; the stack-wide layer only matters for
     // daemon hosts that belong to no fleet.
-    if (component === "daemon" && daemonAddresses.every((addr) => fleetOf.has(addr))) {
+    if (component === "daemon" && daemonAddresses.every((addr) => getFleetForHost(stack, addr) !== null)) {
       continue;
     }
     const missing = missingRequiredFields(analyzeEnvSchema(ENV_SCHEMAS[component]), componentLayerSeed(stack, component));
@@ -111,7 +118,7 @@ async function ensureStackLevelConfig(stack: StackDefinition, deployments: Deplo
     }
   }
 
-  const involvedFleets = [...new Set(daemonAddresses.map((addr) => fleetOf.get(addr)).filter((f): f is FleetDefinition => f !== undefined))];
+  const involvedFleets = [...new Set(daemonAddresses.map((addr) => getFleetForHost(stack, addr)).filter((f): f is FleetDefinition => f !== null))];
   for (const fleet of involvedFleets) {
     const missing = missingRequiredFields(analyzeEnvSchema(ENV_SCHEMAS.daemon), fleetLayerSeed(stack, fleet));
     if (fleet.envOverrides === undefined || missing.length > 0) {
@@ -135,7 +142,9 @@ async function planHostComponent(
   targetVersion: string,
 ): Promise<ComponentAction | null> {
   const version = await resolveVersion(component, targetVersion, host);
-  if (version.status === "failed") return null;
+  if (version.status === "failed") {
+    return null;
+  }
 
   const fields = analyzeEnvSchema(ENV_SCHEMAS[component]);
   const { existingConfig, existingSecrets } = await readExistingEnvState(component, host);
@@ -146,16 +155,9 @@ async function planHostComponent(
 
   const missing = missingRequiredFields(fields, merged);
   if (missing.length > 0) {
-    const result = await menuEditEnv(ENV_SCHEMAS[component], merged, {
-      hiddenKeys: STACK_SHARED_KEYS,
-      message: `${component} settings for ${address} (saved as host overrides)`,
-    });
-    if (result === null) return null;
-    const overrides = diffFromLayer(flattenBundle(result), merged);
-    const stackHost = getHost(stack, address);
-    if (stackHost && Object.keys(overrides).length > 0) {
-      stackHost.envOverrides = { ...stackHost.envOverrides, ...overrides };
-      saveStack(stack);
+    const overrides = await editHostLayer(stack, address, component, merged);
+    if (overrides === null) {
+      return null;
     }
     merged = { ...merged, ...overrides };
   }
@@ -174,6 +176,12 @@ function renderStackPlan(plans: StackHostPlan[], firstStep: number): void {
   let step = firstStep;
   for (const plan of plans) {
     const lines: string[] = [];
+    if (plan.foreignStack) {
+      lines.push(yellow(`⚠ Marked as belonging to stack "${plan.foreignStack}"; this stack will claim it`));
+    }
+    if (plan.evacuate) {
+      lines.push(yellow("⚠ No longer in the stack definition; everything managed here will be removed"));
+    }
     for (const removal of plan.removals) {
       lines.push(`${step++}. Remove ${cyan(removal.component)}${removal.version ? ` ${removal.version}` : ""}`);
       lines.push(dim("   installed on the host but not part of this stack"));
@@ -184,6 +192,12 @@ function renderStackPlan(plans: StackHostPlan[], firstStep: number): void {
       for (const line of rest) {
         lines.push(dim(`   ${line}`));
       }
+    }
+    if (plan.membership) {
+      lines.push(`${step++}. Record stack membership: ${cyan(plan.membership.name)}${plan.membership.fleet ? ` · fleet ${cyan(plan.membership.fleet)}` : ""}`);
+    }
+    if (plan.evacuate) {
+      lines.push(`${step++}. Clear stack membership and stop managing this host`);
     }
     note(lines.join("\n"), cyan(plan.address));
   }
@@ -198,10 +212,20 @@ export async function runStackFlow(
   stack: StackDefinition,
   opts: { targetVersion: string },
 ): Promise<boolean> {
+  const validationErrors = validateStack(stack);
+  if (validationErrors.length > 0) {
+    for (const error of validationErrors) {
+      fail(error.field, error.message);
+    }
+    fail("Stack", `The definition is invalid; fix it with: xinity stack edit ${stack.name}`);
+    return false;
+  }
+
   const deployments = selectDeployments(stack);
   const migrateUrl = stack.secrets.DB_CONNECTION_URL ?? stack.env.DB_CONNECTION_URL;
+  const orphanCandidates = findOrphanHosts(loadStackState(stack.name), stack);
 
-  if (deployments.length === 0 && !migrateUrl) {
+  if (deployments.length === 0 && !migrateUrl && orphanCandidates.length === 0) {
     warn("Stack", "Nothing to deploy (no matching hosts with components)");
     return true;
   }
@@ -211,7 +235,7 @@ export async function runStackFlow(
     for (const d of deployments) {
       log.info(`  ${hostLabel(d.host)}: ${d.components.map((c) => cyan(c)).join(", ")}`);
     }
-  } else {
+  } else if (orphanCandidates.length === 0) {
     log.info(dim(`No hosts defined yet; planning database migrations only. Add hosts with: xinity stack edit ${stack.name}`));
   }
 
@@ -229,32 +253,79 @@ export async function runStackFlow(
   const hosts = deployments.length > 0
     ? await connectHosts(deployments.map((d) => d.host.address))
     : new Map<string, Host>();
-  if (!hosts) return false;
+  if (!hosts) {
+    return false;
+  }
 
+  const orphanHosts = new Map<string, Host>();
   let localFallback: Host | null = null;
   try {
+    const plans: StackHostPlan[] = [];
+
+    // Hosts the state says we manage but the definition no longer lists get
+    // evacuated: everything on them is removed. Unreachable ones are
+    // forgotten; a host another stack has since claimed is left to it.
+    for (const address of orphanCandidates) {
+      const connection = await connectElevated(address);
+      if ("failed" in connection) {
+        if (connection.failed === "declined") {
+          log.error(connection.message);
+          return false;
+        }
+        warn(address, "No longer in the stack and unreachable; forgetting it");
+        unmarkHostManaged(stack.name, address);
+        continue;
+      }
+      const host = connection.host;
+      orphanHosts.set(address, host);
+      const manifest = await readManifest(host);
+      if (manifest.stack && manifest.stack.name !== stack.name) {
+        log.info(`${address} is no longer in this stack and now belongs to "${manifest.stack.name}"; leaving it untouched`);
+        unmarkHostManaged(stack.name, address);
+        continue;
+      }
+      const removals = COMPONENT_ORDER
+        .filter((c) => manifest.components[c])
+        .map((c) => ({ component: c, version: manifest.components[c]?.version }));
+      if (removals.length === 0 && !manifest.stack) {
+        unmarkHostManaged(stack.name, address);
+        continue;
+      }
+      plans.push({ address, removals, actions: [], membership: null, evacuate: true });
+    }
+
     deriveInfoserverUrl(stack);
     if (!(await ensureStackLevelConfig(stack, deployments))) {
       cancel("Cancelled, nothing was changed on the hosts.");
       return true;
     }
 
-    const plans: StackHostPlan[] = [];
     for (const d of deployments) {
       const host = hosts.get(d.host.address)!;
+      markHostManaged(stack.name, d.host.address);
 
       const manifest = await readManifest(host);
       const removals = COMPONENT_ORDER
         .filter((c) => manifest.components[c] && !d.host.components.includes(c))
         .map((c) => ({ component: c, version: manifest.components[c]?.version }));
 
+      const fleetName = getFleetForHost(stack, d.host.address)?.name;
+      const marked = manifest.stack;
+      const membership: StackMembership | null =
+        marked?.name === stack.name && marked.fleet === fleetName
+          ? null
+          : { name: stack.name, ...(fleetName ? { fleet: fleetName } : {}) };
+      const foreignStack = marked && marked.name !== stack.name ? marked.name : undefined;
+
       const actions: ComponentAction[] = [];
       for (const component of d.components) {
         const action = await planHostComponent(stack, component, d.host.address, host, opts.targetVersion);
-        if (!action) return false;
+        if (!action) {
+          return false;
+        }
         actions.push(action);
       }
-      plans.push({ address: d.host.address, removals, actions });
+      plans.push({ address: d.host.address, removals, actions, membership, foreignStack });
     }
 
     log.step(bold("Planned actions"));
@@ -267,14 +338,16 @@ export async function runStackFlow(
     renderStackPlan(plans, firstStep);
 
     const nothingToDo = plans.every(
-      (plan) => plan.removals.length === 0 && plan.actions.every((a) => a.kind === "none"),
+      (plan) => plan.removals.length === 0 && plan.membership === null && !plan.evacuate && plan.actions.every((a) => a.kind === "none"),
     );
     if (!migrationsPending && nothingToDo) {
       pass("Stack", "Everything is current and configured; nothing to apply");
       return true;
     }
 
-    if (!(await reviewGate())) return true;
+    if (!(await reviewGate())) {
+      return true;
+    }
 
     if (migrationsPending) {
       heading("database");
@@ -305,13 +378,14 @@ export async function runStackFlow(
     let failures = 0;
     for (const plan of plans) {
       heading(plan.address);
-      const host = hosts.get(plan.address)!;
+      const host = (hosts.get(plan.address) ?? orphanHosts.get(plan.address))!;
+      let hostFailures = 0;
       // Strays go first: a component moving between roles could otherwise
       // collide with its replacement over ports or paths.
       for (const removal of plan.removals) {
         const result = await removeComponentCollapsed({ component: removal.component, host });
         if (!result.success) {
-          failures++;
+          hostFailures++;
           for (const err of result.errors) {
             fail(removal.component, err);
           }
@@ -320,22 +394,32 @@ export async function runStackFlow(
       for (const action of plan.actions) {
         const result = await applyComponentAction(action, host);
         if (!result.success) {
-          failures++;
+          hostFailures++;
           for (const err of result.errors) {
             fail(action.component, err);
           }
         }
       }
+      if (plan.membership) {
+        await saveStackMembership(plan.membership, host);
+      }
+      // A failed evacuation stays in the state so the next up retries it.
+      if (plan.evacuate && hostFailures === 0) {
+        await saveStackMembership(null, host);
+        unmarkHostManaged(stack.name, plan.address);
+      }
+      failures += hostFailures;
     }
 
     if (failures > 0) {
       warn("Stack", `${failures} component action(s) failed; see above`);
       return false;
     }
-    pass("Stack", deployments.length > 0 ? "All hosts applied successfully" : "Database migrations applied");
+    pass("Stack", plans.length > 0 ? "All hosts applied successfully" : "Database migrations applied");
     return true;
   } finally {
     await disposeAll(hosts);
+    await disposeAll(orphanHosts);
     await localFallback?.dispose();
   }
 }

--- a/packages/xinity-cli/src/lib/stack-state.ts
+++ b/packages/xinity-cli/src/lib/stack-state.ts
@@ -7,30 +7,46 @@
  */
 import { existsSync, unlinkSync } from "fs";
 import { join } from "path";
+import { z } from "zod";
 import { version as cliVersion } from "../../../../package.json";
 import { xinityConfigDir, loadPrivateJson, savePrivateJson } from "./config.ts";
 import type { StackDefinition } from "./stack.ts";
 
-export interface ManagedHost {
-  address: string;
-}
+// ── Schema & Types ──────────────────────────────────────────────────────
 
-export interface StackState {
-  /** CLI version that last wrote this file; lets future versions migrate breaking changes. */
-  version: string;
-  hosts: ManagedHost[];
-}
+const managedHostT = z.object({ address: z.string() });
+
+const stackStateT = z.object({
+  version: z.string().default("0.0.0"),
+  hosts: z.array(managedHostT).default([]),
+});
+
+export type ManagedHost = z.infer<typeof managedHostT>;
+export type StackState = z.infer<typeof stackStateT>;
+
+// ── Paths ───────────────────────────────────────────────────────────────
 
 function statePath(name: string): string {
   return join(xinityConfigDir(), "stacks", "state", `${name}.json`);
 }
 
+// ── Persistence ─────────────────────────────────────────────────────────
+
 export function loadStackState(name: string): StackState {
-  const parsed = loadPrivateJson<Partial<StackState>>(statePath(name));
-  if (!parsed) {
+  let raw: unknown;
+  try {
+    raw = loadPrivateJson<unknown>(statePath(name));
+  } catch {
     return { version: cliVersion, hosts: [] };
   }
-  return { version: "0.0.0", hosts: [], ...parsed };
+  if (raw === null) {
+    return { version: cliVersion, hosts: [] };
+  }
+  const result = stackStateT.safeParse(raw);
+  if (!result.success) {
+    return { version: cliVersion, hosts: [] };
+  }
+  return result.data;
 }
 
 function saveStackState(name: string, state: StackState): void {

--- a/packages/xinity-cli/src/lib/stack-state.ts
+++ b/packages/xinity-cli/src/lib/stack-state.ts
@@ -1,0 +1,85 @@
+/**
+ * Stack state: the hosts a stack actually manages, recorded as they are
+ * reached. The observed counterpart to the declarative stack definition;
+ * `stack up` diffs the two so hosts that were removed from the definition
+ * still get torn down. Kept in its own file so observed facts never mix
+ * with desired configuration.
+ */
+import { existsSync, unlinkSync } from "fs";
+import { join } from "path";
+import { version as cliVersion } from "../../../../package.json";
+import { xinityConfigDir, loadPrivateJson, savePrivateJson } from "./config.ts";
+import type { StackDefinition } from "./stack.ts";
+
+export interface ManagedHost {
+  address: string;
+}
+
+export interface StackState {
+  /** CLI version that last wrote this file; lets future versions migrate breaking changes. */
+  version: string;
+  hosts: ManagedHost[];
+}
+
+function statePath(name: string): string {
+  return join(xinityConfigDir(), "stacks", "state", `${name}.json`);
+}
+
+export function loadStackState(name: string): StackState {
+  const parsed = loadPrivateJson<Partial<StackState>>(statePath(name));
+  if (!parsed) {
+    return { version: cliVersion, hosts: [] };
+  }
+  return { version: "0.0.0", hosts: [], ...parsed };
+}
+
+function saveStackState(name: string, state: StackState): void {
+  state.version = cliVersion;
+  savePrivateJson(statePath(name), state);
+}
+
+export function deleteStackState(name: string): void {
+  const path = statePath(name);
+  if (existsSync(path)) {
+    unlinkSync(path);
+  }
+}
+
+/** Returns true when the state changed. */
+export function addManagedHost(state: StackState, address: string): boolean {
+  if (state.hosts.some((h) => h.address === address)) {
+    return false;
+  }
+  state.hosts.push({ address });
+  return true;
+}
+
+/** Returns true when the state changed. */
+export function removeManagedHost(state: StackState, address: string): boolean {
+  const remaining = state.hosts.filter((h) => h.address !== address);
+  if (remaining.length === state.hosts.length) {
+    return false;
+  }
+  state.hosts = remaining;
+  return true;
+}
+
+export function markHostManaged(name: string, address: string): void {
+  const state = loadStackState(name);
+  if (addManagedHost(state, address)) {
+    saveStackState(name, state);
+  }
+}
+
+export function unmarkHostManaged(name: string, address: string): void {
+  const state = loadStackState(name);
+  if (removeManagedHost(state, address)) {
+    saveStackState(name, state);
+  }
+}
+
+/** Managed hosts that are no longer part of the stack definition. */
+export function findOrphanHosts(state: StackState, stack: StackDefinition): string[] {
+  const configured = new Set(stack.hosts.map((h) => h.address));
+  return state.hosts.map((h) => h.address).filter((address) => !configured.has(address));
+}

--- a/packages/xinity-cli/src/lib/stack.ts
+++ b/packages/xinity-cli/src/lib/stack.ts
@@ -37,7 +37,7 @@ export interface StackDefinition {
   /** Release tag whose migrations were last applied to the stack's database. */
   dbMigratedVersion?: string;
   /** The release every component is held at; updated only on explicit request. */
-  pinnedVersion?: string;
+  pinnedVersion: string;
   hosts: StackHost[];
   fleets: FleetDefinition[];
 }
@@ -115,7 +115,7 @@ export function loadStack(name: string): StackDefinition | null {
   if (!parsed) {
     return null;
   }
-  return { ...createStack(name), version: "0.0.0", ...parsed };
+  return { ...createStack(name, ""), version: "0.0.0", ...parsed };
 }
 
 export function saveStack(stack: StackDefinition): void {
@@ -248,11 +248,24 @@ export interface ValidationError {
   message: string;
 }
 
+export function validateStackName(name: string): string | null {
+  return !name || !/^[a-z0-9][a-z0-9_-]*$/.test(name)
+    ? "Must be lowercase alphanumeric with hyphens/underscores, starting with a letter or digit"
+    : null;
+}
+
 export function validateStack(stack: StackDefinition): ValidationError[] {
   const errors: ValidationError[] = [];
 
-  if (!stack.name || !/^[a-z0-9][a-z0-9_-]*$/.test(stack.name)) {
-    errors.push({ field: "name", message: "Must be lowercase alphanumeric with hyphens/underscores, starting with a letter or digit" });
+  const nameError = validateStackName(stack.name);
+  if (nameError) {
+    errors.push({ field: "name", message: nameError });
+  }
+
+  // Only reachable through hand-edited files; the CLI never writes a stack
+  // without a pin.
+  if (!stack.pinnedVersion) {
+    errors.push({ field: "pinnedVersion", message: "No release version pinned" });
   }
 
   const hostAddresses = new Set(stack.hosts.map((h) => h.address));
@@ -307,13 +320,14 @@ export function validateStack(stack: StackDefinition): ValidationError[] {
 
 // ── Factory ──────────────────────────────────────────────────────────────
 
-export function createStack(name: string): StackDefinition {
+export function createStack(name: string, pinnedVersion: string): StackDefinition {
   return {
     version: cliVersion,
     name,
     env: {},
     secrets: {},
     componentEnv: {},
+    pinnedVersion,
     hosts: [],
     fleets: [],
   };

--- a/packages/xinity-cli/src/lib/stack.ts
+++ b/packages/xinity-cli/src/lib/stack.ts
@@ -15,45 +15,46 @@ import { secret } from "common-env";
 import { version as cliVersion } from "../../../../package.json";
 import { type Component, getAutoDefaults } from "./component-meta.ts";
 import { analyzeEnvSchema } from "./env-prompt.ts";
+import { log } from "./clack.ts";
+import { dim } from "picocolors";
 import { deleteStackState } from "./stack-state.ts";
 
-// ── Types ────────────────────────────────────────────────────────────────
+// ── Schemas & Types ─────────────────────────────────────────────────────
 
-export interface StackDefinition {
-  /** CLI version that last wrote this file; lets future versions migrate breaking changes. */
-  version: string;
-  name: string;
-  /** Shared, inherited by every component (DB_CONNECTION_URL, INFOSERVER_URL, ...). */
-  env: Record<string, string>;
-  /**
-   * Values derived for the current run (e.g. INFOSERVER_URL from the
-   * infoserver host's address). Sits below `env` so explicit values win,
-   * and is never persisted so it re-derives when the stack changes.
-   */
+const componentT = z.enum(["gateway", "dashboard", "daemon", "infoserver"]);
+
+const envRecordT = z.record(z.string(), z.string());
+
+const stackHostT = z.object({
+  alias: z.string().optional(),
+  address: z.string(),
+  components: z.array(componentT),
+  envOverrides: envRecordT.optional(),
+});
+
+const fleetDefinitionT = z.object({
+  name: z.string(),
+  hosts: z.array(z.string()),
+  envOverrides: envRecordT.optional(),
+});
+
+const stackDefinitionT = z.object({
+  version: z.string().default("0.0.0"),
+  name: z.string(),
+  env: envRecordT.default({}),
+  secrets: envRecordT.default({}),
+  componentEnv: z.record(z.string(), envRecordT).default({}) as z.ZodType<Partial<Record<Component, Record<string, string>>>>,
+  dbMigratedVersion: z.string().optional(),
+  pinnedVersion: z.string().default(""),
+  hosts: z.array(stackHostT).default([]),
+  fleets: z.array(fleetDefinitionT).default([]),
+});
+
+export type StackDefinition = z.infer<typeof stackDefinitionT> & {
   derivedEnv?: Record<string, string>;
-  secrets: Record<string, string>;
-  /** Stack-wide settings per component type (gateway PORT vs dashboard PORT don't collide here). */
-  componentEnv: Partial<Record<Component, Record<string, string>>>;
-  /** Release tag whose migrations were last applied to the stack's database. */
-  dbMigratedVersion?: string;
-  /** The release every component is held at; updated only on explicit request. */
-  pinnedVersion: string;
-  hosts: StackHost[];
-  fleets: FleetDefinition[];
-}
-
-export interface StackHost {
-  alias?: string;
-  address: string;
-  components: Component[];
-  envOverrides?: Record<string, string>;
-}
-
-export interface FleetDefinition {
-  name: string;
-  hosts: string[];
-  envOverrides?: Record<string, string>;
-}
+};
+export type StackHost = z.infer<typeof stackHostT>;
+export type FleetDefinition = z.infer<typeof fleetDefinitionT>;
 
 export function hostLabel(host: StackHost): string {
   return host.alias ? `${host.alias} (${host.address})` : host.address;
@@ -108,14 +109,37 @@ function stackPath(name: string): string {
   return join(stacksDir(), `${name}.json`);
 }
 
+export function stackExists(name: string): boolean {
+  return existsSync(stackPath(name));
+}
+
 // ── Persistence ──────────────────────────────────────────────────────────
 
 export function loadStack(name: string): StackDefinition | null {
-  const parsed = loadPrivateJson<Partial<StackDefinition>>(stackPath(name));
-  if (!parsed) {
+  const path = stackPath(name);
+  let raw: unknown;
+  try {
+    raw = loadPrivateJson<unknown>(path);
+  } catch {
+    log.error(`Stack file is not valid JSON: ${dim(path)}`);
     return null;
   }
-  return { ...createStack(name, ""), version: "0.0.0", ...parsed };
+  if (raw === null) {
+    return null;
+  }
+  const result = stackDefinitionT.safeParse(raw);
+  if (!result.success) {
+    log.error(`Stack file is malformed: ${dim(path)}`);
+    for (const issue of result.error.issues) {
+      const field = issue.path.length > 0 ? issue.path.join(".") : "(root)";
+      log.message(`  ${dim("•")} ${field}: ${issue.message}`);
+    }
+    log.message("");
+    log.message(`  Fix the file manually, or remove and re-create it:`)
+    log.message(`  ${dim("xinity stack rm <name> && xinity stack init <name>")}`);
+    return null;
+  }
+  return result.data as StackDefinition;
 }
 
 export function saveStack(stack: StackDefinition): void {

--- a/packages/xinity-cli/src/lib/stack.ts
+++ b/packages/xinity-cli/src/lib/stack.ts
@@ -7,9 +7,9 @@
  * highest level possible; per-host settings are the escape hatch, not the
  * norm.
  */
-import { chmodSync, existsSync, mkdirSync, readFileSync, readdirSync, unlinkSync, writeFileSync } from "fs";
+import { existsSync, readdirSync, unlinkSync } from "fs";
 import { join } from "path";
-import { homedir } from "os";
+import { xinityConfigDir, loadPrivateJson, savePrivateJson } from "./config.ts";
 import { z } from "zod";
 import { secret } from "common-env";
 import { version as cliVersion } from "../../../../package.json";
@@ -93,39 +93,27 @@ export function sharedHiddenKeys(stack: StackDefinition): Set<string> | undefine
 
 // ── Paths ────────────────────────────────────────────────────────────────
 
-const CONFIG_DIR = join(homedir(), ".config", "xinity");
-const STACKS_DIR = join(CONFIG_DIR, "stacks");
+function stacksDir(): string {
+  return join(xinityConfigDir(), "stacks");
+}
 
 function stackPath(name: string): string {
-  return join(STACKS_DIR, `${name}.json`);
+  return join(stacksDir(), `${name}.json`);
 }
 
 // ── Persistence ──────────────────────────────────────────────────────────
 
-function ensureStacksDir(): void {
-  mkdirSync(STACKS_DIR, { recursive: true, mode: 0o700 });
-  chmodSync(STACKS_DIR, 0o700);
-}
-
 export function loadStack(name: string): StackDefinition | null {
-  const path = stackPath(name);
-  if (!existsSync(path)) {
+  const parsed = loadPrivateJson<Partial<StackDefinition>>(stackPath(name));
+  if (!parsed) {
     return null;
   }
-  try {
-    const parsed = JSON.parse(readFileSync(path, "utf-8")) as Partial<StackDefinition>;
-    return { ...createStack(name), version: "0.0.0", ...parsed };
-  } catch {
-    return null;
-  }
+  return { ...createStack(name), version: "0.0.0", ...parsed };
 }
 
 export function saveStack(stack: StackDefinition): void {
-  ensureStacksDir();
-  const path = stackPath(stack.name);
   stack.version = cliVersion;
-  writeFileSync(path, JSON.stringify(stack, null, 2) + "\n", { mode: 0o600 });
-  chmodSync(path, 0o600);
+  savePrivateJson(stackPath(stack.name), stack);
 }
 
 export function deleteStack(name: string): boolean {
@@ -138,10 +126,10 @@ export function deleteStack(name: string): boolean {
 }
 
 export function listStacks(): string[] {
-  if (!existsSync(STACKS_DIR)) {
+  if (!existsSync(stacksDir())) {
     return [];
   }
-  return readdirSync(STACKS_DIR)
+  return readdirSync(stacksDir())
     .filter((f) => f.endsWith(".json"))
     .map((f) => f.replace(/\.json$/, ""))
     .sort();

--- a/packages/xinity-cli/src/lib/stack.ts
+++ b/packages/xinity-cli/src/lib/stack.ts
@@ -25,9 +25,14 @@ const componentT = z.enum(["gateway", "dashboard", "daemon", "infoserver"]);
 
 const envRecordT = z.record(z.string(), z.string());
 
+const hostAddressT = z.string().regex(
+  /^[a-zA-Z0-9_.@:\[\]-]+$/,
+  "Host address may only contain alphanumerics, dots, hyphens, underscores, @, colons, and brackets",
+);
+
 const stackHostT = z.object({
   alias: z.string().optional(),
-  address: z.string(),
+  address: hostAddressT,
   components: z.array(componentT),
   envOverrides: envRecordT.optional(),
 });
@@ -64,7 +69,7 @@ export function hostLabel(host: StackHost): string {
 export const STACK_SHARED_SCHEMA = z.object({
   DB_CONNECTION_URL: z.url().describe("PostgreSQL connection string shared by all components").meta(secret()),
   REDIS_URL: z.url().describe("Redis connection URL shared by all components").meta(secret()),
-  INFOSERVER_URL: z.url().optional().describe("Infoserver URL (hosted default: https://sysinfo.xinity.ai; leave unset when the stack hosts its own)"),
+  INFOSERVER_URL: z.url().optional().describe("Infoserver URL (auto-derived from the infoserver host address if left empty)"),
   METRICS_AUTH: z.string().describe("Basic auth for every component's /metrics endpoint (user:pass, comma-separated for multiple)").meta(secret()),
   HF_TOKEN: z.string().optional().describe("Hugging Face token for gated model downloads").meta(secret()),
 });
@@ -88,15 +93,10 @@ export function applySharedResult(
   }
 }
 
-/** True when the stack runs its own infoserver (configured or placed on a host), so INFOSERVER_URL is derived, never asked. */
+/** True when the stack runs its own infoserver (configured or placed on a host). */
 export function stackHostsInfoserver(stack: StackDefinition): boolean {
   return stack.componentEnv.infoserver !== undefined
     || stack.hosts.some((h) => h.components.includes("infoserver"));
-}
-
-/** Shared-schema keys the shared editor must not offer for this stack. */
-export function sharedHiddenKeys(stack: StackDefinition): Set<string> | undefined {
-  return stackHostsInfoserver(stack) ? new Set(["INFOSERVER_URL"]) : undefined;
 }
 
 // ── Paths ────────────────────────────────────────────────────────────────

--- a/packages/xinity-cli/src/lib/stack.ts
+++ b/packages/xinity-cli/src/lib/stack.ts
@@ -1,0 +1,278 @@
+/**
+ * Stack definitions: declarative multi-host deployments stored locally.
+ *
+ * Configuration is layered, most general first, later layers win:
+ * schema defaults → shared env/secrets → per-component-type settings →
+ * fleet overrides (daemon only) → per-host overrides. Values live at the
+ * highest level possible; per-host settings are the escape hatch, not the
+ * norm.
+ */
+import { chmodSync, existsSync, mkdirSync, readFileSync, readdirSync, unlinkSync, writeFileSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+import { z } from "zod";
+import { secret } from "common-env";
+import { version as cliVersion } from "../../../../package.json";
+import { type Component, getAutoDefaults } from "./component-meta.ts";
+import { analyzeEnvSchema } from "./env-prompt.ts";
+
+// ── Types ────────────────────────────────────────────────────────────────
+
+export interface StackDefinition {
+  /** CLI version that last wrote this file; lets future versions migrate breaking changes. */
+  version: string;
+  name: string;
+  /** Shared, inherited by every component (DB_CONNECTION_URL, INFOSERVER_URL, ...). */
+  env: Record<string, string>;
+  secrets: Record<string, string>;
+  /** Stack-wide settings per component type (gateway PORT vs dashboard PORT don't collide here). */
+  componentEnv: Partial<Record<Component, Record<string, string>>>;
+  /** Release tag whose migrations were last applied to the stack's database. */
+  dbMigratedVersion?: string;
+  /** The release every component is held at; updated only on explicit request. */
+  pinnedVersion?: string;
+  hosts: StackHost[];
+  fleets: FleetDefinition[];
+}
+
+export interface StackHost {
+  alias?: string;
+  address: string;
+  components: Component[];
+  envOverrides?: Record<string, string>;
+}
+
+export interface FleetDefinition {
+  name: string;
+  hosts: string[];
+  envOverrides?: Record<string, string>;
+}
+
+export function hostLabel(host: StackHost): string {
+  return host.alias ? `${host.alias} (${host.address})` : host.address;
+}
+
+/** Shared infra values collected at `stack init`; everything else lives in component/fleet layers. */
+export const STACK_SHARED_SCHEMA = z.object({
+  DB_CONNECTION_URL: z.url().describe("PostgreSQL connection string shared by all components").meta(secret()),
+  REDIS_URL: z.url().describe("Redis connection URL shared by all components").meta(secret()),
+  INFOSERVER_URL: z.url().optional().describe("Infoserver URL (hosted default: https://sysinfo.xinity.ai; leave unset when the stack hosts its own)"),
+  METRICS_AUTH: z.string().describe("Basic auth for every component's /metrics endpoint (user:pass, comma-separated for multiple)").meta(secret()),
+  HF_TOKEN: z.string().optional().describe("Hugging Face token for gated model downloads").meta(secret()),
+});
+
+/** Owned by the shared layer; component/fleet/host editors must not offer them. */
+export const STACK_SHARED_KEYS: Set<string> = new Set(Object.keys(STACK_SHARED_SCHEMA.shape));
+
+/** Write a shared-settings editor result back, honoring deletions of optional keys. */
+export function applySharedResult(
+  stack: StackDefinition,
+  result: { config: Record<string, string>; secrets: Record<string, string> },
+): void {
+  for (const field of analyzeEnvSchema(STACK_SHARED_SCHEMA)) {
+    const bucket = field.isSecret ? stack.secrets : stack.env;
+    const value = field.isSecret ? result.secrets[field.key] : result.config[field.key];
+    if (value === undefined) {
+      delete bucket[field.key];
+    } else {
+      bucket[field.key] = value;
+    }
+  }
+}
+
+/** True when the stack runs its own infoserver (configured or placed on a host), so INFOSERVER_URL is derived, never asked. */
+export function stackHostsInfoserver(stack: StackDefinition): boolean {
+  return stack.componentEnv.infoserver !== undefined
+    || stack.hosts.some((h) => h.components.includes("infoserver"));
+}
+
+/** Shared-schema keys the shared editor must not offer for this stack. */
+export function sharedHiddenKeys(stack: StackDefinition): Set<string> | undefined {
+  return stackHostsInfoserver(stack) ? new Set(["INFOSERVER_URL"]) : undefined;
+}
+
+// ── Paths ────────────────────────────────────────────────────────────────
+
+const CONFIG_DIR = join(homedir(), ".config", "xinity");
+const STACKS_DIR = join(CONFIG_DIR, "stacks");
+
+function stackPath(name: string): string {
+  return join(STACKS_DIR, `${name}.json`);
+}
+
+// ── Persistence ──────────────────────────────────────────────────────────
+
+function ensureStacksDir(): void {
+  mkdirSync(STACKS_DIR, { recursive: true, mode: 0o700 });
+  chmodSync(STACKS_DIR, 0o700);
+}
+
+export function loadStack(name: string): StackDefinition | null {
+  const path = stackPath(name);
+  if (!existsSync(path)) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf-8")) as Partial<StackDefinition>;
+    return { ...createStack(name), version: "0.0.0", ...parsed };
+  } catch {
+    return null;
+  }
+}
+
+export function saveStack(stack: StackDefinition): void {
+  ensureStacksDir();
+  const path = stackPath(stack.name);
+  stack.version = cliVersion;
+  writeFileSync(path, JSON.stringify(stack, null, 2) + "\n", { mode: 0o600 });
+  chmodSync(path, 0o600);
+}
+
+export function deleteStack(name: string): boolean {
+  const path = stackPath(name);
+  if (!existsSync(path)) {
+    return false;
+  }
+  unlinkSync(path);
+  return true;
+}
+
+export function listStacks(): string[] {
+  if (!existsSync(STACKS_DIR)) {
+    return [];
+  }
+  return readdirSync(STACKS_DIR)
+    .filter((f) => f.endsWith(".json"))
+    .map((f) => f.replace(/\.json$/, ""))
+    .sort();
+}
+
+// ── Lookup ───────────────────────────────────────────────────────────────
+
+export function getFleet(stack: StackDefinition, fleetName: string): FleetDefinition | null {
+  return stack.fleets.find((f) => f.name === fleetName) ?? null;
+}
+
+export function getHost(stack: StackDefinition, address: string): StackHost | null {
+  return stack.hosts.find((h) => h.address === address) ?? null;
+}
+
+export function getFleetForHost(stack: StackDefinition, address: string): FleetDefinition | null {
+  return stack.fleets.find((f) => f.hosts.includes(address)) ?? null;
+}
+
+// ── Env resolution ───────────────────────────────────────────────────────
+
+/**
+ * The stack's declared configuration for one component on one host.
+ * Fleets are a daemon concept; their overrides don't leak into other
+ * components that happen to share the host.
+ */
+export function resolveEnv(
+  stack: StackDefinition,
+  component: Component,
+  hostAddress?: string,
+): Record<string, string> {
+  const host = hostAddress ? getHost(stack, hostAddress) : null;
+  const fleet = component === "daemon" && hostAddress ? getFleetForHost(stack, hostAddress) : null;
+  return {
+    ...getAutoDefaults(component),
+    ...stack.env,
+    ...stack.secrets,
+    ...(stack.componentEnv[component] ?? {}),
+    ...(fleet?.envOverrides ?? {}),
+    ...(host?.envOverrides ?? {}),
+  };
+}
+
+/** Keep only entries that differ from the base layer, so stored overrides stay minimal. */
+export function diffFromLayer(
+  values: Record<string, string>,
+  base: Record<string, string>,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(values)) {
+    if (base[key] !== value) {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
+// ── Validation ───────────────────────────────────────────────────────────
+
+export interface ValidationError {
+  field: string;
+  message: string;
+}
+
+export function validateStack(stack: StackDefinition): ValidationError[] {
+  const errors: ValidationError[] = [];
+
+  if (!stack.name || !/^[a-z0-9][a-z0-9_-]*$/.test(stack.name)) {
+    errors.push({ field: "name", message: "Must be lowercase alphanumeric with hyphens/underscores, starting with a letter or digit" });
+  }
+
+  const hostAddresses = new Set(stack.hosts.map((h) => h.address));
+
+  if (hostAddresses.size !== stack.hosts.length) {
+    errors.push({ field: "hosts", message: "Duplicate host addresses" });
+  }
+
+  for (const host of stack.hosts) {
+    if (!host.address) {
+      errors.push({ field: "hosts", message: "Host address must not be empty" });
+    }
+    if (host.components.length === 0) {
+      errors.push({ field: "hosts", message: `Host ${host.address} has no components assigned` });
+    }
+  }
+
+  const fleetNames = new Set<string>();
+  const fleetOf = new Map<string, string>();
+  for (const fleet of stack.fleets) {
+    if (!fleet.name) {
+      errors.push({ field: "fleets", message: "Fleet name must not be empty" });
+      continue;
+    }
+    if (fleetNames.has(fleet.name)) {
+      errors.push({ field: "fleets", message: `Duplicate fleet name: ${fleet.name}` });
+    }
+    fleetNames.add(fleet.name);
+
+    let hasDaemonHost = false;
+    for (const hostAddr of fleet.hosts) {
+      const owner = fleetOf.get(hostAddr);
+      if (owner) {
+        errors.push({ field: "fleets", message: `Host ${hostAddr} is in multiple fleets ("${owner}", "${fleet.name}"); a host belongs to at most one fleet` });
+      } else {
+        fleetOf.set(hostAddr, fleet.name);
+      }
+      if (!hostAddresses.has(hostAddr)) {
+        errors.push({ field: "fleets", message: `Fleet "${fleet.name}" references unknown host: ${hostAddr}` });
+      }
+      if (getHost(stack, hostAddr)?.components.includes("daemon")) {
+        hasDaemonHost = true;
+      }
+    }
+    if (!hasDaemonHost && fleet.hosts.length > 0) {
+      errors.push({ field: "fleets", message: `Fleet "${fleet.name}" has no hosts with the daemon component` });
+    }
+  }
+
+  return errors;
+}
+
+// ── Factory ──────────────────────────────────────────────────────────────
+
+export function createStack(name: string): StackDefinition {
+  return {
+    version: cliVersion,
+    name,
+    env: {},
+    secrets: {},
+    componentEnv: {},
+    hosts: [],
+    fleets: [],
+  };
+}

--- a/packages/xinity-cli/src/lib/stack.ts
+++ b/packages/xinity-cli/src/lib/stack.ts
@@ -15,6 +15,7 @@ import { secret } from "common-env";
 import { version as cliVersion } from "../../../../package.json";
 import { type Component, getAutoDefaults } from "./component-meta.ts";
 import { analyzeEnvSchema } from "./env-prompt.ts";
+import { deleteStackState } from "./stack-state.ts";
 
 // ── Types ────────────────────────────────────────────────────────────────
 
@@ -24,6 +25,12 @@ export interface StackDefinition {
   name: string;
   /** Shared, inherited by every component (DB_CONNECTION_URL, INFOSERVER_URL, ...). */
   env: Record<string, string>;
+  /**
+   * Values derived for the current run (e.g. INFOSERVER_URL from the
+   * infoserver host's address). Sits below `env` so explicit values win,
+   * and is never persisted so it re-derives when the stack changes.
+   */
+  derivedEnv?: Record<string, string>;
   secrets: Record<string, string>;
   /** Stack-wide settings per component type (gateway PORT vs dashboard PORT don't collide here). */
   componentEnv: Partial<Record<Component, Record<string, string>>>;
@@ -113,7 +120,8 @@ export function loadStack(name: string): StackDefinition | null {
 
 export function saveStack(stack: StackDefinition): void {
   stack.version = cliVersion;
-  savePrivateJson(stackPath(stack.name), stack);
+  const { derivedEnv: _, ...persisted } = stack;
+  savePrivateJson(stackPath(stack.name), persisted);
 }
 
 export function deleteStack(name: string): boolean {
@@ -122,6 +130,7 @@ export function deleteStack(name: string): boolean {
     return false;
   }
   unlinkSync(path);
+  deleteStackState(name);
   return true;
 }
 
@@ -149,7 +158,55 @@ export function getFleetForHost(stack: StackDefinition, address: string): FleetD
   return stack.fleets.find((f) => f.hosts.includes(address)) ?? null;
 }
 
+// ── Fleet membership ─────────────────────────────────────────────────────
+
+/** Assign members to a fleet, pulling any that belonged to other fleets. Returns the names of fleets removed because they lost their last host. */
+export function claimFleetHosts(stack: StackDefinition, fleet: FleetDefinition, members: string[]): string[] {
+  const claimed = new Set(members);
+  fleet.hosts = members;
+  const emptied: string[] = [];
+  for (const other of stack.fleets) {
+    if (other === fleet) {
+      continue;
+    }
+    const remaining = other.hosts.filter((a) => !claimed.has(a));
+    if (remaining.length === 0 && other.hosts.length > 0) {
+      emptied.push(other.name);
+    }
+    other.hosts = remaining;
+  }
+  stack.fleets = stack.fleets.filter((f) => f.hosts.length > 0);
+  return emptied;
+}
+
+/** Hosts no longer running a daemon can't stay fleet members. */
+export function pruneFleetMembership(stack: StackDefinition, address: string): void {
+  for (const fleet of stack.fleets) {
+    fleet.hosts = fleet.hosts.filter((a) => a !== address);
+  }
+  stack.fleets = stack.fleets.filter((f) => f.hosts.length > 0);
+}
+
 // ── Env resolution ───────────────────────────────────────────────────────
+// One layer order, used by both the editors (base/seed) and the deploy
+// (resolveEnv): schema auto defaults → derived → shared env → shared
+// secrets → component type → fleet (daemon only) → host.
+
+export function componentLayerBase(stack: StackDefinition, component: Component): Record<string, string> {
+  return { ...getAutoDefaults(component), ...(stack.derivedEnv ?? {}), ...stack.env, ...stack.secrets };
+}
+
+export function componentLayerSeed(stack: StackDefinition, component: Component): Record<string, string> {
+  return { ...componentLayerBase(stack, component), ...(stack.componentEnv[component] ?? {}) };
+}
+
+export function fleetLayerBase(stack: StackDefinition): Record<string, string> {
+  return componentLayerSeed(stack, "daemon");
+}
+
+export function fleetLayerSeed(stack: StackDefinition, fleet: FleetDefinition): Record<string, string> {
+  return { ...fleetLayerBase(stack), ...(fleet.envOverrides ?? {}) };
+}
 
 /**
  * The stack's declared configuration for one component on one host.
@@ -164,10 +221,7 @@ export function resolveEnv(
   const host = hostAddress ? getHost(stack, hostAddress) : null;
   const fleet = component === "daemon" && hostAddress ? getFleetForHost(stack, hostAddress) : null;
   return {
-    ...getAutoDefaults(component),
-    ...stack.env,
-    ...stack.secrets,
-    ...(stack.componentEnv[component] ?? {}),
+    ...componentLayerSeed(stack, component),
     ...(fleet?.envOverrides ?? {}),
     ...(host?.envOverrides ?? {}),
   };

--- a/packages/xinity-cli/src/lib/step-event.ts
+++ b/packages/xinity-cli/src/lib/step-event.ts
@@ -1,0 +1,7 @@
+export type StepEvent =
+  | { type: "pass"; label: string; detail?: string }
+  | { type: "fail"; label: string; detail?: string }
+  | { type: "warn"; label: string; detail?: string }
+  | { type: "info"; label: string; detail?: string }
+  | { type: "spinner"; id: string; message?: string; done?: boolean }
+  | { type: "log"; message: string };

--- a/packages/xinity-cli/src/lib/step-runner.ts
+++ b/packages/xinity-cli/src/lib/step-runner.ts
@@ -18,6 +18,18 @@ export interface Progress {
   ensureSettled(): void;
 }
 
+export function createSilentProgress(): Progress {
+  let failed = false;
+  return {
+    update() {},
+    warn() {},
+    fail() { failed = true; },
+    hasFailed: () => failed,
+    done() {},
+    ensureSettled() {},
+  };
+}
+
 /**
  * Collapses a stream of mechanical steps into one live spinner: successes
  * only update the spinner text, warnings persist, and the first failure

--- a/packages/xinity-cli/src/lib/step-runner.ts
+++ b/packages/xinity-cli/src/lib/step-runner.ts
@@ -1,0 +1,72 @@
+import type { SpinnerResult } from "@clack/prompts";
+import * as p from "./clack.ts";
+import { pass, fail, warn, info } from "./output.ts";
+import type { StepEvent } from "./step-event.ts";
+
+function renderEvent(event: StepEvent, spinners: Map<string, SpinnerResult>): void {
+  switch (event.type) {
+    case "pass": {
+      pass(event.label, event.detail);
+      break;
+    }
+    case "fail": {
+      fail(event.label, event.detail);
+      break;
+    }
+    case "warn": {
+      warn(event.label, event.detail);
+      break;
+    }
+    case "info": {
+      info(event.label, event.detail);
+      break;
+    }
+    case "spinner": {
+      const existing = spinners.get(event.id);
+      if (event.done) {
+        existing?.stop(event.message);
+        spinners.delete(event.id);
+      } else if (existing) {
+        if (event.message) {
+          existing.message(event.message);
+        }
+      } else {
+        const s = p.spinner();
+        s.start(event.message ?? "");
+        spinners.set(event.id, s);
+      }
+      break;
+    }
+    case "log": {
+      p.log.info(event.message);
+      break;
+    }
+  }
+}
+
+export async function runSteps<T>(gen: AsyncGenerator<StepEvent, T>): Promise<T> {
+  const spinners = new Map<string, SpinnerResult>();
+  try {
+    let result = await gen.next();
+    while (!result.done) {
+      renderEvent(result.value, spinners);
+      result = await gen.next();
+    }
+    return result.value;
+  } finally {
+    for (const s of spinners.values()) {
+      s.stop();
+    }
+    spinners.clear();
+  }
+}
+
+export async function collectSteps<T>(gen: AsyncGenerator<StepEvent, T>): Promise<{ events: StepEvent[]; result: T }> {
+  const events: StepEvent[] = [];
+  let result = await gen.next();
+  while (!result.done) {
+    events.push(result.value);
+    result = await gen.next();
+  }
+  return { events, result: result.value };
+}

--- a/packages/xinity-cli/src/lib/step-runner.ts
+++ b/packages/xinity-cli/src/lib/step-runner.ts
@@ -1,7 +1,122 @@
 import type { SpinnerResult } from "@clack/prompts";
-import * as p from "./clack.ts";
+import { log, spinner as clackSpinner } from "./clack.ts";
+import { dim } from "picocolors";
 import { pass, fail, warn, info } from "./output.ts";
 import type { StepEvent } from "./step-event.ts";
+
+export interface Progress {
+  /** Transient: only updates the spinner text. */
+  update(message: string): void;
+  /** Persists; the spinner pauses around it. */
+  warn(label: string, detail?: string, hint?: string): void;
+  /** Persists; the first failure replays the transient trail for context. */
+  fail(label: string, detail?: string): void;
+  hasFailed(): boolean;
+  /** One persistent summary line for the whole scope; suppressed after a failure. */
+  done(summary: string): void;
+  /** Safety net for early exits: never leave the spinner running. */
+  ensureSettled(): void;
+}
+
+/**
+ * Collapses a stream of mechanical steps into one live spinner: successes
+ * only update the spinner text, warnings persist, and the first failure
+ * replays the transient trail so the error keeps its context. `done()`
+ * leaves exactly one persistent line for the whole scope.
+ */
+export function createProgress(start: string): Progress {
+  let spinner = clackSpinner();
+  const trail: string[] = [];
+  let lastMessage = start;
+  let failed = false;
+  let finished = false;
+
+  spinner.start(start);
+
+  const pause = () => spinner.stop(dim(lastMessage));
+  const resume = () => {
+    spinner = clackSpinner();
+    spinner.start(lastMessage);
+  };
+
+  return {
+    update(message) {
+      if (failed) {
+        log.info(dim(message));
+        return;
+      }
+      trail.push(message);
+      lastMessage = message;
+      spinner.message(message);
+    },
+
+    warn(label, detail, hint) {
+      if (!failed) {
+        pause();
+      }
+      warn(label, detail);
+      if (hint) {
+        log.info(dim(hint));
+      }
+      if (!failed) {
+        resume();
+      }
+    },
+
+    fail(label, detail) {
+      if (!failed) {
+        pause();
+        if (trail.length > 0) {
+          log.message(trail.map((line) => dim(line)));
+        }
+        failed = true;
+      }
+      fail(label, detail);
+    },
+
+    hasFailed: () => failed,
+
+    done(summary) {
+      if (failed || finished) return;
+      finished = true;
+      spinner.stop(summary);
+    },
+
+    ensureSettled() {
+      if (failed || finished) return;
+      finished = true;
+      spinner.stop(dim(lastMessage));
+    },
+  };
+}
+
+function renderToProgress(event: StepEvent, progress: Progress): void {
+  switch (event.type) {
+    case "pass":
+    case "info": {
+      progress.update(event.detail ?? event.label);
+      break;
+    }
+    case "warn": {
+      progress.warn(event.label, event.detail);
+      break;
+    }
+    case "fail": {
+      progress.fail(event.label, event.detail);
+      break;
+    }
+    case "spinner": {
+      if (event.message) {
+        progress.update(event.message);
+      }
+      break;
+    }
+    case "log": {
+      progress.update(event.message);
+      break;
+    }
+  }
+}
 
 function renderEvent(event: StepEvent, spinners: Map<string, SpinnerResult>): void {
   switch (event.type) {
@@ -31,20 +146,29 @@ function renderEvent(event: StepEvent, spinners: Map<string, SpinnerResult>): vo
           existing.message(event.message);
         }
       } else {
-        const s = p.spinner();
+        const s = clackSpinner();
         s.start(event.message ?? "");
         spinners.set(event.id, s);
       }
       break;
     }
     case "log": {
-      p.log.info(event.message);
+      log.info(event.message);
       break;
     }
   }
 }
 
-export async function runSteps<T>(gen: AsyncGenerator<StepEvent, T>): Promise<T> {
+export async function runSteps<T>(gen: AsyncGenerator<StepEvent, T>, progress?: Progress): Promise<T> {
+  if (progress) {
+    let result = await gen.next();
+    while (!result.done) {
+      renderToProgress(result.value, progress);
+      result = await gen.next();
+    }
+    return result.value;
+  }
+
   const spinners = new Map<string, SpinnerResult>();
   try {
     let result = await gen.next();
@@ -59,6 +183,18 @@ export async function runSteps<T>(gen: AsyncGenerator<StepEvent, T>): Promise<T>
     }
     spinners.clear();
   }
+}
+
+/** Run a step stream inside its own collapsed scope with a single summary line. */
+export async function runStepsCollapsed<T>(
+  gen: AsyncGenerator<StepEvent, T>,
+  start: string,
+  summary: string,
+): Promise<T> {
+  const progress = createProgress(start);
+  const result = await runSteps(gen, progress);
+  progress.done(summary);
+  return result;
 }
 
 export async function collectSteps<T>(gen: AsyncGenerator<StepEvent, T>): Promise<{ events: StepEvent[]; result: T }> {

--- a/packages/xinity-cli/src/lib/up-plan.ts
+++ b/packages/xinity-cli/src/lib/up-plan.ts
@@ -1,0 +1,599 @@
+/**
+ * Planning and review phases of `xinity up` and `xinity configure`:
+ * collect everything first (host state, versions, env values via the
+ * familiar prompts) without touching the host, show the assembled actions,
+ * gate on a single confirmation (with a bash-script dump as a secondary
+ * option), then apply hands-off through the installer.
+ */
+import * as p from "./clack.ts";
+import pc from "picocolors";
+import { type Component, ENV_SCHEMAS, ENV_DIR, getAutoDefaults } from "./component-meta.ts";
+import { type Host, isUnitActiveOn } from "./host.ts";
+import { pass, fail, warn, heading } from "./output.ts";
+import { parseEnvString } from "./env-file.ts";
+import { unitName } from "./systemd.ts";
+import { pickReleaseAsset, resolveDirectUrl, getProjectUrl, type Release } from "./github.ts";
+import { assetSizeMb, buildInstallBinaryCommand } from "./install-download.ts";
+import { buildEnvWriteCommand, buildSecretsWriteCommand, buildUnitWriteCommand, writeEnvConfig, writeSystemdUnit, restartService } from "./service.ts";
+import { runSteps } from "./step-runner.ts";
+import { resolveVersion, applyComponentAction } from "./installer.ts";
+import { collectEnv, menuEditEnv, readExistingEnvState, diffEnv, type EnvBundle, type EnvChange } from "./env-prompt.ts";
+import { discoverConnectionUrl, dbHint, runMigrations } from "./migrator.ts";
+import { describePostgresProvision, buildPostgresProvisionCommands, applyPostgresProvision, type PostgresProvision } from "./postgres-setup.ts";
+import { planRedis, applyRedisPlan, describeRedisPlan, type RedisPlan } from "./redis-setup.ts";
+import { readManifest } from "./manifest.ts";
+
+export type ComponentActionKind = "install" | "update" | "reconfigure" | "none";
+
+export interface ComponentAction {
+  component: Component;
+  kind: ComponentActionKind;
+  installedVersion?: string;
+  toVersion: string;
+  release?: Release;
+  localRepoPath?: string;
+  assetName?: string;
+  assetSizeMb?: string;
+  env: EnvBundle;
+  envChanges: EnvChange[];
+  hardReset: boolean;
+  serviceRunning: boolean;
+}
+
+export interface UpPlan {
+  targetVersion: string;
+  provisionPostgres?: PostgresProvision;
+  migrations?: { connectionUrl: string; hint: string };
+  redis?: RedisPlan;
+  provisionOllama: boolean;
+  components: ComponentAction[];
+}
+
+export interface PlanUpOptions {
+  targetVersion: string;
+  hardReset: boolean;
+  dryRun: boolean;
+  /** `up all`: resolve shared infrastructure (db, redis, optional ollama) first. */
+  withInfra: boolean;
+}
+
+// ─── Collect ────────────────────────────────────────────────────────────────
+
+/** Returns null when the user cancels or resolution fails. */
+async function planComponentAction(
+  component: Component,
+  opts: PlanUpOptions,
+  host: Host,
+  shared: Record<string, string>,
+  resolvedKeys: Set<string>,
+): Promise<ComponentAction | null> {
+  heading(component);
+
+  const autoDefaults = { ...getAutoDefaults(component), ...shared };
+  const base = {
+    component,
+    hardReset: opts.hardReset,
+    serviceRunning: await isUnitActiveOn(host, unitName(component)),
+  };
+
+  if (opts.targetVersion.startsWith("local:")) {
+    const collected = await collectEnv(component, host, autoDefaults, resolvedKeys);
+    if (!collected) return null;
+    const isUpdate = !!(await readManifest(host)).components[component];
+    return {
+      ...base,
+      kind: isUpdate ? "update" : "install",
+      toVersion: "local",
+      localRepoPath: opts.targetVersion.slice(6),
+      env: collected,
+      envChanges: collected.changes,
+    };
+  }
+
+  const version = await resolveVersion(component, opts.targetVersion, host);
+  if (version.status === "failed") return null;
+
+  const collected = await collectEnv(component, host, autoDefaults, resolvedKeys);
+  if (!collected) return null;
+
+  if (version.status === "current") {
+    return {
+      ...base,
+      kind: collected.changes.length > 0 ? "reconfigure" : "none",
+      installedVersion: version.version,
+      toVersion: version.version,
+      env: collected,
+      envChanges: collected.changes,
+    };
+  }
+
+  let assetName: string;
+  try {
+    assetName = pickReleaseAsset(version.release, component, await host.getArch());
+  } catch (err) {
+    fail("Download", (err as Error).message);
+    return null;
+  }
+  const asset = version.release.assets.find((a) => a.name === assetName);
+
+  return {
+    ...base,
+    kind: version.isUpdate ? "update" : "install",
+    installedVersion: version.installedVersion,
+    toVersion: version.release.tagName,
+    release: version.release,
+    assetName,
+    assetSizeMb: asset ? assetSizeMb(asset) : undefined,
+    env: collected,
+    envChanges: collected.changes,
+  };
+}
+
+/**
+ * Collect the full plan. All prompting happens here; nothing on the host
+ * changes. Returns null when the user cancels.
+ */
+export async function planUp(
+  components: Component[],
+  opts: PlanUpOptions,
+  host: Host,
+): Promise<UpPlan | null> {
+  const shared: Record<string, string> = {};
+  // Shared values the user already confirmed at an infra step this run;
+  // the component wizards skip re-prompting these. Suggested defaults
+  // (INFOSERVER_URL, GATEWAY_URL) stay out so their prompts still appear.
+  const resolvedKeys = new Set<string>();
+  const plan: UpPlan = {
+    targetVersion: opts.targetVersion,
+    provisionOllama: false,
+    components: [],
+  };
+  let orderedComponents = components;
+
+  if (opts.withInfra) {
+    heading("database");
+    const dbPlan = await discoverConnectionUrl(host);
+    if (!dbPlan) return null;
+    plan.provisionPostgres = dbPlan.provision;
+    plan.migrations = { connectionUrl: dbPlan.connectionUrl, hint: dbHint(dbPlan.connectionUrl) };
+    shared.DB_CONNECTION_URL = dbPlan.connectionUrl;
+    resolvedKeys.add("DB_CONNECTION_URL");
+
+    heading("redis");
+    const redisPlan = await planRedis(host);
+    if (redisPlan) {
+      shared.REDIS_URL = redisPlan.url;
+      resolvedKeys.add("REDIS_URL");
+      if (redisPlan.persist || redisPlan.provision) plan.redis = redisPlan;
+    } else {
+      warn("Redis", "No Redis URL configured");
+      const cont = await p.confirm({ message: "Continue without Redis?", initialValue: true });
+      if (p.isCancel(cont) || !cont) return null;
+    }
+
+    p.log.info(pc.dim(`Model registry guide: ${getProjectUrl()}/tree/main/packages/xinity-infoserver#readme`));
+    const installInfoserver = await p.confirm({
+      message: "Install the info server? (optional - most installations use the default at sysinfo.xinity.ai)",
+      initialValue: false,
+    });
+    if (p.isCancel(installInfoserver)) return null;
+
+    const installDaemon = await p.confirm({
+      message: "Install the daemon? (only needed on inference hardware)",
+      initialValue: false,
+    });
+    if (p.isCancel(installDaemon)) return null;
+
+    if (installDaemon) {
+      const setupOllama = await p.confirm({
+        message: "Set up Ollama on this machine? (one inference driver the daemon can use)",
+        initialValue: false,
+      });
+      if (p.isCancel(setupOllama)) return null;
+      if (setupOllama) {
+        const { LOCAL_OLLAMA_ENDPOINT } = await import("./ollama-setup.ts");
+        plan.provisionOllama = true;
+        shared.XINITY_OLLAMA_ENDPOINT = LOCAL_OLLAMA_ENDPOINT;
+        resolvedKeys.add("XINITY_OLLAMA_ENDPOINT");
+      }
+    }
+
+    orderedComponents = [
+      ...(installInfoserver ? ["infoserver" as Component] : []),
+      "gateway", "dashboard",
+      ...(installDaemon ? ["daemon" as Component] : []),
+    ];
+  }
+
+  for (const component of orderedComponents) {
+    const action = await planComponentAction(component, opts, host, shared, resolvedKeys);
+    if (!action) return null;
+    plan.components.push(action);
+
+    // An infoserver declared in this run is the one the following
+    // components should use, not the hosted default.
+    if (component === "infoserver") {
+      shared.INFOSERVER_URL = `http://localhost:${action.env.config.PORT ?? "8090"}`;
+    }
+
+    // Suggested prompt default only: the dashboard's GATEWAY_URL is the
+    // public URL, which differs behind a reverse proxy; the user confirms
+    // it at the prompt, whose description says so.
+    if (component === "gateway") {
+      const bind = action.env.config.HOST;
+      const gatewayHost = !bind || bind === "0.0.0.0" ? "localhost" : bind;
+      shared.GATEWAY_URL = `http://${gatewayHost}:${action.env.config.PORT ?? "4010"}`;
+    }
+  }
+
+  return plan;
+}
+
+// ─── Review ─────────────────────────────────────────────────────────────────
+
+function envChangeLines(changes: EnvChange[]): string[] {
+  return changes.map((c) => {
+    if (c.kind === "removed") return `- ${c.key}`;
+    const value = c.isSecret ? "••••••" : c.after;
+    if (c.kind === "added") return `+ ${c.key} = ${value}`;
+    return c.isSecret ? `~ ${c.key} = ••••••` : `~ ${c.key} = ${c.before} → ${c.after}`;
+  });
+}
+
+function serviceLine(action: ComponentAction): string {
+  const unit = unitName(action.component);
+  return action.serviceRunning ? `restart ${unit}` : `enable and start ${unit}`;
+}
+
+function describeComponentAction(action: ComponentAction): string[] {
+  const { component, envChanges } = action;
+  const configLines = envChanges.length > 0
+    ? [`config changes:`, ...envChangeLines(envChanges).map((l) => `  ${l}`)]
+    : ["configuration unchanged"];
+
+  switch (action.kind) {
+    case "none": {
+      return [`${pc.cyan(component)} ${action.toVersion} is current, configuration unchanged: nothing to do`];
+    }
+    case "reconfigure": {
+      return [
+        `Reconfigure ${pc.cyan(component)} (binary ${action.toVersion} stays)`,
+        ...configLines.map((l) => `  ${l}`),
+        `  update systemd unit, ${serviceLine(action)}`,
+      ];
+    }
+    case "install":
+    case "update": {
+      const verb = action.kind === "install"
+        ? `Install ${pc.cyan(component)} ${action.toVersion}`
+        : `Update ${pc.cyan(component)} ${action.installedVersion} → ${action.toVersion}`;
+      const source = action.localRepoPath
+        ? `build locally from ${action.localRepoPath} and upload`
+        : `download ${action.assetName}${action.assetSizeMb ? ` (${action.assetSizeMb} MB)` : ""}`;
+      return [
+        verb,
+        `  ${source}`,
+        ...(action.kind === "update" ? ["  back up current binary and configuration"] : []),
+        ...(action.hardReset && action.kind === "update" ? ["  hard reset: clean service state"] : []),
+        ...configLines.map((l) => `  ${l}`),
+        `  update systemd unit, ${serviceLine(action)}`,
+      ];
+    }
+  }
+}
+
+export function renderUpPlan(plan: UpPlan): void {
+  p.log.step(pc.bold("Planned actions"));
+
+  let step = 1;
+  const item = (lines: string[]) => {
+    const [head, ...rest] = lines;
+    p.log.info(`${step++}. ${head}`);
+    for (const line of rest) {
+      p.log.info(pc.dim(`   ${line}`));
+    }
+  };
+
+  if (plan.provisionPostgres) {
+    item([describePostgresProvision(plan.provisionPostgres)]);
+  }
+  if (plan.migrations) {
+    item([`Apply database migrations from release ${plan.targetVersion} to ${plan.migrations.hint}`]);
+  }
+  if (plan.redis) {
+    const lines = describeRedisPlan(plan.redis);
+    if (lines.length > 0) item(lines);
+  }
+  if (plan.provisionOllama) {
+    item(["Provision ollama (install when missing, start the service)"]);
+  }
+  for (const action of plan.components) {
+    item(describeComponentAction(action));
+  }
+}
+
+/** The single go-ahead gate after review. Returns true to apply. */
+export async function reviewGate(renderScript?: () => Promise<string>): Promise<boolean> {
+  while (true) {
+    const options = [
+      { value: "apply", label: "Yes, apply these actions" },
+      { value: "abort", label: "Abort" },
+      ...(renderScript ? [{ value: "script", label: pc.dim("Show the equivalent bash script"), hint: "runs nothing" }] : []),
+    ];
+    const choice = await p.select({ message: "Proceed?", options });
+
+    if (p.isCancel(choice) || choice === "abort") {
+      p.cancel("Aborted, nothing was changed.");
+      return false;
+    }
+    if (choice === "apply") return true;
+
+    p.log.message((await renderScript!()).split("\n"));
+  }
+}
+
+// ─── Script dump ────────────────────────────────────────────────────────────
+
+const SCRIPT_HEADER = [
+  "#!/usr/bin/env bash",
+  "# Equivalent script for the reviewed actions. Run as root on the target host.",
+  "# WARNING: contains configuration secrets in plain text.",
+  "set -euo pipefail",
+  "",
+];
+
+function scriptConfigSection(component: Component, env: EnvBundle, serviceRunning: boolean): string[] {
+  const secretsCommand = buildSecretsWriteCommand(env.secrets);
+  return [
+    buildEnvWriteCommand(component, env.config),
+    ...(secretsCommand ? [secretsCommand] : []),
+    buildUnitWriteCommand(component, Object.keys(env.secrets)),
+    serviceRunning ? `systemctl restart ${unitName(component)}` : `systemctl enable --now ${unitName(component)}`,
+  ];
+}
+
+async function scriptComponentSection(action: ComponentAction): Promise<string[]> {
+  const { component } = action;
+  const header = `# ── ${component}: ${action.kind} ${action.toVersion} ──`;
+
+  if (action.kind === "none") {
+    return [`# ── ${component}: ${action.toVersion} already current, nothing to do ──`];
+  }
+  if (action.kind === "reconfigure") {
+    return [header, ...scriptConfigSection(component, action.env, action.serviceRunning)];
+  }
+  if (action.localRepoPath) {
+    return [
+      header,
+      `# local build from ${action.localRepoPath} has no script equivalent (the build runs on the CLI machine)`,
+    ];
+  }
+
+  const asset = action.release!.assets.find((a) => a.name === action.assetName);
+  const url = asset ? await resolveDirectUrl(asset) : "";
+  const archivePath = `/tmp/xinity-script-install/${action.assetName}`;
+  return [
+    header,
+    `mkdir -p /tmp/xinity-script-install`,
+    `curl -fsSL -o '${archivePath}' '${url}'`,
+    buildInstallBinaryCommand(component, archivePath),
+    ...scriptConfigSection(component, action.env, action.serviceRunning),
+  ];
+}
+
+/**
+ * Bash script reproducing the plan's component actions. Database migrations
+ * run through drizzle's programmatic migrator and have no bash equivalent;
+ * the script defers them to `xinity up db`.
+ */
+export async function renderUpPlanScript(plan: UpPlan): Promise<string> {
+  const sections: string[] = [...SCRIPT_HEADER];
+
+  if (plan.provisionPostgres) {
+    sections.push(
+      "# PostgreSQL provisioning (Docker compose stack):",
+      ...buildPostgresProvisionCommands(plan.provisionPostgres),
+      "",
+    );
+  }
+  if (plan.migrations) {
+    sections.push(
+      "# Database migrations run inside the CLI (drizzle migrator, no bash equivalent):",
+      `#   xinity up db --target-version ${plan.targetVersion}`,
+      "",
+    );
+  }
+  if (plan.redis) {
+    sections.push("# Redis:");
+    if (plan.redis.provision?.installCmd) sections.push(plan.redis.provision.installCmd);
+    if (plan.redis.provision?.startCmd) sections.push(plan.redis.provision.startCmd);
+    if (plan.redis.persist) sections.push(buildSecretsWriteCommand({ REDIS_URL: plan.redis.url })!);
+    sections.push("");
+  }
+  if (plan.provisionOllama) {
+    sections.push(
+      "# Ollama provisioning:",
+      "curl -fsSL https://ollama.com/install.sh | sh",
+      "systemctl enable --now ollama",
+      "",
+    );
+  }
+
+  for (const action of plan.components) {
+    sections.push(...(await scriptComponentSection(action)), "");
+  }
+
+  return sections.join("\n");
+}
+
+// ─── Apply ──────────────────────────────────────────────────────────────────
+
+export interface ApplyResult {
+  success: boolean;
+  errors: string[];
+}
+
+export async function applyUpPlan(plan: UpPlan, host: Host): Promise<ApplyResult> {
+  const errors: string[] = [];
+
+  if (plan.provisionPostgres || plan.migrations) {
+    heading("database");
+  }
+  if (plan.provisionPostgres) {
+    if (!(await applyPostgresProvision(plan.provisionPostgres, host))) {
+      return { success: false, errors: ["PostgreSQL provisioning failed"] };
+    }
+  }
+  if (plan.migrations) {
+    const result = await runMigrations({
+      connectionUrl: plan.migrations.connectionUrl,
+      targetVersion: plan.targetVersion,
+      dryRun: false,
+      host,
+    });
+    if (!result.success) {
+      return { success: false, errors: ["Database migrations failed", ...result.errors] };
+    }
+  }
+
+  if (plan.redis) {
+    heading("redis");
+    if (!(await applyRedisPlan(plan.redis, host))) {
+      warn("Redis", "Redis setup failed; dependent services may not work until it is fixed");
+    }
+  }
+
+  if (plan.provisionOllama) {
+    heading("ollama");
+    const { ensureOllama } = await import("./ollama-setup.ts");
+    if (!(await ensureOllama(host, false))) {
+      warn("Ollama", "Provisioning failed; the daemon may not reach its ollama endpoint");
+    }
+  }
+
+  for (const action of plan.components) {
+    heading(action.component);
+    const result = await applyComponentAction(action, host);
+    if (!result.success) {
+      errors.push(`${action.component}: ${result.errors.join(", ")}`);
+    }
+  }
+
+  return { success: errors.length === 0, errors };
+}
+
+/** Health check + next-steps note shown after a successful `up all` apply. */
+export async function printPostInstallSummary(host: Host): Promise<void> {
+  heading("health check");
+  const { runDoctor } = await import("./doctor.ts");
+  const doctorSpinner = p.spinner();
+  doctorSpinner.start("Running diagnostics…");
+  const report = await runDoctor({
+    interactive: false,
+    host,
+    spinner: {
+      message: (msg: string) => doctorSpinner.message(msg),
+      stop: () => doctorSpinner.stop(""),
+    },
+  });
+  doctorSpinner.stop("");
+
+  const { pass: passCount, warn: warnCount, fail: failCount } = report.summary;
+  if (failCount > 0) {
+    warn("Health", `${failCount} check(s) failed. Run ${pc.cyan("xinity doctor")} for details.`);
+  } else if (warnCount > 0) {
+    pass("Health", `All checks passed (${warnCount} warning(s))`);
+  } else {
+    pass("Health", `All ${passCount} checks passed`);
+  }
+
+  const summaryLines: string[] = [];
+
+  const dashContent = await host.readFile(`${ENV_DIR}/dashboard.env`);
+  const dashboardOrigin = dashContent ? parseEnvString(dashContent).ORIGIN : undefined;
+  if (dashboardOrigin) summaryLines.push(`Dashboard:  ${pc.cyan(dashboardOrigin)}`);
+
+  const gwContent = await host.readFile(`${ENV_DIR}/gateway.env`);
+  if (gwContent) {
+    const parsed = parseEnvString(gwContent);
+    const gwHost = parsed.HOST || "localhost";
+    const gwPort = parsed.PORT || "4010";
+    summaryLines.push(`Gateway:    ${pc.cyan(`http://${gwHost}:${gwPort}`)}`);
+  }
+
+  if (summaryLines.length > 0) summaryLines.push("");
+  summaryLines.push(pc.bold("Next steps:"));
+  if (dashboardOrigin) {
+    summaryLines.push(`  1. Connect the CLI to your dashboard:`);
+    summaryLines.push(`     ${pc.cyan(`xinity configure dashboardUrl ${dashboardOrigin}`)}`);
+    summaryLines.push(`  2. Create your admin account from the CLI:`);
+    summaryLines.push(`     ${pc.cyan("xinity act onboarding.cli")}`);
+    summaryLines.push(`     Or open ${pc.cyan(dashboardOrigin)} in a browser to sign up there.`);
+  } else {
+    summaryLines.push(`  1. Create your admin account via the dashboard UI`);
+    summaryLines.push(`     Or from the CLI: ${pc.cyan("xinity act onboarding.cli")}`);
+  }
+  summaryLines.push(`  ${dashboardOrigin ? "3" : "2"}. Add inference nodes: ${pc.cyan("xinity up daemon")} on each GPU machine`);
+  summaryLines.push(`  ${dashboardOrigin ? "4" : "3"}. Check health anytime: ${pc.cyan("xinity doctor")}`);
+  summaryLines.push("");
+  summaryLines.push(pc.dim(`Model registry guide: ${getProjectUrl()}/tree/main/packages/xinity-infoserver#readme`));
+
+  p.note(summaryLines.join("\n"), "Installation complete");
+}
+
+// ─── configure <component> ──────────────────────────────────────────────────
+
+/**
+ * `xinity configure <component>`: the familiar menu editor, then a review of
+ * what actually changed and the same gate as `up`. Writes nothing until
+ * confirmed.
+ */
+export async function configureComponentFlow(component: Component, host: Host): Promise<void> {
+  p.intro(`xinity configure ${pc.cyan(component)}`);
+
+  if (!(await host.prepareElevation())) {
+    p.outro("Aborted");
+    return;
+  }
+
+  const state = await readExistingEnvState(component, host);
+  const existing = { ...getAutoDefaults(component), ...state.existingConfig, ...state.existingSecrets };
+
+  const result = await menuEditEnv(ENV_SCHEMAS[component], existing);
+  if (result === null) {
+    p.cancel("Cancelled, no changes saved.");
+    return;
+  }
+
+  const changes = diffEnv({ config: state.existingConfig, secrets: state.existingSecrets }, result);
+  if (changes.length === 0) {
+    p.log.info("No changes.");
+    p.outro("Done");
+    return;
+  }
+
+  const serviceRunning = await isUnitActiveOn(host, unitName(component));
+
+  p.log.step(pc.bold("Planned changes"));
+  for (const line of envChangeLines(changes)) {
+    p.log.info(`  ${line}`);
+  }
+  p.log.info(pc.dim(serviceRunning
+    ? `  update systemd unit, restart ${unitName(component)}`
+    : `  update systemd unit (${unitName(component)} is not running, takes effect on next start)`));
+
+  const proceed = await reviewGate(async () =>
+    [...SCRIPT_HEADER, ...scriptConfigSection(component, result, serviceRunning)].join("\n"),
+  );
+  if (!proceed) return;
+
+  const configResult = await writeEnvConfig(component, result.config, result.secrets, host);
+  if (configResult.success) {
+    pass("Config", "Environment configured");
+    await writeSystemdUnit(component, Object.keys(result.secrets), host);
+    await runSteps(restartService(component, host));
+  } else if (configResult.error) {
+    fail("Config", configResult.error);
+  }
+  p.outro("Done");
+}

--- a/packages/xinity-cli/src/lib/up-plan.ts
+++ b/packages/xinity-cli/src/lib/up-plan.ts
@@ -7,7 +7,7 @@
  */
 import { cancel, confirm, intro, isCancel, log, note, outro, select, spinner } from "./clack.ts";
 import { bold, cyan, dim } from "picocolors";
-import { type Component, ENV_SCHEMAS, ENV_DIR, getAutoDefaults } from "./component-meta.ts";
+import { type Component, ENV_SCHEMAS, ENV_DIR, getAutoDefaults, GATEWAY_DEFAULT_PORT, INFOSERVER_DEFAULT_PORT } from "./component-meta.ts";
 import { type Host, isUnitActiveOn } from "./host.ts";
 import { pass, fail, warn, heading } from "./output.ts";
 import { parseEnvString } from "./env-file.ts";
@@ -18,7 +18,7 @@ import { buildEnvWriteCommand, buildSecretsWriteCommand, buildUnitWriteCommand, 
 import { runSteps, createProgress } from "./step-runner.ts";
 import { resolveVersion, applyComponentAction, type VersionResult } from "./installer.ts";
 import { collectEnv, menuEditEnv, readExistingEnvState, diffEnv, type EnvBundle, type EnvChange } from "./env-prompt.ts";
-import { discoverConnectionUrl, dbHint, runMigrations } from "./migrator.ts";
+import { discoverConnectionUrl, describeMigrationStep, migrationScriptComment, runMigrations } from "./migrator.ts";
 import { describePostgresProvision, buildPostgresProvisionCommands, applyPostgresProvision, type PostgresProvision } from "./postgres-setup.ts";
 import { planRedis, applyRedisPlan, describeRedisPlan, type RedisPlan } from "./redis-setup.ts";
 import { readManifest } from "./manifest.ts";
@@ -43,7 +43,7 @@ export interface ComponentAction {
 export interface UpPlan {
   targetVersion: string;
   provisionPostgres?: PostgresProvision;
-  migrations?: { connectionUrl: string; hint: string };
+  migrations?: { connectionUrl: string };
   redis?: RedisPlan;
   provisionOllama: boolean;
   components: ComponentAction[];
@@ -170,7 +170,7 @@ export async function planUp(
     const dbPlan = await discoverConnectionUrl(host);
     if (!dbPlan) return null;
     plan.provisionPostgres = dbPlan.provision;
-    plan.migrations = { connectionUrl: dbPlan.connectionUrl, hint: dbHint(dbPlan.connectionUrl) };
+    plan.migrations = { connectionUrl: dbPlan.connectionUrl };
     shared.DB_CONNECTION_URL = dbPlan.connectionUrl;
     resolvedKeys.add("DB_CONNECTION_URL");
 
@@ -228,7 +228,7 @@ export async function planUp(
     // An infoserver declared in this run is the one the following
     // components should use, not the hosted default.
     if (component === "infoserver") {
-      shared.INFOSERVER_URL = `http://localhost:${action.env.config.PORT ?? "8090"}`;
+      shared.INFOSERVER_URL = `http://localhost:${action.env.config.PORT ?? INFOSERVER_DEFAULT_PORT}`;
     }
 
     // Suggested prompt default only: the dashboard's GATEWAY_URL is the
@@ -237,7 +237,7 @@ export async function planUp(
     if (component === "gateway") {
       const bind = action.env.config.HOST;
       const gatewayHost = !bind || bind === "0.0.0.0" ? "localhost" : bind;
-      shared.GATEWAY_URL = `http://${gatewayHost}:${action.env.config.PORT ?? "4010"}`;
+      shared.GATEWAY_URL = `http://${gatewayHost}:${action.env.config.PORT ?? GATEWAY_DEFAULT_PORT}`;
     }
   }
 
@@ -314,7 +314,7 @@ export function renderUpPlan(plan: UpPlan): void {
     item([describePostgresProvision(plan.provisionPostgres)]);
   }
   if (plan.migrations) {
-    item([`Apply database migrations from release ${plan.targetVersion} to ${plan.migrations.hint}`]);
+    item([describeMigrationStep(plan.targetVersion, plan.migrations.connectionUrl)]);
   }
   if (plan.redis) {
     const lines = describeRedisPlan(plan.redis);
@@ -413,11 +413,7 @@ export async function renderUpPlanScript(plan: UpPlan): Promise<string> {
     );
   }
   if (plan.migrations) {
-    sections.push(
-      "# Database migrations run inside the CLI (drizzle migrator, no bash equivalent):",
-      `#   xinity up db --target-version ${plan.targetVersion}`,
-      "",
-    );
+    sections.push(...migrationScriptComment(`xinity up db --target-version ${plan.targetVersion}`));
   }
   if (plan.redis) {
     sections.push("# Redis:");
@@ -533,7 +529,7 @@ export async function printPostInstallSummary(host: Host): Promise<void> {
   if (gwContent) {
     const parsed = parseEnvString(gwContent);
     const gwHost = parsed.HOST || "localhost";
-    const gwPort = parsed.PORT || "4010";
+    const gwPort = parsed.PORT || GATEWAY_DEFAULT_PORT;
     summaryLines.push(`Gateway:    ${cyan(`http://${gwHost}:${gwPort}`)}`);
   }
 

--- a/packages/xinity-cli/src/lib/up-plan.ts
+++ b/packages/xinity-cli/src/lib/up-plan.ts
@@ -5,6 +5,9 @@
  * gate on a single confirmation (with a bash-script dump as a secondary
  * option), then apply hands-off through the installer.
  */
+import { writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
 import { cancel, confirm, intro, isCancel, log, note, outro, select, spinner } from "./clack.ts";
 import { bold, cyan, dim } from "picocolors";
 import { type Component, ENV_SCHEMAS, ENV_DIR, getAutoDefaults, GATEWAY_DEFAULT_PORT, INFOSERVER_DEFAULT_PORT } from "./component-meta.ts";
@@ -334,7 +337,7 @@ export async function reviewGate(renderScript?: () => Promise<string>): Promise<
     const options = [
       { value: "apply", label: "Yes, apply these actions" },
       { value: "abort", label: "Abort" },
-      ...(renderScript ? [{ value: "script", label: dim("Show the equivalent bash script"), hint: "runs nothing" }] : []),
+      ...(renderScript ? [{ value: "script", label: dim("Save the equivalent bash script to a file"), hint: "runs nothing" }] : []),
     ];
     const choice = await select({ message: "Proceed?", options });
 
@@ -344,7 +347,11 @@ export async function reviewGate(renderScript?: () => Promise<string>): Promise<
     }
     if (choice === "apply") return true;
 
-    log.message((await renderScript!()).split("\n"));
+    const script = await renderScript!();
+    const path = join(tmpdir(), `xinity-apply-${Date.now()}.sh`);
+    writeFileSync(path, script, { mode: 0o600 });
+    log.info(`Script written to ${cyan(path)}`);
+    log.info(dim("Contains secrets. Inspect, then run on the target host as root."));
   }
 }
 

--- a/packages/xinity-cli/src/lib/up-plan.ts
+++ b/packages/xinity-cli/src/lib/up-plan.ts
@@ -368,7 +368,7 @@ function scriptConfigSection(component: Component, env: EnvBundle, serviceRunnin
   ];
 }
 
-async function scriptComponentSection(action: ComponentAction): Promise<string[]> {
+export async function scriptComponentSection(action: ComponentAction): Promise<string[]> {
   const { component } = action;
   const header = `# ── ${component}: ${action.kind} ${action.toVersion} ──`;
 

--- a/packages/xinity-cli/src/lib/up-plan.ts
+++ b/packages/xinity-cli/src/lib/up-plan.ts
@@ -5,8 +5,8 @@
  * gate on a single confirmation (with a bash-script dump as a secondary
  * option), then apply hands-off through the installer.
  */
-import * as p from "./clack.ts";
-import pc from "picocolors";
+import { cancel, confirm, intro, isCancel, log, note, outro, select, spinner } from "./clack.ts";
+import { bold, cyan, dim } from "picocolors";
 import { type Component, ENV_SCHEMAS, ENV_DIR, getAutoDefaults } from "./component-meta.ts";
 import { type Host, isUnitActiveOn } from "./host.ts";
 import { pass, fail, warn, heading } from "./output.ts";
@@ -15,8 +15,8 @@ import { unitName } from "./systemd.ts";
 import { pickReleaseAsset, resolveDirectUrl, getProjectUrl, type Release } from "./github.ts";
 import { assetSizeMb, buildInstallBinaryCommand } from "./install-download.ts";
 import { buildEnvWriteCommand, buildSecretsWriteCommand, buildUnitWriteCommand, writeEnvConfig, writeSystemdUnit, restartService } from "./service.ts";
-import { runSteps } from "./step-runner.ts";
-import { resolveVersion, applyComponentAction } from "./installer.ts";
+import { runSteps, createProgress } from "./step-runner.ts";
+import { resolveVersion, applyComponentAction, type VersionResult } from "./installer.ts";
 import { collectEnv, menuEditEnv, readExistingEnvState, diffEnv, type EnvBundle, type EnvChange } from "./env-prompt.ts";
 import { discoverConnectionUrl, dbHint, runMigrations } from "./migrator.ts";
 import { describePostgresProvision, buildPostgresProvisionCommands, applyPostgresProvision, type PostgresProvision } from "./postgres-setup.ts";
@@ -59,6 +59,51 @@ export interface PlanUpOptions {
 
 // ─── Collect ────────────────────────────────────────────────────────────────
 
+/**
+ * Assemble the action for a resolved version and collected env; the
+ * single-host and stack planners differ only in how the env is collected.
+ * Returns null when no matching release asset exists.
+ */
+export async function buildComponentAction(
+  base: {
+    component: Component;
+    hardReset: boolean;
+    serviceRunning: boolean;
+    env: EnvBundle;
+    envChanges: EnvChange[];
+  },
+  version: Extract<VersionResult, { status: "proceed" | "current" }>,
+  host: Host,
+): Promise<ComponentAction | null> {
+  if (version.status === "current") {
+    return {
+      ...base,
+      kind: base.envChanges.length > 0 ? "reconfigure" : "none",
+      installedVersion: version.version,
+      toVersion: version.version,
+    };
+  }
+
+  let assetName: string;
+  try {
+    assetName = pickReleaseAsset(version.release, base.component, await host.getArch());
+  } catch (err) {
+    fail("Download", `${base.component}: ${(err as Error).message}`);
+    return null;
+  }
+  const asset = version.release.assets.find((a) => a.name === assetName);
+
+  return {
+    ...base,
+    kind: version.isUpdate ? "update" : "install",
+    installedVersion: version.installedVersion,
+    toVersion: version.release.tagName,
+    release: version.release,
+    assetName,
+    assetSizeMb: asset ? assetSizeMb(asset) : undefined,
+  };
+}
+
 /** Returns null when the user cancels or resolution fails. */
 async function planComponentAction(
   component: Component,
@@ -96,37 +141,7 @@ async function planComponentAction(
   const collected = await collectEnv(component, host, autoDefaults, resolvedKeys);
   if (!collected) return null;
 
-  if (version.status === "current") {
-    return {
-      ...base,
-      kind: collected.changes.length > 0 ? "reconfigure" : "none",
-      installedVersion: version.version,
-      toVersion: version.version,
-      env: collected,
-      envChanges: collected.changes,
-    };
-  }
-
-  let assetName: string;
-  try {
-    assetName = pickReleaseAsset(version.release, component, await host.getArch());
-  } catch (err) {
-    fail("Download", (err as Error).message);
-    return null;
-  }
-  const asset = version.release.assets.find((a) => a.name === assetName);
-
-  return {
-    ...base,
-    kind: version.isUpdate ? "update" : "install",
-    installedVersion: version.installedVersion,
-    toVersion: version.release.tagName,
-    release: version.release,
-    assetName,
-    assetSizeMb: asset ? assetSizeMb(asset) : undefined,
-    env: collected,
-    envChanges: collected.changes,
-  };
+  return buildComponentAction({ ...base, env: collected, envChanges: collected.changes }, version, host);
 }
 
 /**
@@ -167,29 +182,29 @@ export async function planUp(
       if (redisPlan.persist || redisPlan.provision) plan.redis = redisPlan;
     } else {
       warn("Redis", "No Redis URL configured");
-      const cont = await p.confirm({ message: "Continue without Redis?", initialValue: true });
-      if (p.isCancel(cont) || !cont) return null;
+      const cont = await confirm({ message: "Continue without Redis?", initialValue: true });
+      if (isCancel(cont) || !cont) return null;
     }
 
-    p.log.info(pc.dim(`Model registry guide: ${getProjectUrl()}/tree/main/packages/xinity-infoserver#readme`));
-    const installInfoserver = await p.confirm({
+    log.info(dim(`Model registry guide: ${getProjectUrl()}/tree/main/packages/xinity-infoserver#readme`));
+    const installInfoserver = await confirm({
       message: "Install the info server? (optional - most installations use the default at sysinfo.xinity.ai)",
       initialValue: false,
     });
-    if (p.isCancel(installInfoserver)) return null;
+    if (isCancel(installInfoserver)) return null;
 
-    const installDaemon = await p.confirm({
+    const installDaemon = await confirm({
       message: "Install the daemon? (only needed on inference hardware)",
       initialValue: false,
     });
-    if (p.isCancel(installDaemon)) return null;
+    if (isCancel(installDaemon)) return null;
 
     if (installDaemon) {
-      const setupOllama = await p.confirm({
+      const setupOllama = await confirm({
         message: "Set up Ollama on this machine? (one inference driver the daemon can use)",
         initialValue: false,
       });
-      if (p.isCancel(setupOllama)) return null;
+      if (isCancel(setupOllama)) return null;
       if (setupOllama) {
         const { LOCAL_OLLAMA_ENDPOINT } = await import("./ollama-setup.ts");
         plan.provisionOllama = true;
@@ -245,7 +260,7 @@ function serviceLine(action: ComponentAction): string {
   return action.serviceRunning ? `restart ${unit}` : `enable and start ${unit}`;
 }
 
-function describeComponentAction(action: ComponentAction): string[] {
+export function describeComponentAction(action: ComponentAction): string[] {
   const { component, envChanges } = action;
   const configLines = envChanges.length > 0
     ? [`config changes:`, ...envChangeLines(envChanges).map((l) => `  ${l}`)]
@@ -253,11 +268,11 @@ function describeComponentAction(action: ComponentAction): string[] {
 
   switch (action.kind) {
     case "none": {
-      return [`${pc.cyan(component)} ${action.toVersion} is current, configuration unchanged: nothing to do`];
+      return [`${cyan(component)} ${action.toVersion} is current, configuration unchanged: nothing to do`];
     }
     case "reconfigure": {
       return [
-        `Reconfigure ${pc.cyan(component)} (binary ${action.toVersion} stays)`,
+        `Reconfigure ${cyan(component)} (binary ${action.toVersion} stays)`,
         ...configLines.map((l) => `  ${l}`),
         `  update systemd unit, ${serviceLine(action)}`,
       ];
@@ -265,8 +280,8 @@ function describeComponentAction(action: ComponentAction): string[] {
     case "install":
     case "update": {
       const verb = action.kind === "install"
-        ? `Install ${pc.cyan(component)} ${action.toVersion}`
-        : `Update ${pc.cyan(component)} ${action.installedVersion} → ${action.toVersion}`;
+        ? `Install ${cyan(component)} ${action.toVersion}`
+        : `Update ${cyan(component)} ${action.installedVersion} → ${action.toVersion}`;
       const source = action.localRepoPath
         ? `build locally from ${action.localRepoPath} and upload`
         : `download ${action.assetName}${action.assetSizeMb ? ` (${action.assetSizeMb} MB)` : ""}`;
@@ -283,15 +298,16 @@ function describeComponentAction(action: ComponentAction): string[] {
 }
 
 export function renderUpPlan(plan: UpPlan): void {
-  p.log.step(pc.bold("Planned actions"));
+  log.step(bold("Planned actions"));
 
   let step = 1;
   const item = (lines: string[]) => {
     const [head, ...rest] = lines;
-    p.log.info(`${step++}. ${head}`);
-    for (const line of rest) {
-      p.log.info(pc.dim(`   ${line}`));
+    if (rest.length === 0) {
+      log.info(`${step++}. ${head}`);
+      return;
     }
+    note(rest.map((line) => dim(line.trim())).join("\n"), `${step++}. ${head}`);
   };
 
   if (plan.provisionPostgres) {
@@ -318,17 +334,17 @@ export async function reviewGate(renderScript?: () => Promise<string>): Promise<
     const options = [
       { value: "apply", label: "Yes, apply these actions" },
       { value: "abort", label: "Abort" },
-      ...(renderScript ? [{ value: "script", label: pc.dim("Show the equivalent bash script"), hint: "runs nothing" }] : []),
+      ...(renderScript ? [{ value: "script", label: dim("Show the equivalent bash script"), hint: "runs nothing" }] : []),
     ];
-    const choice = await p.select({ message: "Proceed?", options });
+    const choice = await select({ message: "Proceed?", options });
 
-    if (p.isCancel(choice) || choice === "abort") {
-      p.cancel("Aborted, nothing was changed.");
+    if (isCancel(choice) || choice === "abort") {
+      cancel("Aborted, nothing was changed.");
       return false;
     }
     if (choice === "apply") return true;
 
-    p.log.message((await renderScript!()).split("\n"));
+    log.message((await renderScript!()).split("\n"));
   }
 }
 
@@ -486,7 +502,7 @@ export async function applyUpPlan(plan: UpPlan, host: Host): Promise<ApplyResult
 export async function printPostInstallSummary(host: Host): Promise<void> {
   heading("health check");
   const { runDoctor } = await import("./doctor.ts");
-  const doctorSpinner = p.spinner();
+  const doctorSpinner = spinner();
   doctorSpinner.start("Running diagnostics…");
   const report = await runDoctor({
     interactive: false,
@@ -500,7 +516,7 @@ export async function printPostInstallSummary(host: Host): Promise<void> {
 
   const { pass: passCount, warn: warnCount, fail: failCount } = report.summary;
   if (failCount > 0) {
-    warn("Health", `${failCount} check(s) failed. Run ${pc.cyan("xinity doctor")} for details.`);
+    warn("Health", `${failCount} check(s) failed. Run ${cyan("xinity doctor")} for details.`);
   } else if (warnCount > 0) {
     pass("Health", `All checks passed (${warnCount} warning(s))`);
   } else {
@@ -511,34 +527,34 @@ export async function printPostInstallSummary(host: Host): Promise<void> {
 
   const dashContent = await host.readFile(`${ENV_DIR}/dashboard.env`);
   const dashboardOrigin = dashContent ? parseEnvString(dashContent).ORIGIN : undefined;
-  if (dashboardOrigin) summaryLines.push(`Dashboard:  ${pc.cyan(dashboardOrigin)}`);
+  if (dashboardOrigin) summaryLines.push(`Dashboard:  ${cyan(dashboardOrigin)}`);
 
   const gwContent = await host.readFile(`${ENV_DIR}/gateway.env`);
   if (gwContent) {
     const parsed = parseEnvString(gwContent);
     const gwHost = parsed.HOST || "localhost";
     const gwPort = parsed.PORT || "4010";
-    summaryLines.push(`Gateway:    ${pc.cyan(`http://${gwHost}:${gwPort}`)}`);
+    summaryLines.push(`Gateway:    ${cyan(`http://${gwHost}:${gwPort}`)}`);
   }
 
   if (summaryLines.length > 0) summaryLines.push("");
-  summaryLines.push(pc.bold("Next steps:"));
+  summaryLines.push(bold("Next steps:"));
   if (dashboardOrigin) {
     summaryLines.push(`  1. Connect the CLI to your dashboard:`);
-    summaryLines.push(`     ${pc.cyan(`xinity configure dashboardUrl ${dashboardOrigin}`)}`);
+    summaryLines.push(`     ${cyan(`xinity configure dashboardUrl ${dashboardOrigin}`)}`);
     summaryLines.push(`  2. Create your admin account from the CLI:`);
-    summaryLines.push(`     ${pc.cyan("xinity act onboarding.cli")}`);
-    summaryLines.push(`     Or open ${pc.cyan(dashboardOrigin)} in a browser to sign up there.`);
+    summaryLines.push(`     ${cyan("xinity act onboarding.cli")}`);
+    summaryLines.push(`     Or open ${cyan(dashboardOrigin)} in a browser to sign up there.`);
   } else {
     summaryLines.push(`  1. Create your admin account via the dashboard UI`);
-    summaryLines.push(`     Or from the CLI: ${pc.cyan("xinity act onboarding.cli")}`);
+    summaryLines.push(`     Or from the CLI: ${cyan("xinity act onboarding.cli")}`);
   }
-  summaryLines.push(`  ${dashboardOrigin ? "3" : "2"}. Add inference nodes: ${pc.cyan("xinity up daemon")} on each GPU machine`);
-  summaryLines.push(`  ${dashboardOrigin ? "4" : "3"}. Check health anytime: ${pc.cyan("xinity doctor")}`);
+  summaryLines.push(`  ${dashboardOrigin ? "3" : "2"}. Add inference nodes: ${cyan("xinity up daemon")} on each GPU machine`);
+  summaryLines.push(`  ${dashboardOrigin ? "4" : "3"}. Check health anytime: ${cyan("xinity doctor")}`);
   summaryLines.push("");
-  summaryLines.push(pc.dim(`Model registry guide: ${getProjectUrl()}/tree/main/packages/xinity-infoserver#readme`));
+  summaryLines.push(dim(`Model registry guide: ${getProjectUrl()}/tree/main/packages/xinity-infoserver#readme`));
 
-  p.note(summaryLines.join("\n"), "Installation complete");
+  note(summaryLines.join("\n"), "Installation complete");
 }
 
 // ─── configure <component> ──────────────────────────────────────────────────
@@ -549,10 +565,10 @@ export async function printPostInstallSummary(host: Host): Promise<void> {
  * confirmed.
  */
 export async function configureComponentFlow(component: Component, host: Host): Promise<void> {
-  p.intro(`xinity configure ${pc.cyan(component)}`);
+  intro(`xinity configure ${cyan(component)}`);
 
   if (!(await host.prepareElevation())) {
-    p.outro("Aborted");
+    outro("Aborted");
     return;
   }
 
@@ -561,39 +577,46 @@ export async function configureComponentFlow(component: Component, host: Host): 
 
   const result = await menuEditEnv(ENV_SCHEMAS[component], existing);
   if (result === null) {
-    p.cancel("Cancelled, no changes saved.");
+    cancel("Cancelled, no changes saved.");
     return;
   }
 
   const changes = diffEnv({ config: state.existingConfig, secrets: state.existingSecrets }, result);
   if (changes.length === 0) {
-    p.log.info("No changes.");
-    p.outro("Done");
+    log.info("No changes.");
+    outro("Done");
     return;
   }
 
   const serviceRunning = await isUnitActiveOn(host, unitName(component));
 
-  p.log.step(pc.bold("Planned changes"));
-  for (const line of envChangeLines(changes)) {
-    p.log.info(`  ${line}`);
-  }
-  p.log.info(pc.dim(serviceRunning
-    ? `  update systemd unit, restart ${unitName(component)}`
-    : `  update systemd unit (${unitName(component)} is not running, takes effect on next start)`));
+  note(
+    [
+      ...envChangeLines(changes),
+      dim(serviceRunning
+        ? `update systemd unit, restart ${unitName(component)}`
+        : `update systemd unit (${unitName(component)} is not running, takes effect on next start)`),
+    ].join("\n"),
+    bold("Planned changes"),
+  );
 
   const proceed = await reviewGate(async () =>
     [...SCRIPT_HEADER, ...scriptConfigSection(component, result, serviceRunning)].join("\n"),
   );
   if (!proceed) return;
 
+  const progress = createProgress("Applying configuration…");
   const configResult = await writeEnvConfig(component, result.config, result.secrets, host);
   if (configResult.success) {
-    pass("Config", "Environment configured");
+    progress.update("Environment configured");
     await writeSystemdUnit(component, Object.keys(result.secrets), host);
-    await runSteps(restartService(component, host));
+    const restarted = await runSteps(restartService(component, host), progress);
+    progress.done(restarted
+      ? `${component} reconfigured, service restarted`
+      : `${component} reconfigured (service not running, takes effect on next start)`);
   } else if (configResult.error) {
-    fail("Config", configResult.error);
+    progress.fail("Config", configResult.error);
   }
-  p.outro("Done");
+  progress.ensureSettled();
+  outro("Done");
 }

--- a/packages/xinity-cli/tests/helpers/fake-host.ts
+++ b/packages/xinity-cli/tests/helpers/fake-host.ts
@@ -21,20 +21,16 @@ export interface FakeHostConfig {
   withElevation?: ElevationHandler;
   /** Virtual filesystem for readFile/fileExists. */
   files?: Record<string, string>;
-  isRemote?: boolean;
 }
 
 const FAIL: RunResult = { ok: false, output: "", exitCode: 1 };
 const OK: RunResult = { ok: true, output: "", exitCode: 0 };
 
 export class FakeHost implements Host {
-  readonly isRemote: boolean;
   /** Every command string seen, in order, for assertions. */
   readonly calls: string[] = [];
 
-  constructor(private readonly config: FakeHostConfig = {}) {
-    this.isRemote = config.isRemote ?? false;
-  }
+  constructor(private readonly config: FakeHostConfig = {}) {}
 
   async run(args: string[]): Promise<RunResult> {
     this.calls.push(args.join(" "));

--- a/packages/xinity-cli/tests/helpers/fake-host.ts
+++ b/packages/xinity-cli/tests/helpers/fake-host.ts
@@ -44,8 +44,12 @@ export class FakeHost implements Host {
 
   async withElevation(command: string): Promise<ElevationResult> {
     this.calls.push(command);
-    const base: ElevationResult = { success: true, output: "", skipped: false };
+    const base: ElevationResult = { success: true, output: "" };
     return { ...base, ...this.config.withElevation?.(command) };
+  }
+
+  async prepareElevation(): Promise<boolean> {
+    return true;
   }
 
   async readFile(path: string): Promise<string | null> {

--- a/packages/xinity-cli/tests/helpers/temp-config.ts
+++ b/packages/xinity-cli/tests/helpers/temp-config.ts
@@ -22,6 +22,22 @@ export interface TempDir {
   cleanup(): void;
 }
 
+/**
+ * Point XDG_CONFIG_HOME at the temp dir so the real stack/state persistence
+ * writes there instead of the user's config. Returns the restore function.
+ */
+export function redirectXdgConfigHome(tmp: TempDir): () => void {
+  const original = process.env.XDG_CONFIG_HOME;
+  process.env.XDG_CONFIG_HOME = tmp.path;
+  return () => {
+    if (original === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = original;
+    }
+  };
+}
+
 /** Create an isolated temp directory for a test. */
 export function createTempDir(prefix = "xinity-cli-test"): TempDir {
   const path = join(tmpdir(), `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`);

--- a/packages/xinity-cli/tests/integration/configure.test.ts
+++ b/packages/xinity-cli/tests/integration/configure.test.ts
@@ -37,7 +37,7 @@ describe("configure command", () => {
   test("configure <key> <value> sets a config value", async () => {
     const result = await runCli({
       args: ["configure", "dashboardUrl", "http://test.example.com"],
-      env: { HOME: tmp.path },
+      env: { HOME: tmp.path, XDG_CONFIG_HOME: join(tmp.path, ".config") },
     });
 
     // Should succeed (exit 0) with non-interactive set
@@ -50,12 +50,12 @@ describe("configure command", () => {
   test("configure sets multiple values sequentially", async () => {
     await runCli({
       args: ["configure", "dashboardUrl", "http://first.com"],
-      env: { HOME: tmp.path },
+      env: { HOME: tmp.path, XDG_CONFIG_HOME: join(tmp.path, ".config") },
     });
 
     await runCli({
       args: ["configure", "githubProjectUrl", "https://github.com/test/repo"],
-      env: { HOME: tmp.path },
+      env: { HOME: tmp.path, XDG_CONFIG_HOME: join(tmp.path, ".config") },
     });
 
     const config = readConfig();
@@ -66,12 +66,12 @@ describe("configure command", () => {
   test("configure overwrites existing value", async () => {
     await runCli({
       args: ["configure", "dashboardUrl", "http://old.com"],
-      env: { HOME: tmp.path },
+      env: { HOME: tmp.path, XDG_CONFIG_HOME: join(tmp.path, ".config") },
     });
 
     await runCli({
       args: ["configure", "dashboardUrl", "http://new.com"],
-      env: { HOME: tmp.path },
+      env: { HOME: tmp.path, XDG_CONFIG_HOME: join(tmp.path, ".config") },
     });
 
     const config = readConfig();
@@ -82,14 +82,14 @@ describe("configure command", () => {
     // Set a value first
     await runCli({
       args: ["configure", "apiKey", "test-key-123"],
-      env: { HOME: tmp.path },
+      env: { HOME: tmp.path, XDG_CONFIG_HOME: join(tmp.path, ".config") },
     });
     expect(readConfig().apiKey).toBe("test-key-123");
 
     // Reset it
     const result = await runCli({
       args: ["configure", "--reset", "apiKey"],
-      env: { HOME: tmp.path },
+      env: { HOME: tmp.path, XDG_CONFIG_HOME: join(tmp.path, ".config") },
     });
 
     expect(result.exitCode).toBe(0);
@@ -99,16 +99,16 @@ describe("configure command", () => {
   test("configure --reset preserves other keys", async () => {
     await runCli({
       args: ["configure", "apiKey", "key-1"],
-      env: { HOME: tmp.path },
+      env: { HOME: tmp.path, XDG_CONFIG_HOME: join(tmp.path, ".config") },
     });
     await runCli({
       args: ["configure", "dashboardUrl", "http://test.com"],
-      env: { HOME: tmp.path },
+      env: { HOME: tmp.path, XDG_CONFIG_HOME: join(tmp.path, ".config") },
     });
 
     await runCli({
       args: ["configure", "--reset", "apiKey"],
-      env: { HOME: tmp.path },
+      env: { HOME: tmp.path, XDG_CONFIG_HOME: join(tmp.path, ".config") },
     });
 
     const config = readConfig();
@@ -119,7 +119,7 @@ describe("configure command", () => {
   test("configure rejects invalid key", async () => {
     const result = await runCli({
       args: ["configure", "invalidKey", "value"],
-      env: { HOME: tmp.path },
+      env: { HOME: tmp.path, XDG_CONFIG_HOME: join(tmp.path, ".config") },
     });
 
     expect(result.exitCode).not.toBe(0);

--- a/packages/xinity-cli/tests/integration/doctor.test.ts
+++ b/packages/xinity-cli/tests/integration/doctor.test.ts
@@ -11,7 +11,24 @@ import { runCli } from "../helpers/cli-runner.ts";
  * Tests cover both the JSON API contract and the text rendering path.
  * They are designed to pass in a dev environment where no Xinity
  * components are installed, i.e. /opt/xinity/manifest.json is absent.
+ *
+ * Some tests require SSH to localhost. They are skipped when sshd is
+ * not available (the report will only contain a "connection" component).
  */
+
+async function hostConnected(): Promise<boolean> {
+  const result = await runCli({ args: ["doctor", "--format", "json", "--no-interactive"] });
+  const report = JSON.parse(result.stdout);
+  return report.components.some((c: any) => c.component === "system");
+}
+
+let _hostOk: boolean | null = null;
+async function requireHost(): Promise<boolean> {
+  if (_hostOk === null) {
+    _hostOk = await hostConnected();
+  }
+  return _hostOk;
+}
 describe("doctor command", () => {
   // ─── Help ────────────────────────────────────────────────────────────────
 
@@ -97,6 +114,7 @@ describe("doctor command", () => {
     // ─── System component ─────────────────────────────────────────────────
 
     test("components array includes a 'system' entry", async () => {
+      if (!(await requireHost())) return;
       const result = await runCli({
         args: ["doctor", "--format", "json", "--no-interactive"],
       });
@@ -106,6 +124,7 @@ describe("doctor command", () => {
     });
 
     test("system component reports installed: true", async () => {
+      if (!(await requireHost())) return;
       const result = await runCli({
         args: ["doctor", "--format", "json", "--no-interactive"],
       });
@@ -115,6 +134,7 @@ describe("doctor command", () => {
     });
 
     test("system component has a Platform check", async () => {
+      if (!(await requireHost())) return;
       const result = await runCli({
         args: ["doctor", "--format", "json", "--no-interactive"],
       });
@@ -126,6 +146,7 @@ describe("doctor command", () => {
     });
 
     test("system component has a Manifest check", async () => {
+      if (!(await requireHost())) return;
       const result = await runCli({
         args: ["doctor", "--format", "json", "--no-interactive"],
       });
@@ -136,6 +157,7 @@ describe("doctor command", () => {
     });
 
     test("system component has a systemd check", async () => {
+      if (!(await requireHost())) return;
       const result = await runCli({
         args: ["doctor", "--format", "json", "--no-interactive"],
       });
@@ -148,6 +170,7 @@ describe("doctor command", () => {
     // ─── Installable components ───────────────────────────────────────────
 
     test("report includes all four installable components", async () => {
+      if (!(await requireHost())) return;
       const result = await runCli({
         args: ["doctor", "--format", "json", "--no-interactive"],
       });
@@ -233,6 +256,7 @@ describe("doctor command", () => {
 
   describe("doctor text format (default)", () => {
     test("outputs a SYSTEM section header in stdout", async () => {
+      if (!(await requireHost())) return;
       const result = await runCli({ args: ["doctor", "--no-interactive"] });
       expect(result.stdout).toContain("SYSTEM");
     });

--- a/packages/xinity-cli/tests/unit/config.test.ts
+++ b/packages/xinity-cli/tests/unit/config.test.ts
@@ -1,52 +1,25 @@
-import { describe, expect, test, beforeEach, afterEach, mock } from "bun:test";
-import { createTempDir, type TempDir } from "../helpers/temp-config.ts";
-import { readFileSync, writeFileSync, mkdirSync, existsSync } from "fs";
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { createTempDir, redirectXdgConfigHome, type TempDir } from "../helpers/temp-config.ts";
+import { readFileSync, statSync } from "fs";
 import { join } from "path";
+import { loadConfig, saveConfig, updateConfig, configPath } from "../../src/lib/config.ts";
 
-/**
- * Config module tests.
- *
- * Since config.ts derives CONFIG_PATH from os.homedir() at module load time,
- * we test the underlying logic by reimplementing the same patterns against
- * a temp directory. This validates the serialization, merging, and error
- * handling behavior without needing to mock the module import.
- */
 describe("config", () => {
   let tmp: TempDir;
-  let configDir: string;
-  let configPath: string;
-
-  /** Mirror the loadConfig logic against our temp path. */
-  function loadConfig(): Record<string, string | undefined> {
-    if (!existsSync(configPath)) return {};
-    try {
-      return JSON.parse(readFileSync(configPath, "utf-8"));
-    } catch {
-      return {};
-    }
-  }
-
-  /** Mirror the saveConfig logic against our temp path. */
-  function saveConfig(config: Record<string, string | undefined>): void {
-    mkdirSync(configDir, { recursive: true });
-    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
-  }
-
-  /** Mirror the updateConfig logic. */
-  function updateConfig(patch: Record<string, string | undefined>): Record<string, string | undefined> {
-    const config = { ...loadConfig(), ...patch };
-    saveConfig(config);
-    return config;
-  }
+  let restoreEnv: () => void;
 
   beforeEach(() => {
     tmp = createTempDir("config-test");
-    configDir = join(tmp.path, ".config", "xinity");
-    configPath = join(configDir, "config.json");
+    restoreEnv = redirectXdgConfigHome(tmp);
   });
 
   afterEach(() => {
+    restoreEnv();
     tmp.cleanup();
+  });
+
+  test("configPath honors XDG_CONFIG_HOME", () => {
+    expect(configPath()).toBe(join(tmp.path, "xinity", "config.json"));
   });
 
   describe("loadConfig", () => {
@@ -55,23 +28,17 @@ describe("config", () => {
     });
 
     test("loads valid JSON config", () => {
-      mkdirSync(configDir, { recursive: true });
-      writeFileSync(configPath, JSON.stringify({ apiKey: "test-key" }));
-
+      tmp.write("xinity/config.json", JSON.stringify({ apiKey: "test-key" }));
       expect(loadConfig()).toEqual({ apiKey: "test-key" });
     });
 
     test("returns empty object for invalid JSON", () => {
-      mkdirSync(configDir, { recursive: true });
-      writeFileSync(configPath, "not valid json{{{");
-
+      tmp.write("xinity/config.json", "not valid json{{{");
       expect(loadConfig()).toEqual({});
     });
 
     test("returns empty object for empty file", () => {
-      mkdirSync(configDir, { recursive: true });
-      writeFileSync(configPath, "");
-
+      tmp.write("xinity/config.json", "");
       expect(loadConfig()).toEqual({});
     });
   });
@@ -80,17 +47,14 @@ describe("config", () => {
     test("creates directory and writes config", () => {
       saveConfig({ apiKey: "my-key", dashboardUrl: "http://localhost:5173" });
 
-      expect(existsSync(configPath)).toBe(true);
-      const content = readFileSync(configPath, "utf-8");
-      const parsed = JSON.parse(content);
-      expect(parsed.apiKey).toBe("my-key");
-      expect(parsed.dashboardUrl).toBe("http://localhost:5173");
+      expect(tmp.exists("xinity/config.json")).toBe(true);
+      expect(loadConfig()).toEqual({ apiKey: "my-key", dashboardUrl: "http://localhost:5173" });
     });
 
     test("writes pretty-printed JSON with trailing newline", () => {
       saveConfig({ apiKey: "key" });
 
-      const content = readFileSync(configPath, "utf-8");
+      const content = readFileSync(configPath(), "utf-8");
       expect(content).toContain("  ");
       expect(content.endsWith("\n")).toBe(true);
     });
@@ -99,8 +63,12 @@ describe("config", () => {
       saveConfig({ apiKey: "old-key" });
       saveConfig({ apiKey: "new-key" });
 
-      const config = loadConfig();
-      expect(config.apiKey).toBe("new-key");
+      expect(loadConfig().apiKey).toBe("new-key");
+    });
+
+    test("config file is readable only by the user", () => {
+      saveConfig({ apiKey: "key" });
+      expect(statSync(configPath()).mode & 0o777).toBe(0o600);
     });
   });
 

--- a/packages/xinity-cli/tests/unit/env-file.test.ts
+++ b/packages/xinity-cli/tests/unit/env-file.test.ts
@@ -35,4 +35,11 @@ describe("serializeEnvFile", () => {
     const values = { A: "1", B: "two words", C: "https://x.test" };
     expect(parseEnvString(serializeEnvFile(values))).toEqual(values);
   });
+
+  test("round-trips values containing both quote types", () => {
+    const values = { MSG: `she said "it's fine"` };
+    const serialized = serializeEnvFile(values);
+    expect(parseEnvString(serialized)).toEqual(values);
+    expect(parseEnvString(serializeEnvFile(parseEnvString(serialized)))).toEqual(values);
+  });
 });

--- a/packages/xinity-cli/tests/unit/stack-plan.test.ts
+++ b/packages/xinity-cli/tests/unit/stack-plan.test.ts
@@ -14,7 +14,6 @@ const actualManifest = { ...(await import("../../src/lib/manifest.ts")) };
 const actualGithub = { ...(await import("../../src/lib/github.ts")) };
 const actualInstallRemove = { ...(await import("../../src/lib/install-remove.ts")) };
 const actualUpPlan = { ...(await import("../../src/lib/up-plan.ts")) };
-
 let reachable: Set<string>;
 let manifests: Record<string, Manifest>;
 let removals: { component: Component; address: string }[];
@@ -218,4 +217,5 @@ describe("runStackFlow", () => {
     expect(await runStackFlow(makeStack("s8"), { targetVersion: "latest" })).toBe(true);
     expect(loadStackState("s8").hosts).toEqual([{ address: "10.0.0.12" }]);
   });
+
 });

--- a/packages/xinity-cli/tests/unit/stack-plan.test.ts
+++ b/packages/xinity-cli/tests/unit/stack-plan.test.ts
@@ -58,7 +58,7 @@ mock.module("../../src/lib/github.ts", () => ({
 
 mock.module("../../src/lib/install-remove.ts", () => ({
   ...actualInstallRemove,
-  removeComponentCollapsed: async (opts: { component: Component; host: Host }) => {
+  async *removeComponent(opts: { component: Component; host: Host }) {
     removals.push({ component: opts.component, address: hostAddress(opts.host) });
     return removalFails
       ? { success: false, errors: ["simulated removal failure"] }

--- a/packages/xinity-cli/tests/unit/stack-plan.test.ts
+++ b/packages/xinity-cli/tests/unit/stack-plan.test.ts
@@ -67,9 +67,11 @@ mock.module("../../src/lib/install-remove.ts", () => ({
   },
 }));
 
+let gateApproves: boolean;
+
 mock.module("../../src/lib/up-plan.ts", () => ({
   ...actualUpPlan,
-  reviewGate: async () => true,
+  reviewGate: async () => gateApproves,
 }));
 
 const { runStackFlow } = await import("../../src/lib/stack-plan.ts");
@@ -99,7 +101,7 @@ function makeStack(name: string): StackDefinition {
   return stack;
 }
 
-describe("runStackFlow orphan handling", () => {
+describe("runStackFlow", () => {
   let tmp: TempDir;
   let restoreEnv: () => void;
 
@@ -111,6 +113,7 @@ describe("runStackFlow orphan handling", () => {
     removals = [];
     removalFails = false;
     membershipWrites = [];
+    gateApproves = true;
   });
 
   afterEach(() => {
@@ -183,5 +186,36 @@ describe("runStackFlow orphan handling", () => {
     expect(await runStackFlow(makeStack("s5"), { targetVersion: "latest" })).toBe(false);
     expect(membershipWrites).toEqual([]);
     expect(loadStackState("s5").hosts).toEqual([{ address: "10.0.0.9" }]);
+  });
+
+  test("a dry run plans an evacuation but changes neither hosts nor state", async () => {
+    markHostManaged("s6", "10.0.0.10");
+    reachable = new Set(["10.0.0.10"]);
+    manifests["10.0.0.10"] = { components: daemonEntry(), stack: { name: "s6" } };
+
+    expect(await runStackFlow(makeStack("s6"), { targetVersion: "latest", dryRun: true })).toBe(true);
+    expect(removals).toEqual([]);
+    expect(membershipWrites).toEqual([]);
+    expect(loadStackState("s6").hosts).toEqual([{ address: "10.0.0.10" }]);
+  });
+
+  test("aborting at the gate leaves hosts and state untouched", async () => {
+    gateApproves = false;
+    markHostManaged("s7", "10.0.0.11");
+    reachable = new Set(["10.0.0.11"]);
+    manifests["10.0.0.11"] = { components: daemonEntry(), stack: { name: "s7" } };
+
+    expect(await runStackFlow(makeStack("s7"), { targetVersion: "latest" })).toBe(true);
+    expect(removals).toEqual([]);
+    expect(membershipWrites).toEqual([]);
+    expect(loadStackState("s7").hosts).toEqual([{ address: "10.0.0.11" }]);
+  });
+
+  test("an unreachable orphan is only forgotten after the gate approves", async () => {
+    gateApproves = false;
+    markHostManaged("s8", "10.0.0.12");
+
+    expect(await runStackFlow(makeStack("s8"), { targetVersion: "latest" })).toBe(true);
+    expect(loadStackState("s8").hosts).toEqual([{ address: "10.0.0.12" }]);
   });
 });

--- a/packages/xinity-cli/tests/unit/stack-plan.test.ts
+++ b/packages/xinity-cli/tests/unit/stack-plan.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, test, beforeEach, afterEach, afterAll, mock } from "bun:test";
+import { createTempDir, redirectXdgConfigHome, type TempDir } from "../helpers/temp-config.ts";
+import type { Host } from "../../src/lib/host.ts";
+import type { Manifest, StackMembership } from "../../src/lib/manifest.ts";
+import type { Component } from "../../src/lib/component-meta.ts";
+import { createStack, type StackDefinition } from "../../src/lib/stack.ts";
+import { loadStackState, markHostManaged } from "../../src/lib/stack-state.ts";
+
+// bun shares the module registry across test files, so the originals are
+// captured first and restored in afterAll; the module under test is imported
+// only after the mocks are installed.
+const actualRemoteHost = { ...(await import("../../src/lib/remote-host.ts")) };
+const actualManifest = { ...(await import("../../src/lib/manifest.ts")) };
+const actualGithub = { ...(await import("../../src/lib/github.ts")) };
+const actualInstallRemove = { ...(await import("../../src/lib/install-remove.ts")) };
+const actualUpPlan = { ...(await import("../../src/lib/up-plan.ts")) };
+
+let reachable: Set<string>;
+let manifests: Record<string, Manifest>;
+let removals: { component: Component; address: string }[];
+let removalFails: boolean;
+let membershipWrites: { address: string; membership: StackMembership | null }[];
+
+function hostAddress(host: Host): string {
+  return (host as unknown as { address: string }).address;
+}
+
+function fakeHost(address: string): Host {
+  return {
+    address,
+    prepareElevation: async () => true,
+    dispose: async () => {},
+  } as unknown as Host;
+}
+
+mock.module("../../src/lib/remote-host.ts", () => ({
+  ...actualRemoteHost,
+  connectHost: async (address?: string) => {
+    const addr = address ?? "local";
+    if (!reachable.has(addr)) {
+      throw new Error(`no route to ${addr}`);
+    }
+    return fakeHost(addr);
+  },
+}));
+
+mock.module("../../src/lib/manifest.ts", () => ({
+  ...actualManifest,
+  readManifest: async (host: Host) => manifests[hostAddress(host)] ?? { components: {} },
+  saveStackMembership: async (membership: StackMembership | null, host: Host) => {
+    membershipWrites.push({ address: hostAddress(host), membership });
+  },
+}));
+
+mock.module("../../src/lib/github.ts", () => ({
+  ...actualGithub,
+  fetchRelease: async () => ({ tagName: "v9.9.9" }),
+}));
+
+mock.module("../../src/lib/install-remove.ts", () => ({
+  ...actualInstallRemove,
+  removeComponentCollapsed: async (opts: { component: Component; host: Host }) => {
+    removals.push({ component: opts.component, address: hostAddress(opts.host) });
+    return removalFails
+      ? { success: false, errors: ["simulated removal failure"] }
+      : { success: true, errors: [] };
+  },
+}));
+
+mock.module("../../src/lib/up-plan.ts", () => ({
+  ...actualUpPlan,
+  reviewGate: async () => true,
+}));
+
+const { runStackFlow } = await import("../../src/lib/stack-plan.ts");
+
+afterAll(() => {
+  mock.module("../../src/lib/remote-host.ts", () => actualRemoteHost);
+  mock.module("../../src/lib/manifest.ts", () => actualManifest);
+  mock.module("../../src/lib/github.ts", () => actualGithub);
+  mock.module("../../src/lib/install-remove.ts", () => actualInstallRemove);
+  mock.module("../../src/lib/up-plan.ts", () => actualUpPlan);
+});
+
+function daemonEntry(): Manifest["components"] {
+  return { daemon: { version: "v1.0.0", installedAt: "2026-01-01", binaryPath: "/opt/xinity/daemon", unitName: "xinity-ai-daemon" } };
+}
+
+// Shared values keep ensureStackLevelConfig from opening an interactive
+// editor; dbMigratedVersion matches the mocked release so no migrations plan.
+function makeStack(name: string): StackDefinition {
+  const stack = createStack(name);
+  stack.secrets = {
+    DB_CONNECTION_URL: "postgresql://localhost/db",
+    REDIS_URL: "redis://localhost:6379",
+    METRICS_AUTH: "user:pass",
+  };
+  stack.dbMigratedVersion = "v9.9.9";
+  return stack;
+}
+
+describe("runStackFlow orphan handling", () => {
+  let tmp: TempDir;
+  let restoreEnv: () => void;
+
+  beforeEach(() => {
+    tmp = createTempDir("stack-plan-test");
+    restoreEnv = redirectXdgConfigHome(tmp);
+    reachable = new Set();
+    manifests = {};
+    removals = [];
+    removalFails = false;
+    membershipWrites = [];
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    tmp.cleanup();
+  });
+
+  test("an empty stack with nothing tracked deploys nothing and succeeds", async () => {
+    expect(await runStackFlow(createStack("empty"), { targetVersion: "latest" })).toBe(true);
+    expect(removals).toEqual([]);
+  });
+
+  test("rejects an invalid definition before touching any host", async () => {
+    const stack = makeStack("s0");
+    stack.hosts = [
+      { address: "10.0.0.1", components: ["daemon"] },
+      { address: "10.0.0.1", components: ["daemon"] },
+    ];
+    expect(await runStackFlow(stack, { targetVersion: "latest" })).toBe(false);
+    expect(removals).toEqual([]);
+    expect(membershipWrites).toEqual([]);
+  });
+
+  test("an unreachable orphan is forgotten and does not fail the run", async () => {
+    markHostManaged("s1", "10.0.0.5");
+
+    expect(await runStackFlow(makeStack("s1"), { targetVersion: "latest" })).toBe(true);
+    expect(loadStackState("s1").hosts).toEqual([]);
+    expect(removals).toEqual([]);
+  });
+
+  test("an orphan claimed by another stack is left untouched", async () => {
+    markHostManaged("s2", "10.0.0.6");
+    reachable = new Set(["10.0.0.6"]);
+    manifests["10.0.0.6"] = { components: daemonEntry(), stack: { name: "other" } };
+
+    expect(await runStackFlow(makeStack("s2"), { targetVersion: "latest" })).toBe(true);
+    expect(loadStackState("s2").hosts).toEqual([]);
+    expect(removals).toEqual([]);
+    expect(membershipWrites).toEqual([]);
+  });
+
+  test("an orphan with nothing installed is forgotten silently", async () => {
+    markHostManaged("s3", "10.0.0.7");
+    reachable = new Set(["10.0.0.7"]);
+    manifests["10.0.0.7"] = { components: {} };
+
+    expect(await runStackFlow(makeStack("s3"), { targetVersion: "latest" })).toBe(true);
+    expect(loadStackState("s3").hosts).toEqual([]);
+    expect(removals).toEqual([]);
+  });
+
+  test("a removed host is evacuated: components removed, membership and state cleared", async () => {
+    markHostManaged("s4", "10.0.0.8");
+    reachable = new Set(["10.0.0.8"]);
+    manifests["10.0.0.8"] = { components: daemonEntry(), stack: { name: "s4" } };
+
+    expect(await runStackFlow(makeStack("s4"), { targetVersion: "latest" })).toBe(true);
+    expect(removals).toEqual([{ component: "daemon", address: "10.0.0.8" }]);
+    expect(membershipWrites).toEqual([{ address: "10.0.0.8", membership: null }]);
+    expect(loadStackState("s4").hosts).toEqual([]);
+  });
+
+  test("a failed evacuation keeps the state entry so the next up retries", async () => {
+    markHostManaged("s5", "10.0.0.9");
+    reachable = new Set(["10.0.0.9"]);
+    manifests["10.0.0.9"] = { components: daemonEntry(), stack: { name: "s5" } };
+    removalFails = true;
+
+    expect(await runStackFlow(makeStack("s5"), { targetVersion: "latest" })).toBe(false);
+    expect(membershipWrites).toEqual([]);
+    expect(loadStackState("s5").hosts).toEqual([{ address: "10.0.0.9" }]);
+  });
+});

--- a/packages/xinity-cli/tests/unit/stack-plan.test.ts
+++ b/packages/xinity-cli/tests/unit/stack-plan.test.ts
@@ -91,7 +91,7 @@ function daemonEntry(): Manifest["components"] {
 // Shared values keep ensureStackLevelConfig from opening an interactive
 // editor; dbMigratedVersion matches the mocked release so no migrations plan.
 function makeStack(name: string): StackDefinition {
-  const stack = createStack(name);
+  const stack = createStack(name, "v9.9.9");
   stack.secrets = {
     DB_CONNECTION_URL: "postgresql://localhost/db",
     REDIS_URL: "redis://localhost:6379",
@@ -122,7 +122,7 @@ describe("runStackFlow", () => {
   });
 
   test("an empty stack with nothing tracked deploys nothing and succeeds", async () => {
-    expect(await runStackFlow(createStack("empty"), { targetVersion: "latest" })).toBe(true);
+    expect(await runStackFlow(createStack("empty", "v9.9.9"), { targetVersion: "latest" })).toBe(true);
     expect(removals).toEqual([]);
   });
 

--- a/packages/xinity-cli/tests/unit/stack-state.test.ts
+++ b/packages/xinity-cli/tests/unit/stack-state.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { createTempDir, redirectXdgConfigHome, type TempDir } from "../helpers/temp-config.ts";
+import { version as cliVersion } from "../../../../package.json";
+import {
+  type StackState,
+  addManagedHost,
+  removeManagedHost,
+  findOrphanHosts,
+  loadStackState,
+  markHostManaged,
+  unmarkHostManaged,
+  deleteStackState,
+} from "../../src/lib/stack-state.ts";
+import { type StackDefinition, createStack } from "../../src/lib/stack.ts";
+
+function makeState(addresses: string[] = []): StackState {
+  return { version: "0.0.0", hosts: addresses.map((address) => ({ address })) };
+}
+
+function makeStack(addresses: string[] = []): StackDefinition {
+  const stack = createStack("test-stack");
+  stack.hosts = addresses.map((address) => ({ address, components: ["daemon"] }));
+  return stack;
+}
+
+describe("addManagedHost", () => {
+  test("adds a new host and reports the change", () => {
+    const state = makeState(["10.0.0.1"]);
+    expect(addManagedHost(state, "10.0.0.2")).toBe(true);
+    expect(state.hosts).toEqual([{ address: "10.0.0.1" }, { address: "10.0.0.2" }]);
+  });
+
+  test("is a no-op for an already managed host", () => {
+    const state = makeState(["10.0.0.1"]);
+    expect(addManagedHost(state, "10.0.0.1")).toBe(false);
+    expect(state.hosts).toHaveLength(1);
+  });
+});
+
+describe("removeManagedHost", () => {
+  test("removes a managed host and reports the change", () => {
+    const state = makeState(["10.0.0.1", "10.0.0.2"]);
+    expect(removeManagedHost(state, "10.0.0.1")).toBe(true);
+    expect(state.hosts).toEqual([{ address: "10.0.0.2" }]);
+  });
+
+  test("is a no-op for an unknown host", () => {
+    const state = makeState(["10.0.0.1"]);
+    expect(removeManagedHost(state, "10.0.0.9")).toBe(false);
+    expect(state.hosts).toHaveLength(1);
+  });
+});
+
+describe("state persistence", () => {
+  let tmp: TempDir;
+  let restoreEnv: () => void;
+
+  beforeEach(() => {
+    tmp = createTempDir("stack-state-test");
+    restoreEnv = redirectXdgConfigHome(tmp);
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    tmp.cleanup();
+  });
+
+  test("loadStackState returns an empty state when no file exists", () => {
+    expect(loadStackState("fresh")).toEqual({ version: cliVersion, hosts: [] });
+  });
+
+  test("loadStackState falls back to an empty state for a corrupt file", () => {
+    tmp.write("xinity/stacks/state/corrupt.json", "not valid json{{{");
+    expect(loadStackState("corrupt")).toEqual({ version: cliVersion, hosts: [] });
+  });
+
+  test("loadStackState backfills fields missing from older files", () => {
+    tmp.write("xinity/stacks/state/old.json", "{}");
+    expect(loadStackState("old")).toEqual({ version: "0.0.0", hosts: [] });
+  });
+
+  test("mark and unmark round-trip through the real file", () => {
+    markHostManaged("s", "10.0.0.1");
+    markHostManaged("s", "10.0.0.2");
+    markHostManaged("s", "10.0.0.1");
+    expect(loadStackState("s").hosts).toEqual([{ address: "10.0.0.1" }, { address: "10.0.0.2" }]);
+
+    unmarkHostManaged("s", "10.0.0.1");
+    expect(loadStackState("s").hosts).toEqual([{ address: "10.0.0.2" }]);
+  });
+
+  test("deleteStackState removes the file", () => {
+    markHostManaged("s", "10.0.0.1");
+    deleteStackState("s");
+    expect(loadStackState("s").hosts).toEqual([]);
+    expect(tmp.exists("xinity/stacks/state/s.json")).toBe(false);
+  });
+});
+
+describe("findOrphanHosts", () => {
+  test("returns managed hosts missing from the definition", () => {
+    const state = makeState(["10.0.0.1", "10.0.0.2", "10.0.0.3"]);
+    const stack = makeStack(["10.0.0.2"]);
+    expect(findOrphanHosts(state, stack)).toEqual(["10.0.0.1", "10.0.0.3"]);
+  });
+
+  test("returns nothing when state and definition agree", () => {
+    const state = makeState(["10.0.0.1"]);
+    expect(findOrphanHosts(state, makeStack(["10.0.0.1"]))).toEqual([]);
+  });
+
+  test("hosts never applied to are not orphans", () => {
+    const state = makeState([]);
+    expect(findOrphanHosts(state, makeStack(["10.0.0.1"]))).toEqual([]);
+  });
+});

--- a/packages/xinity-cli/tests/unit/stack-state.test.ts
+++ b/packages/xinity-cli/tests/unit/stack-state.test.ts
@@ -18,7 +18,7 @@ function makeState(addresses: string[] = []): StackState {
 }
 
 function makeStack(addresses: string[] = []): StackDefinition {
-  const stack = createStack("test-stack");
+  const stack = createStack("test-stack", "v1.0.0");
   stack.hosts = addresses.map((address) => ({ address, components: ["daemon"] }));
   return stack;
 }

--- a/packages/xinity-cli/tests/unit/stack.test.ts
+++ b/packages/xinity-cli/tests/unit/stack.test.ts
@@ -1,0 +1,415 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { createTempDir, type TempDir } from "../helpers/temp-config.ts";
+import { mkdirSync, writeFileSync, readFileSync, existsSync, readdirSync, unlinkSync } from "fs";
+import { join } from "path";
+import {
+  type StackDefinition,
+  type StackHost,
+  type FleetDefinition,
+  resolveEnv,
+  diffFromLayer,
+  validateStack,
+  getFleet,
+  getHost,
+  getFleetForHost,
+  createStack,
+} from "../../src/lib/stack.ts";
+
+function makeStack(overrides: Partial<StackDefinition> = {}): StackDefinition {
+  return {
+    version: "0.0.0",
+    name: "test-stack",
+    env: {},
+    secrets: {},
+    componentEnv: {},
+    hosts: [],
+    fleets: [],
+    ...overrides,
+  };
+}
+
+function makeHost(overrides: Partial<StackHost> = {}): StackHost {
+  return {
+    address: "10.0.0.1",
+    components: ["daemon"],
+    ...overrides,
+  };
+}
+
+function makeFleet(overrides: Partial<FleetDefinition> = {}): FleetDefinition {
+  return {
+    name: "gpu-pool",
+    hosts: ["10.0.0.1"],
+    ...overrides,
+  };
+}
+
+// ── Persistence (mirrored against temp dir, same pattern as config.test.ts) ──
+
+describe("stack persistence", () => {
+  let tmp: TempDir;
+  let stacksDir: string;
+
+  function stackPath(name: string): string {
+    return join(stacksDir, `${name}.json`);
+  }
+
+  function saveStack(stack: StackDefinition): void {
+    mkdirSync(stacksDir, { recursive: true });
+    writeFileSync(stackPath(stack.name), JSON.stringify(stack, null, 2) + "\n");
+  }
+
+  function loadStack(name: string): StackDefinition | null {
+    const path = stackPath(name);
+    if (!existsSync(path)) {
+      return null;
+    }
+    try {
+      return JSON.parse(readFileSync(path, "utf-8")) as StackDefinition;
+    } catch {
+      return null;
+    }
+  }
+
+  function deleteStack(name: string): boolean {
+    const path = stackPath(name);
+    if (!existsSync(path)) {
+      return false;
+    }
+    unlinkSync(path);
+    return true;
+  }
+
+  function listStacks(): string[] {
+    if (!existsSync(stacksDir)) {
+      return [];
+    }
+    return readdirSync(stacksDir)
+      .filter((f) => f.endsWith(".json"))
+      .map((f) => f.replace(/\.json$/, ""))
+      .sort();
+  }
+
+  beforeEach(() => {
+    tmp = createTempDir("stack-test");
+    stacksDir = join(tmp.path, "stacks");
+  });
+
+  afterEach(() => {
+    tmp.cleanup();
+  });
+
+  test("loadStack returns null when file does not exist", () => {
+    expect(loadStack("nonexistent")).toBeNull();
+  });
+
+  test("round-trips a stack definition", () => {
+    const stack = makeStack({
+      env: { REDIS_URL: "redis://localhost:6379" },
+      secrets: { DB_CONNECTION_URL: "postgresql://localhost/db" },
+      hosts: [makeHost()],
+      fleets: [makeFleet()],
+    });
+
+    saveStack(stack);
+    const loaded = loadStack("test-stack");
+
+    expect(loaded).toEqual(stack);
+  });
+
+  test("deleteStack removes the file", () => {
+    saveStack(makeStack());
+    expect(loadStack("test-stack")).not.toBeNull();
+
+    const deleted = deleteStack("test-stack");
+    expect(deleted).toBe(true);
+    expect(loadStack("test-stack")).toBeNull();
+  });
+
+  test("deleteStack returns false when file does not exist", () => {
+    expect(deleteStack("nonexistent")).toBe(false);
+  });
+
+  test("listStacks returns sorted stack names", () => {
+    saveStack(makeStack({ name: "bravo" }));
+    saveStack(makeStack({ name: "alpha" }));
+    saveStack(makeStack({ name: "charlie" }));
+
+    expect(listStacks()).toEqual(["alpha", "bravo", "charlie"]);
+  });
+
+  test("listStacks returns empty array when directory does not exist", () => {
+    expect(listStacks()).toEqual([]);
+  });
+
+  test("listStacks ignores non-JSON files", () => {
+    mkdirSync(stacksDir, { recursive: true });
+    writeFileSync(join(stacksDir, "notes.txt"), "not a stack");
+    saveStack(makeStack({ name: "real" }));
+
+    expect(listStacks()).toEqual(["real"]);
+  });
+
+  test("loadStack returns null for invalid JSON", () => {
+    mkdirSync(stacksDir, { recursive: true });
+    writeFileSync(stackPath("broken"), "not valid json{{{");
+
+    expect(loadStack("broken")).toBeNull();
+  });
+});
+
+// ── Lookup ───────────────────────────────────────────────────────────────
+
+describe("stack lookup", () => {
+  test("getFleet returns matching fleet", () => {
+    const fleet = makeFleet({ name: "a100" });
+    const stack = makeStack({ fleets: [fleet, makeFleet({ name: "other" })] });
+
+    expect(getFleet(stack, "a100")).toEqual(fleet);
+  });
+
+  test("getFleet returns null for unknown name", () => {
+    const stack = makeStack({ fleets: [makeFleet()] });
+    expect(getFleet(stack, "nonexistent")).toBeNull();
+  });
+
+  test("getHost returns matching host", () => {
+    const host = makeHost({ address: "10.0.0.5" });
+    const stack = makeStack({ hosts: [makeHost(), host] });
+
+    expect(getHost(stack, "10.0.0.5")).toEqual(host);
+  });
+
+  test("getHost returns null for unknown address", () => {
+    const stack = makeStack({ hosts: [makeHost()] });
+    expect(getHost(stack, "10.0.0.99")).toBeNull();
+  });
+
+  test("getFleetForHost returns fleet containing the host", () => {
+    const fleet = makeFleet({ name: "pool", hosts: ["10.0.0.1", "10.0.0.2"] });
+    const stack = makeStack({
+      hosts: [makeHost({ address: "10.0.0.1" }), makeHost({ address: "10.0.0.2" })],
+      fleets: [fleet],
+    });
+
+    expect(getFleetForHost(stack, "10.0.0.2")?.name).toBe("pool");
+  });
+
+  test("getFleetForHost returns null when host is not in any fleet", () => {
+    const stack = makeStack({
+      hosts: [makeHost({ address: "10.0.0.1" })],
+      fleets: [makeFleet({ hosts: ["10.0.0.99"] })],
+    });
+
+    expect(getFleetForHost(stack, "10.0.0.1")).toBeNull();
+  });
+});
+
+// ── Env resolution ───────────────────────────────────────────────────────
+
+describe("resolveEnv", () => {
+  test("shared env and secrets reach every component", () => {
+    const stack = makeStack({
+      env: { REDIS_URL: "redis://localhost:6379" },
+      secrets: { DB_CONNECTION_URL: "postgresql://localhost/db" },
+    });
+
+    expect(resolveEnv(stack, "gateway")).toMatchObject({
+      REDIS_URL: "redis://localhost:6379",
+      DB_CONNECTION_URL: "postgresql://localhost/db",
+    });
+    expect(resolveEnv(stack, "daemon")).toMatchObject({
+      DB_CONNECTION_URL: "postgresql://localhost/db",
+    });
+  });
+
+  test("includes the component's auto defaults as the base layer", () => {
+    const stack = makeStack();
+    expect(resolveEnv(stack, "daemon").STATE_DIR).toBe("/var/lib/xinity-ai-daemon");
+    expect(resolveEnv(stack, "gateway").INFOSERVER_URL).toBe("https://sysinfo.xinity.ai");
+  });
+
+  test("shared env overrides auto defaults", () => {
+    const stack = makeStack({ env: { INFOSERVER_URL: "http://infoserver.internal:8090" } });
+    expect(resolveEnv(stack, "gateway").INFOSERVER_URL).toBe("http://infoserver.internal:8090");
+  });
+
+  test("componentEnv applies only to its own component type", () => {
+    const stack = makeStack({
+      componentEnv: { gateway: { PORT: "9000" } },
+    });
+
+    expect(resolveEnv(stack, "gateway").PORT).toBe("9000");
+    expect(resolveEnv(stack, "dashboard").PORT).toBeUndefined();
+  });
+
+  test("fleet overrides apply to the daemon on fleet hosts only", () => {
+    const stack = makeStack({
+      env: { CIDR_PREFIX: "10.0" },
+      hosts: [makeHost({ address: "10.0.0.1", components: ["daemon", "gateway"] })],
+      fleets: [makeFleet({ hosts: ["10.0.0.1"], envOverrides: { CIDR_PREFIX: "172.16" } })],
+    });
+
+    expect(resolveEnv(stack, "daemon", "10.0.0.1").CIDR_PREFIX).toBe("172.16");
+    expect(resolveEnv(stack, "gateway", "10.0.0.1").CIDR_PREFIX).toBe("10.0");
+  });
+
+  test("full precedence chain: shared < componentEnv < fleet < host", () => {
+    const stack = makeStack({
+      env: { A: "stack", B: "stack", C: "stack", D: "stack" },
+      secrets: { S: "stack-secret" },
+      componentEnv: { daemon: { B: "component", C: "component", D: "component" } },
+      hosts: [makeHost({ address: "h1", envOverrides: { D: "host" } })],
+      fleets: [makeFleet({ hosts: ["h1"], envOverrides: { C: "fleet", D: "fleet" } })],
+    });
+
+    const result = resolveEnv(stack, "daemon", "h1");
+    expect(result.A).toBe("stack");
+    expect(result.B).toBe("component");
+    expect(result.C).toBe("fleet");
+    expect(result.D).toBe("host");
+    expect(result.S).toBe("stack-secret");
+  });
+
+  test("host without a fleet gets no fleet layer", () => {
+    const stack = makeStack({
+      env: { KEY: "value" },
+      hosts: [makeHost({ address: "10.0.0.1" })],
+      fleets: [makeFleet({ hosts: ["10.0.0.9"], envOverrides: { KEY: "fleet" } })],
+    });
+
+    expect(resolveEnv(stack, "daemon", "10.0.0.1").KEY).toBe("value");
+  });
+});
+
+describe("diffFromLayer", () => {
+  test("keeps only entries that differ from the base", () => {
+    expect(diffFromLayer(
+      { A: "same", B: "changed", C: "new" },
+      { A: "same", B: "original" },
+    )).toEqual({ B: "changed", C: "new" });
+  });
+
+  test("identical values produce an empty diff", () => {
+    expect(diffFromLayer({ A: "x" }, { A: "x" })).toEqual({});
+  });
+});
+
+// ── Validation ───────────────────────────────────────────────────────────
+
+describe("validateStack", () => {
+  test("valid stack produces no errors", () => {
+    const stack = makeStack({
+      name: "production",
+      hosts: [makeHost({ address: "10.0.0.1", components: ["daemon"] })],
+      fleets: [makeFleet({ name: "gpu", hosts: ["10.0.0.1"] })],
+    });
+
+    expect(validateStack(stack)).toEqual([]);
+  });
+
+  test("rejects a host that belongs to multiple fleets", () => {
+    const stack = makeStack({
+      name: "production",
+      hosts: [makeHost({ address: "10.0.0.1", components: ["daemon"] })],
+      fleets: [
+        makeFleet({ name: "pool-a", hosts: ["10.0.0.1"] }),
+        makeFleet({ name: "pool-b", hosts: ["10.0.0.1"] }),
+      ],
+    });
+
+    const errors = validateStack(stack);
+    expect(errors.some((e) => e.message.includes("multiple fleets"))).toBe(true);
+  });
+
+  test("rejects invalid stack name", () => {
+    const stack = makeStack({ name: "INVALID NAME!" });
+    const errors = validateStack(stack);
+
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].field).toBe("name");
+  });
+
+  test("rejects empty stack name", () => {
+    const stack = makeStack({ name: "" });
+    const errors = validateStack(stack);
+
+    expect(errors.some((e) => e.field === "name")).toBe(true);
+  });
+
+  test("accepts hyphenated and underscored names", () => {
+    expect(validateStack(makeStack({ name: "my-stack" }))).toEqual([]);
+    expect(validateStack(makeStack({ name: "my_stack" }))).toEqual([]);
+    expect(validateStack(makeStack({ name: "prod-01" }))).toEqual([]);
+  });
+
+  test("rejects duplicate host addresses", () => {
+    const stack = makeStack({
+      hosts: [
+        makeHost({ address: "10.0.0.1" }),
+        makeHost({ address: "10.0.0.1" }),
+      ],
+    });
+    const errors = validateStack(stack);
+
+    expect(errors.some((e) => e.message.includes("Duplicate host"))).toBe(true);
+  });
+
+  test("rejects host with no components", () => {
+    const stack = makeStack({
+      hosts: [makeHost({ address: "10.0.0.1", components: [] })],
+    });
+    const errors = validateStack(stack);
+
+    expect(errors.some((e) => e.message.includes("no components"))).toBe(true);
+  });
+
+  test("rejects fleet referencing unknown host", () => {
+    const stack = makeStack({
+      hosts: [makeHost({ address: "10.0.0.1" })],
+      fleets: [makeFleet({ hosts: ["10.0.0.99"] })],
+    });
+    const errors = validateStack(stack);
+
+    expect(errors.some((e) => e.message.includes("unknown host"))).toBe(true);
+  });
+
+  test("rejects duplicate fleet names", () => {
+    const stack = makeStack({
+      hosts: [makeHost()],
+      fleets: [
+        makeFleet({ name: "pool" }),
+        makeFleet({ name: "pool" }),
+      ],
+    });
+    const errors = validateStack(stack);
+
+    expect(errors.some((e) => e.message.includes("Duplicate fleet"))).toBe(true);
+  });
+
+  test("warns when fleet hosts lack daemon component", () => {
+    const stack = makeStack({
+      hosts: [makeHost({ address: "10.0.0.1", components: ["gateway"] })],
+      fleets: [makeFleet({ hosts: ["10.0.0.1"] })],
+    });
+    const errors = validateStack(stack);
+
+    expect(errors.some((e) => e.message.includes("no hosts with the daemon"))).toBe(true);
+  });
+});
+
+// ── Factory ──────────────────────────────────────────────────────────────
+
+describe("createStack", () => {
+  test("returns an empty stack with the given name", () => {
+    const stack = createStack("my-stack");
+
+    expect(stack.name).toBe("my-stack");
+    expect(stack.env).toEqual({});
+    expect(stack.secrets).toEqual({});
+    expect(stack.componentEnv).toEqual({});
+    expect(stack.hosts).toEqual([]);
+    expect(stack.fleets).toEqual([]);
+    expect(stack.version).not.toBe("");
+  });
+});

--- a/packages/xinity-cli/tests/unit/stack.test.ts
+++ b/packages/xinity-cli/tests/unit/stack.test.ts
@@ -19,6 +19,7 @@ import {
   deleteStack,
   listStacks,
 } from "../../src/lib/stack.ts";
+import { loadStackState, markHostManaged } from "../../src/lib/stack-state.ts";
 
 function makeStack(overrides: Partial<StackDefinition> = {}): StackDefinition {
   return {
@@ -107,10 +108,23 @@ describe("stack persistence", () => {
     });
   });
 
-  test("deleteStack removes the definition", () => {
+  test("saveStack never persists derivedEnv", () => {
+    const stack = makeStack({ derivedEnv: { INFOSERVER_URL: "http://10.0.0.1:8090" } });
+    saveStack(stack);
+
+    const written = JSON.parse(readFileSync(definitionPath("test-stack"), "utf-8")) as Record<string, unknown>;
+    expect(written.derivedEnv).toBeUndefined();
+    expect(loadStack("test-stack")?.derivedEnv).toBeUndefined();
+  });
+
+  test("deleteStack removes the definition and its state", () => {
     saveStack(makeStack());
+    markHostManaged("test-stack", "10.0.0.9");
+    expect(loadStackState("test-stack").hosts).toEqual([{ address: "10.0.0.9" }]);
+
     expect(deleteStack("test-stack")).toBe(true);
     expect(loadStack("test-stack")).toBeNull();
+    expect(loadStackState("test-stack").hosts).toEqual([]);
   });
 
   test("deleteStack returns false when file does not exist", () => {
@@ -211,6 +225,17 @@ describe("resolveEnv", () => {
   test("shared env overrides auto defaults", () => {
     const stack = makeStack({ env: { INFOSERVER_URL: "http://infoserver.internal:8090" } });
     expect(resolveEnv(stack, "gateway").INFOSERVER_URL).toBe("http://infoserver.internal:8090");
+  });
+
+  test("derivedEnv sits above auto defaults but below explicit shared env", () => {
+    const derived = makeStack({ derivedEnv: { INFOSERVER_URL: "http://10.0.0.9:8090" } });
+    expect(resolveEnv(derived, "gateway").INFOSERVER_URL).toBe("http://10.0.0.9:8090");
+
+    const overridden = makeStack({
+      derivedEnv: { INFOSERVER_URL: "http://10.0.0.9:8090" },
+      env: { INFOSERVER_URL: "http://public.example:8090" },
+    });
+    expect(resolveEnv(overridden, "gateway").INFOSERVER_URL).toBe("http://public.example:8090");
   });
 
   test("componentEnv applies only to its own component type", () => {

--- a/packages/xinity-cli/tests/unit/stack.test.ts
+++ b/packages/xinity-cli/tests/unit/stack.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
-import { createTempDir, type TempDir } from "../helpers/temp-config.ts";
-import { mkdirSync, writeFileSync, readFileSync, existsSync, readdirSync, unlinkSync } from "fs";
+import { createTempDir, redirectXdgConfigHome, type TempDir } from "../helpers/temp-config.ts";
+import { readFileSync, statSync } from "fs";
 import { join } from "path";
+import { version as cliVersion } from "../../../../package.json";
 import {
   type StackDefinition,
   type StackHost,
@@ -13,6 +14,10 @@ import {
   getHost,
   getFleetForHost,
   createStack,
+  loadStack,
+  saveStack,
+  deleteStack,
+  listStacks,
 } from "../../src/lib/stack.ts";
 
 function makeStack(overrides: Partial<StackDefinition> = {}): StackDefinition {
@@ -44,66 +49,36 @@ function makeFleet(overrides: Partial<FleetDefinition> = {}): FleetDefinition {
   };
 }
 
-// ── Persistence (mirrored against temp dir, same pattern as config.test.ts) ──
+// ── Persistence ──────────────────────────────────────────────────────────
 
 describe("stack persistence", () => {
   let tmp: TempDir;
-  let stacksDir: string;
-
-  function stackPath(name: string): string {
-    return join(stacksDir, `${name}.json`);
-  }
-
-  function saveStack(stack: StackDefinition): void {
-    mkdirSync(stacksDir, { recursive: true });
-    writeFileSync(stackPath(stack.name), JSON.stringify(stack, null, 2) + "\n");
-  }
-
-  function loadStack(name: string): StackDefinition | null {
-    const path = stackPath(name);
-    if (!existsSync(path)) {
-      return null;
-    }
-    try {
-      return JSON.parse(readFileSync(path, "utf-8")) as StackDefinition;
-    } catch {
-      return null;
-    }
-  }
-
-  function deleteStack(name: string): boolean {
-    const path = stackPath(name);
-    if (!existsSync(path)) {
-      return false;
-    }
-    unlinkSync(path);
-    return true;
-  }
-
-  function listStacks(): string[] {
-    if (!existsSync(stacksDir)) {
-      return [];
-    }
-    return readdirSync(stacksDir)
-      .filter((f) => f.endsWith(".json"))
-      .map((f) => f.replace(/\.json$/, ""))
-      .sort();
-  }
+  let restoreEnv: () => void;
 
   beforeEach(() => {
     tmp = createTempDir("stack-test");
-    stacksDir = join(tmp.path, "stacks");
+    restoreEnv = redirectXdgConfigHome(tmp);
   });
 
   afterEach(() => {
+    restoreEnv();
     tmp.cleanup();
   });
+
+  function definitionPath(name: string): string {
+    return join(tmp.path, "xinity", "stacks", `${name}.json`);
+  }
 
   test("loadStack returns null when file does not exist", () => {
     expect(loadStack("nonexistent")).toBeNull();
   });
 
-  test("round-trips a stack definition", () => {
+  test("loadStack returns null for invalid JSON", () => {
+    tmp.write("xinity/stacks/broken.json", "not valid json{{{");
+    expect(loadStack("broken")).toBeNull();
+  });
+
+  test("round-trips a stack definition, stamping the CLI version", () => {
     const stack = makeStack({
       env: { REDIS_URL: "redis://localhost:6379" },
       secrets: { DB_CONNECTION_URL: "postgresql://localhost/db" },
@@ -114,15 +89,27 @@ describe("stack persistence", () => {
     saveStack(stack);
     const loaded = loadStack("test-stack");
 
-    expect(loaded).toEqual(stack);
+    expect(loaded).toEqual({ ...stack, version: cliVersion });
   });
 
-  test("deleteStack removes the file", () => {
+  test("saved stack files are readable only by the user", () => {
     saveStack(makeStack());
-    expect(loadStack("test-stack")).not.toBeNull();
+    expect(statSync(definitionPath("test-stack")).mode & 0o777).toBe(0o600);
+  });
 
-    const deleted = deleteStack("test-stack");
-    expect(deleted).toBe(true);
+  test("loadStack backfills fields missing from older files", () => {
+    tmp.write("xinity/stacks/old.json", JSON.stringify({ name: "old", env: { A: "1" } }));
+
+    expect(loadStack("old")).toEqual({
+      ...createStack("old"),
+      version: "0.0.0",
+      env: { A: "1" },
+    });
+  });
+
+  test("deleteStack removes the definition", () => {
+    saveStack(makeStack());
+    expect(deleteStack("test-stack")).toBe(true);
     expect(loadStack("test-stack")).toBeNull();
   });
 
@@ -143,18 +130,10 @@ describe("stack persistence", () => {
   });
 
   test("listStacks ignores non-JSON files", () => {
-    mkdirSync(stacksDir, { recursive: true });
-    writeFileSync(join(stacksDir, "notes.txt"), "not a stack");
+    tmp.write("xinity/stacks/notes.txt", "not a stack");
     saveStack(makeStack({ name: "real" }));
 
     expect(listStacks()).toEqual(["real"]);
-  });
-
-  test("loadStack returns null for invalid JSON", () => {
-    mkdirSync(stacksDir, { recursive: true });
-    writeFileSync(stackPath("broken"), "not valid json{{{");
-
-    expect(loadStack("broken")).toBeNull();
   });
 });
 

--- a/packages/xinity-cli/tests/unit/stack.test.ts
+++ b/packages/xinity-cli/tests/unit/stack.test.ts
@@ -28,6 +28,7 @@ function makeStack(overrides: Partial<StackDefinition> = {}): StackDefinition {
     env: {},
     secrets: {},
     componentEnv: {},
+    pinnedVersion: "v1.0.0",
     hosts: [],
     fleets: [],
     ...overrides,
@@ -93,6 +94,15 @@ describe("stack persistence", () => {
     expect(loaded).toEqual({ ...stack, version: cliVersion });
   });
 
+  test("saveStack never persists derivedEnv", () => {
+    const stack = makeStack({ derivedEnv: { INFOSERVER_URL: "http://10.0.0.1:8090" } });
+    saveStack(stack);
+
+    const written = JSON.parse(readFileSync(definitionPath("test-stack"), "utf-8")) as Record<string, unknown>;
+    expect(written.derivedEnv).toBeUndefined();
+    expect(loadStack("test-stack")?.derivedEnv).toBeUndefined();
+  });
+
   test("saved stack files are readable only by the user", () => {
     saveStack(makeStack());
     expect(statSync(definitionPath("test-stack")).mode & 0o777).toBe(0o600);
@@ -102,19 +112,10 @@ describe("stack persistence", () => {
     tmp.write("xinity/stacks/old.json", JSON.stringify({ name: "old", env: { A: "1" } }));
 
     expect(loadStack("old")).toEqual({
-      ...createStack("old"),
+      ...createStack("old", ""),
       version: "0.0.0",
       env: { A: "1" },
     });
-  });
-
-  test("saveStack never persists derivedEnv", () => {
-    const stack = makeStack({ derivedEnv: { INFOSERVER_URL: "http://10.0.0.1:8090" } });
-    saveStack(stack);
-
-    const written = JSON.parse(readFileSync(definitionPath("test-stack"), "utf-8")) as Record<string, unknown>;
-    expect(written.derivedEnv).toBeUndefined();
-    expect(loadStack("test-stack")?.derivedEnv).toBeUndefined();
   });
 
   test("deleteStack removes the definition and its state", () => {
@@ -331,7 +332,7 @@ describe("validateStack", () => {
     const errors = validateStack(stack);
 
     expect(errors.length).toBeGreaterThan(0);
-    expect(errors[0].field).toBe("name");
+    expect(errors[0]?.field).toBe("name");
   });
 
   test("rejects empty stack name", () => {
@@ -345,6 +346,12 @@ describe("validateStack", () => {
     expect(validateStack(makeStack({ name: "my-stack" }))).toEqual([]);
     expect(validateStack(makeStack({ name: "my_stack" }))).toEqual([]);
     expect(validateStack(makeStack({ name: "prod-01" }))).toEqual([]);
+  });
+
+  test("rejects a missing pinned version", () => {
+    const errors = validateStack(makeStack({ pinnedVersion: "" }));
+
+    expect(errors.some((e) => e.field === "pinnedVersion")).toBe(true);
   });
 
   test("rejects duplicate host addresses", () => {
@@ -405,10 +412,11 @@ describe("validateStack", () => {
 // ── Factory ──────────────────────────────────────────────────────────────
 
 describe("createStack", () => {
-  test("returns an empty stack with the given name", () => {
-    const stack = createStack("my-stack");
+  test("returns an empty stack with the given name and pin", () => {
+    const stack = createStack("my-stack", "v1.2.3");
 
     expect(stack.name).toBe("my-stack");
+    expect(stack.pinnedVersion).toBe("v1.2.3");
     expect(stack.env).toEqual({});
     expect(stack.secrets).toEqual({});
     expect(stack.componentEnv).toEqual({});

--- a/packages/xinity-cli/tests/unit/up-plan.test.ts
+++ b/packages/xinity-cli/tests/unit/up-plan.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+import { renderUpPlanScript, type UpPlan } from "../../src/lib/up-plan.ts";
+import { buildPostgresProvisionCommands, describePostgresProvision, type PostgresProvision } from "../../src/lib/postgres-setup.ts";
+import { describeRedisPlan, type RedisPlan } from "../../src/lib/redis-setup.ts";
+
+const COMPOSE = { docker: "docker", sub: ["compose"] } as const;
+
+const newStackProvision: PostgresProvision = {
+  compose: COMPOSE,
+  user: "xinity",
+  port: 5432,
+  url: "postgresql://xinity:secret@localhost:5432/xinity",
+  files: { envFile: "POSTGRES_DB=xinity\n", composeFile: "services:\n" },
+};
+
+const existingStackProvision: PostgresProvision = {
+  compose: COMPOSE,
+  user: "xinity",
+  port: 5433,
+  url: "postgresql://xinity:secret@localhost:5433/xinity",
+};
+
+const provisionedRedis: RedisPlan = {
+  url: "redis://localhost:6379",
+  persist: true,
+  provision: {
+    variant: "valkey",
+    installCmd: "apt-get install -y valkey",
+    startCmd: "systemctl start valkey",
+    userIsSuper: false,
+  },
+};
+
+function planWith(overrides: Partial<UpPlan>): UpPlan {
+  return { targetVersion: "v1.0.0", provisionOllama: false, components: [], ...overrides };
+}
+
+describe("buildPostgresProvisionCommands", () => {
+  test("new stack: writes both files then starts the stack", () => {
+    const cmds = buildPostgresProvisionCommands(newStackProvision);
+    expect(cmds[0]).toContain("mkdir -p");
+    expect(cmds.some((c) => c.includes("postgres.env") && c.includes("chmod 600"))).toBe(true);
+    expect(cmds.some((c) => c.includes("docker-compose.yml"))).toBe(true);
+    expect(cmds.at(-1)).toContain("up -d");
+  });
+
+  test("existing stack: only ensures the stack is running", () => {
+    const cmds = buildPostgresProvisionCommands(existingStackProvision);
+    expect(cmds).toHaveLength(1);
+    expect(cmds[0]).toContain("up -d");
+  });
+});
+
+describe("describePostgresProvision", () => {
+  test("distinguishes creating from restarting", () => {
+    expect(describePostgresProvision(newStackProvision)).toContain("Provision PostgreSQL");
+    expect(describePostgresProvision(existingStackProvision)).toContain("existing PostgreSQL");
+  });
+});
+
+describe("describeRedisPlan", () => {
+  test("lists install, start, and persist actions", () => {
+    const lines = describeRedisPlan(provisionedRedis);
+    expect(lines[0]).toContain("Provision valkey");
+    expect(lines.some((l) => l.includes("apt-get install -y valkey"))).toBe(true);
+    expect(lines.some((l) => l.includes("systemctl start valkey"))).toBe(true);
+    expect(lines.some((l) => l.includes("store REDIS_URL"))).toBe(true);
+  });
+
+  test("nothing to do produces no lines", () => {
+    expect(describeRedisPlan({ url: "redis://localhost:6379", persist: false })).toEqual([]);
+  });
+});
+
+describe("renderUpPlanScript", () => {
+  test("includes provisioning commands, migration deferral, and the redis secret write", async () => {
+    const script = await renderUpPlanScript(planWith({
+      provisionPostgres: newStackProvision,
+      migrations: { connectionUrl: newStackProvision.url, hint: "xinity@localhost:5432/xinity" },
+      redis: provisionedRedis,
+    }));
+    expect(script).toContain("docker compose -f");
+    expect(script).toContain("xinity up db --target-version v1.0.0");
+    expect(script).toContain("apt-get install -y valkey");
+    expect(script).toContain("printf '%s' 'redis://localhost:6379' > /etc/xinity-ai/secrets/REDIS_URL");
+  });
+
+  test("a keep-current redis plan is not part of an up-all script", async () => {
+    const script = await renderUpPlanScript(planWith({}));
+    expect(script).not.toContain("Redis");
+  });
+});


### PR DESCRIPTION
## Description

The CLI can now manage entire stacks declaratively.  
A stack defines which components run on which hosts, organized into fleets (groups of identically-configured machines). Instead of running `xinity up` with `--target-host` one machine at a time, the operator creates a stack with `xinity stack init`, configures it through `xinity stack edit`, and deploys with `xinity stack up`. 
The CLI compares the definition against the actual state of every host, builds a consolidated plan showing exactly what will be installed, updated, configured, or removed, and waits for confirmation before applying anything.

Configuration is layered: shared settings (database, Redis, metrics auth) at the stack level, per-component-type settings below that, fleet overrides for daemon groups, and per-host overrides as the escape hatch. Values live at the highest level possible, so a 20-host deployment typically needs only a handful of shared values and one or two fleet overrides. 
The menu editor enforces required fields and hides shared-owned keys from lower-level editors to prevent conflicts.

Host execution is unified. Local and remote hosts share a single SSH-based abstraction. Multi-host operations run with bounded concurrency, so a fleet of 20 machines does not open 20 SSH sessions at once.

Stack state is persisted across runs. When a host is removed from the stack, the next `stack up` detects it and evacuates the host: uninstalls managed components and clears its stack membership. Hosts that are unreachable at evacuation time are forgotten. `--dry-run` mode lets operators preview what would happen without modifying anything.

The installer and configuration logic now emit structured `StepEvent` generators instead of driving the UI directly. A step runner collects events from all hosts, renders a single plan, and only after the user approves does it run the apply phase. The same mechanism powers `xinity up` and `xinity configure` on single hosts.

Other changes: persistent paths (config, stack definition, state) resolve via `XDG_CONFIG_HOME` instead of hardcoded locations. Version pinning pulls from the published GitHub release list. The env-config editor uses a menu with wrap-around navigation and search instead of a sequential prompt wizard.

Closes #26 

## Type of change

New feature

## Testing

- New unit tests for stack definition parsing, validation, state tracking, and plan generation (`stack.test.ts`, `stack-plan.test.ts`, `stack-state.test.ts`, `up-plan.test.ts`)

## Checklist

- [x] Tests pass locally (`bun test`), or no testable code was changed
- [x] New or changed behavior is covered by tests, or this change does not require tests
- [x] Documentation is updated, or no user-facing behavior or configuration was changed
- [x] There are no breaking changes, or they are marked with `!` in the commit type and described above
- [x] No security-sensitive changes (authentication, credentials, input handling), or they have been reviewed
- [x] No new dependencies were added, or they have been reviewed for license and maintenance status