### PR TITLE
feat(dashboard): audit trail UI

### DIFF
--- a/deployment/docker/docker-compose.yml
+++ b/deployment/docker/docker-compose.yml
@@ -77,6 +77,8 @@ services:
       METRICS_AUTH_FILE: /run/secrets/metrics_auth
       ORIGIN: ${ORIGIN:-http://localhost:${DASHBOARD_PORT:-5121}}
       HTTP_OVERRIDE_ORIGIN: ${HTTP_OVERRIDE_ORIGIN:-${ORIGIN:-http://localhost:${DASHBOARD_PORT:-5121}}}
+      HTTP_IP_HEADER: ${HTTP_IP_HEADER:-}
+      HTTP_XFF_DEPTH: ${HTTP_XFF_DEPTH:-1}
       GATEWAY_URL: ${GATEWAY_URL:-http://localhost:${GATEWAY_PORT:-4121}}
       INFOSERVER_URL: ${INFOSERVER_URL:-https://sysinfo.xinity.ai}
       APP_NAME: ${APP_NAME:-Xinity Admin}

--- a/deployment/docker/example.env
+++ b/deployment/docker/example.env
@@ -19,6 +19,12 @@ SIGNUP_ENABLED=true
 # HTTP_OVERRIDE_ORIGIN=https://dashboard.example.com
 # GATEWAY_URL=https://api.example.com
 
+# Reverse proxy: tell the dashboard how to resolve the real client IP.
+# HTTP_IP_HEADER: header containing the client IP (e.g. x-forwarded-for, x-real-ip)
+# HTTP_XFF_DEPTH: when using x-forwarded-for, count N entries from the right (default 1)
+# HTTP_IP_HEADER=x-forwarded-for
+# HTTP_XFF_DEPTH=1
+
 # --profile caddy
 # DOMAIN=example.com
 # ACME_EMAIL=admin@example.com

--- a/docs/security/reverse-proxy.md
+++ b/docs/security/reverse-proxy.md
@@ -20,7 +20,7 @@ Set `X-Forwarded-For` and `X-Forwarded-Proto` on every proxied request.
 
 ### Dashboard: trusting forwarded headers
 
-The dashboard uses the client IP for audit log entries. By default it reads the raw TCP peer address, which behind a proxy is the proxy itself. To resolve the real client IP, set two environment variables on the dashboard:
+The dashboard uses the client IP for audit log entries, session records, and auth rate limiting. All three read the same address, resolved once per request by the HTTP adapter. By default that is the raw TCP peer address, which behind a proxy is the proxy itself. To resolve the real client IP, set two environment variables on the dashboard:
 
 | Variable | Purpose | Example |
 |---|---|---|

--- a/docs/security/reverse-proxy.md
+++ b/docs/security/reverse-proxy.md
@@ -16,9 +16,20 @@ Three common proxy defaults break features rather than degrade them. If you take
 
 ## Forwarded headers
 
-Set `X-Forwarded-For` and `X-Forwarded-Proto` on every proxied request. The gateway does not currently derive client identity from these headers, so nothing breaks if you omit them, but access logs and any future per-IP policy depend on them.
+Set `X-Forwarded-For` and `X-Forwarded-Proto` on every proxied request.
 
-If you ever configure the gateway to trust forwarded headers, only do so when a proxy you control is the sole path to it. `X-Forwarded-For` is client-settable: a gateway reachable directly will believe whatever it is told.
+### Dashboard: trusting forwarded headers
+
+The dashboard uses the client IP for audit log entries. By default it reads the raw TCP peer address, which behind a proxy is the proxy itself. To resolve the real client IP, set two environment variables on the dashboard:
+
+| Variable | Purpose | Example |
+|---|---|---|
+| `HTTP_IP_HEADER` | Header containing the client IP | `x-forwarded-for` or `x-real-ip` |
+| `HTTP_XFF_DEPTH` | Trusted proxy hops (counted from the right of the header value) | `1` for a single proxy, `2` for two chained proxies |
+
+In `xinity configure dashboard`, these appear under advanced/expert settings.
+
+Only trust forwarded headers when a proxy you control is the sole path to the dashboard. `X-Forwarded-For` is client-settable: a dashboard reachable directly will believe whatever it is told.
 
 ## Do not expose /metrics
 

--- a/nix/modules/xinity-ai-allinone.mod.nix
+++ b/nix/modules/xinity-ai-allinone.mod.nix
@@ -547,7 +547,9 @@
             mcpEnabled = lib.mkDefault cfg.dashboard.mcpEnabled;
             licenseKey = lib.mkDefault cfg.dashboard.licenseKey;
             betterAuthUrl = lib.mkDefault publicDashboardUrl;  # Public URL for auth redirects
-            origin = lib.mkDefault publicDashboardUrl;          # Public URL for CORS
+            origin = lib.mkDefault publicDashboardUrl;
+            reverseProxy.ipHeader = lib.mkDefault "x-forwarded-for";
+            reverseProxy.xffDepth = lib.mkDefault 1;
             infoserverUrl = lib.mkDefault infoserverUrl;        # Internal URL for server-side fetching
             gatewayUrl = lib.mkDefault publicGatewayUrl;        # Public gateway base URL (no /v1 suffix)
             nodeEnv = lib.mkDefault "production";

--- a/nix/modules/xinity-ai-dashboard.mod.nix
+++ b/nix/modules/xinity-ai-dashboard.mod.nix
@@ -287,6 +287,24 @@
           description = "Path to a file containing the license key.";
         };
 
+        # --- Reverse proxy (adapter-level settings) ---
+
+        reverseProxy = {
+          ipHeader = lib.mkOption {
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+            example = "x-forwarded-for";
+            description = "HTTP header the reverse proxy uses to pass the real client IP. Set to \"x-forwarded-for\" when running behind a reverse proxy (Caddy, nginx, Traefik). When null, the adapter uses the raw TCP peer address.";
+          };
+
+          xffDepth = lib.mkOption {
+            type = lib.types.int;
+            default = 1;
+            description = "Number of trusted proxy hops. The adapter reads the Nth entry from the right of the X-Forwarded-For header. Set to 1 for a single reverse proxy, 2 for two chained proxies, etc.";
+          };
+
+        };
+
         # --- Generic escape hatches ---
 
         environmentFiles = lib.mkOption {
@@ -325,6 +343,7 @@
           environment = {
             HTTP_PORT = toString cfg.port;
             ORIGIN = cfg.origin;
+            HTTP_OVERRIDE_ORIGIN = cfg.origin;
             NODE_ENV = cfg.nodeEnv;
             APP_NAME = cfg.appName;
             SIGNUP_ENABLED = lib.boolToString cfg.signupEnabled;
@@ -397,6 +416,10 @@
           }
           // lib.optionalAttrs (cfg.licenseKeyFile != null) {
             LICENSE_KEY_FILE = "%d/license-key";
+          }
+          // lib.optionalAttrs (cfg.reverseProxy.ipHeader != null) {
+            HTTP_IP_HEADER = cfg.reverseProxy.ipHeader;
+            HTTP_XFF_DEPTH = toString cfg.reverseProxy.xffDepth;
           }
           // cfg.extraEnvironment;
           serviceConfig = {

--- a/packages/xinity-ai-dashboard/src/hooks.server.ts
+++ b/packages/xinity-ai-dashboard/src/hooks.server.ts
@@ -64,11 +64,16 @@ const migrationGuard: Handle = ({ event, resolve }) => {
  */
 const fillLocals: Handle = ({ event, resolve }) => {
   event.locals.request = event.request;
+  let clientAddress = "";
   try {
-    event.locals.clientAddress = event.getClientAddress();
+    clientAddress = event.getClientAddress();
   } catch {
-    event.locals.clientAddress = "";
+    // getClientAddress throws when the address is unavailable
   }
+  event.locals.clientAddress = clientAddress;
+  // Stamp the adapter-resolved address so Better Auth middleware can read it
+  // without re-parsing x-forwarded-for independently.
+  event.request.headers.set("x-client-address", clientAddress);
   const incoming = event.request.headers.get("x-trace-id");
   const sanitized = incoming?.replace(/[^A-Za-z0-9_.:-]/g, "").slice(0, 300);
   const traceId = sanitized || `trc_${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;

--- a/packages/xinity-ai-dashboard/src/hooks.server.ts
+++ b/packages/xinity-ai-dashboard/src/hooks.server.ts
@@ -11,6 +11,7 @@ import { startNotificationScheduler } from "$lib/server/notifications/scheduler"
 import { serverEnv } from "$lib/server/serverenv";
 import { checkMigrationState, isMigrationOk } from "$lib/server/migration-check";
 import { loadDeploymentId } from "$lib/server/deployment-id";
+import { stampClientAddress } from "$lib/server/client-address";
 
 const log = rootLogger.child({ name: "hooks" });
 
@@ -71,9 +72,7 @@ const fillLocals: Handle = ({ event, resolve }) => {
     // getClientAddress throws when the address is unavailable
   }
   event.locals.clientAddress = clientAddress;
-  // Stamp the adapter-resolved address so Better Auth middleware can read it
-  // without re-parsing x-forwarded-for independently.
-  event.request.headers.set("x-client-address", clientAddress);
+  stampClientAddress(event.request, clientAddress);
   const incoming = event.request.headers.get("x-trace-id");
   const sanitized = incoming?.replace(/[^A-Za-z0-9_.:-]/g, "").slice(0, 300);
   const traceId = sanitized || `trc_${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;

--- a/packages/xinity-ai-dashboard/src/lib/components/RolesPermissionMatrix.svelte
+++ b/packages/xinity-ai-dashboard/src/lib/components/RolesPermissionMatrix.svelte
@@ -17,6 +17,7 @@
     "aiApplication": "Applications",
     "organization": "Organization Settings",
     "member": "Members & Invitations",
+    "auditLog": "Audit Log",
   }
 
   const resources: ResourcePermissions[] = Object.entries(permissionObjects).map(([object, label]) => ({

--- a/packages/xinity-ai-dashboard/src/lib/server/auth-server.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/auth-server.ts
@@ -215,7 +215,7 @@ const recordAuthAudit = createAuthMiddleware(async (ctx) => {
     resource: "account",
     actorId,
     actorLabel,
-    ipAddress: headers?.get("x-forwarded-for")?.split(",")[0]?.trim() ?? null,
+    ipAddress: headers?.get("x-client-address") || null,
     userAgent: headers?.get("user-agent") ?? null,
     resourceId,
     result: isSuccess ? "success" : "failure",

--- a/packages/xinity-ai-dashboard/src/lib/server/auth-server.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/auth-server.ts
@@ -18,6 +18,7 @@ import { sendEmail, commonEmailProps, type AnyComponent } from "./email";
 import { notify } from "./notifications/notification.service";
 import { NotificationType } from "./notifications/events";
 import { emitAuthAuditEvent, type AuditAction } from "./orpc/audit";
+import { CLIENT_ADDRESS_HEADER, readClientAddress } from "./client-address";
 import EmailVerificationTemplate from "$lib/components/mailTemplates/EmailVerificationTemplate.svelte";
 import EmailForgotPasswordTemplate from "$lib/components/mailTemplates/EmailForgotPasswordTemplate.svelte";
 import EmailInvitationTemplate from "$lib/components/mailTemplates/EmailInvitationTemplate.svelte";
@@ -215,7 +216,7 @@ const recordAuthAudit = createAuthMiddleware(async (ctx) => {
     resource: "account",
     actorId,
     actorLabel,
-    ipAddress: headers?.get("x-client-address") || null,
+    ipAddress: readClientAddress(headers),
     userAgent: headers?.get("user-agent") ?? null,
     resourceId,
     result: isSuccess ? "success" : "failure",
@@ -228,6 +229,11 @@ export const auth = betterAuth({
   secret: serverEnv.BETTER_AUTH_SECRET,
   rateLimit: {
     enabled: serverEnv.NODE_ENV !== "test",
+  },
+  advanced: {
+    // Session rows and rate-limit buckets read the address the adapter already
+    // resolved, so Better Auth never trusts a forwarded header on its own.
+    ipAddress: { ipAddressHeaders: [CLIENT_ADDRESS_HEADER] },
   },
   session: {
     expiresIn: 60 * 60 * 24 * 30, // 30 days

--- a/packages/xinity-ai-dashboard/src/lib/server/client-address.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/client-address.ts
@@ -1,0 +1,23 @@
+/**
+ * Single source of truth for the client IP.
+ *
+ * The Bun adapter resolves the address from the raw connection plus the
+ * HTTP_IP_HEADER / HTTP_XFF_DEPTH / HTTP_TRUSTED_PROXIES settings, so
+ * `event.getClientAddress()` is the only place a forwarded header is trusted.
+ * The request hook stamps that result onto CLIENT_ADDRESS_HEADER, overwriting
+ * anything the client sent, so downstream consumers that only see a Request
+ * (Better Auth) read the same value instead of re-parsing x-forwarded-for.
+ */
+export const CLIENT_ADDRESS_HEADER = "x-client-address";
+
+export function stampClientAddress(request: Request, address: string): void {
+  if (address) {
+    request.headers.set(CLIENT_ADDRESS_HEADER, address);
+  } else {
+    request.headers.delete(CLIENT_ADDRESS_HEADER);
+  }
+}
+
+export function readClientAddress(headers: Headers | null | undefined): string | null {
+  return headers?.get(CLIENT_ADDRESS_HEADER) || null;
+}

--- a/packages/xinity-ai-dashboard/src/lib/server/env-schema.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/env-schema.ts
@@ -27,6 +27,8 @@ export const dashboardEnvSchema = z.object({
   S3_REGION: z.string().default("us-east-1").describe("S3 region").meta(expert()),
   MCP_ENABLED: z.stringbool().default(true).describe("Enable the /mcp Model Context Protocol endpoint"),
   LICENSE_KEY: z.string().optional().describe("License key for unlocking paid features (Ed25519-signed token)").meta(secret()),
+  HTTP_IP_HEADER: z.string().optional().describe("Header your reverse proxy uses to forward the client IP (e.g. x-forwarded-for, x-real-ip). Without this, audit logs record the proxy address, not the real client.").meta(expert()),
+  HTTP_XFF_DEPTH: z.coerce.number().int().default(1).describe("When HTTP_IP_HEADER is x-forwarded-for, how many proxy hops to skip from the right. 1 for a single proxy, 2 for two chained proxies.").meta(expert()),
   TRUSTED_ORIGINS: z.string().optional().describe("Comma-separated additional trusted origins for CSRF validation behind reverse proxies").meta(expert()),
   GATEWAY_URL: z.url().default("http://localhost:4010").describe("Gateway base URL shown to users in docs and code examples (e.g. https://api.example.com). Must NOT include the /v1 path segment - that is appended where needed.").meta(clientPublic()),
   DEPLOYMENT_STRATEGY: z.enum(["first-fit", "balanced", "bin-pack", "proportional"]).default("balanced").describe("Node selection strategy for new model installations. 'first-fit' picks the first node that fits (deterministic). 'balanced' picks the node with the most absolute free VRAM (spread for HA). 'bin-pack' picks the tightest fit (consolidate so idle nodes stay drainable). 'proportional' picks the node with the lowest percent utilization (fair spread across heterogeneous nodes).").meta(expert()),

--- a/packages/xinity-ai-dashboard/src/lib/server/license/license.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/license/license.ts
@@ -216,6 +216,7 @@ export function getLicenseSummary() {
       multiOrg: hasFeature("multi-org"),
       ssoSelfManage: hasFeature("sso-self-manage"),
       allRoles: hasFeature("all-roles"),
+      auditLog: hasFeature("audit-log"),
     },
   };
 }

--- a/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/audit.procedure.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/audit.procedure.ts
@@ -1,36 +1,117 @@
-/**
- * ORPC procedures for reading the audit trail. Owner/admin only (via the
- * `auditLog` resource), scoped to the caller's active organization.
- */
 import { rootOs, withOrganization, requirePermission } from "../root";
 import { z } from "zod";
-import { auditEventT, sql } from "common-db";
+import { auditEventT, auditResultEnum, sql, and } from "common-db";
 import { getDB } from "$lib/server/db";
 import { hasFeature } from "$lib/server/license";
+import { isInstanceAdmin } from "$lib/server/serverenv";
 
 const tags = ["Audit"];
+const EXPORT_ROW_CAP = 10_000;
+
+const auditFilters = z.object({
+  actorId: z.string().optional(),
+  action: z.string().optional(),
+  resource: z.string().optional(),
+  result: z.enum(auditResultEnum.enumValues).optional(),
+  from: z.coerce.date().optional(),
+  to: z.coerce.date().optional(),
+});
+
+function buildWhereClause(orgId: string, filters: z.infer<typeof auditFilters>, includeInstanceEvents = false) {
+  const orgCondition = includeInstanceEvents
+    ? sql`(${auditEventT.organizationId} = ${orgId} OR ${auditEventT.organizationId} IS NULL)`
+    : sql`${auditEventT.organizationId} = ${orgId}`;
+  const conditions = [orgCondition];
+  if (filters.actorId) {
+    conditions.push(sql`${auditEventT.actorId} = ${filters.actorId}`);
+  }
+  if (filters.action) {
+    conditions.push(sql`${auditEventT.action} = ${filters.action}`);
+  }
+  if (filters.resource) {
+    conditions.push(sql`${auditEventT.resource} = ${filters.resource}`);
+  }
+  if (filters.result) {
+    conditions.push(sql`${auditEventT.result} = ${filters.result}`);
+  }
+  if (filters.from) {
+    conditions.push(sql`${auditEventT.createdAt} >= ${filters.from.toISOString()}`);
+  }
+  if (filters.to) {
+    conditions.push(sql`${auditEventT.createdAt} <= ${filters.to.toISOString()}`);
+  }
+  return and(...conditions);
+}
+
+const listAudit = rootOs
+  .use(withOrganization)
+  .use(requirePermission({ auditLog: ["read"] }))
+  .meta({ mcp: false })
+  .route({ path: "/list", method: "GET", tags, summary: "List Audit Events" })
+  .input(auditFilters.extend({
+    cursor: z.coerce.date().optional(),
+    limit: z.coerce.number().int().min(1).max(100).default(50),
+    includeInstanceEvents: z.boolean().default(false),
+  }))
+  .handler(async ({ context, input, errors }) => {
+    if (!hasFeature("audit-log")) {
+      throw errors.FORBIDDEN({ message: "Audit log requires an Enterprise license." });
+    }
+
+    const { cursor, limit, includeInstanceEvents, ...filters } = input;
+    const includeInstance = includeInstanceEvents && isInstanceAdmin(context.session.user.email);
+    const where = buildWhereClause(context.activeOrganizationId, filters, includeInstance);
+
+    const cursorClause = cursor
+      ? sql`${where} AND ${auditEventT.createdAt} < ${cursor.toISOString()}`
+      : where;
+
+    const events = await getDB()
+      .select()
+      .from(auditEventT)
+      .where(cursorClause)
+      .orderBy(sql`${auditEventT.createdAt} DESC`)
+      .limit(limit + 1);
+
+    const hasMore = events.length > limit;
+    if (hasMore) {
+      events.pop();
+    }
+
+    return {
+      events,
+      nextCursor: hasMore ? events[events.length - 1]!.createdAt.toISOString() : null,
+    };
+  });
 
 const exportAudit = rootOs
   .use(withOrganization)
   .use(requirePermission({ auditLog: ["read"] }))
   .meta({ mcp: false })
   .route({ path: "/export", method: "GET", tags, summary: "Export Audit Events" })
-  .input(z.object({
-    from: z.coerce.date(),
-    to: z.coerce.date().optional(),
+  .input(auditFilters.pick({ from: true, to: true }).required({ from: true }).extend({
+    includeInstanceEvents: z.boolean().default(false),
   }))
   .handler(async ({ context, input, errors }) => {
     if (!hasFeature("audit-log")) {
       throw errors.FORBIDDEN({ message: "Audit log export requires an Enterprise license." });
     }
-    const to = input.to ?? new Date();
-    return getDB()
+    const includeInstance = input.includeInstanceEvents && isInstanceAdmin(context.session.user.email);
+    const where = buildWhereClause(context.activeOrganizationId, {
+      from: input.from,
+      to: input.to ?? new Date(),
+    }, includeInstance);
+    const events = await getDB()
       .select()
       .from(auditEventT)
-      .where(sql`${auditEventT.organizationId} = ${context.activeOrganizationId} AND ${auditEventT.createdAt} >= ${input.from} AND ${auditEventT.createdAt} <= ${to}`)
-      .orderBy(auditEventT.createdAt);
+      .where(where)
+      .orderBy(sql`${auditEventT.createdAt} ASC`)
+      .limit(EXPORT_ROW_CAP);
+
+    return { events, truncated: events.length === EXPORT_ROW_CAP };
   });
 
 export const auditRouter = rootOs.prefix("/audit").router({
+  list: listAudit,
   export: exportAudit,
 });

--- a/packages/xinity-ai-dashboard/src/lib/state/permissions.svelte.ts
+++ b/packages/xinity-ai-dashboard/src/lib/state/permissions.svelte.ts
@@ -8,7 +8,7 @@ import type { RoleName } from "$lib/roles";
 
 const log = browserLogger.child({ name: "permissions_manager" });
 
-type Resource = "apiKey" | "apiCall" | "apiCallResponse" | "modelDeployment" | "model" | "aiApplication" | "organization" | "member" | "invitation";
+type Resource = "apiKey" | "apiCall" | "apiCallResponse" | "modelDeployment" | "model" | "aiApplication" | "organization" | "member" | "invitation" | "auditLog";
 type Action = "create" | "read" | "update" | "delete";
 
 // Reactive state
@@ -131,5 +131,8 @@ export const permissions = {
   },
   get canInviteMembers() {
     return can("invitation", "create");
+  },
+  get canViewAuditLog() {
+    return can("auditLog", "read");
   },
 };

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/Sidebar.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/Sidebar.svelte
@@ -10,7 +10,7 @@
   import ModelIcon from "$lib/components/icons/ModelIcon.svelte";
   import OrganizationIcon from "$lib/components/icons/OrganizationIcon.svelte";
   import GearIcon from "$lib/components/icons/GearIcon.svelte";
-  import { Shield, BookOpen } from "@lucide/svelte";
+  import { Shield, BookOpen, ScrollText } from "@lucide/svelte";
   import { goto } from "$app/navigation";
   import { permissions } from "$lib/state/permissions.svelte";
 
@@ -55,6 +55,7 @@
       heading: "User",
       items: [
         { key: "organizations",    href: "/organizations/",    label: "Organizations",    icon: OrganizationIcon },
+        { key: "audit",            href: "/audit/",             label: "Audit Log",        icon: ScrollText, show: permissions.canViewAuditLog && !!license?.features.auditLog },
         { key: "instanceSettings", href: "/instance-settings/", label: "Instance Settings", icon: Shield, show: isInstanceAdmin },
         { key: "settings",         href: "/settings/",          label: "Settings",           icon: GearIcon },
       ],

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/audit/+page.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/audit/+page.svelte
@@ -1,0 +1,515 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { orpc } from "$lib/orpc/orpc-client";
+  import { Badge } from "$lib/components/ui/badge";
+  import { Button } from "$lib/components/ui/button";
+  import { Input } from "$lib/components/ui/input";
+  import { Switch } from "$lib/components/ui/switch";
+  import * as Card from "$lib/components/ui/card";
+  import * as Select from "$lib/components/ui/select";
+  import { ChevronLeft, ChevronRight, Search, Download, ChevronDown, ChevronUp } from "@lucide/svelte";
+  import { toastState } from "$lib/state/toast.svelte";
+  import { createUrlSearchParamsStore } from "$lib/urlSearchParamsStore";
+  import { humanDate } from "$lib/util";
+  import type { PageData } from "./$types";
+  import type { AuditEvent } from "common-db";
+
+  let { data }: { data: PageData } = $props();
+
+  const hasFeature = $derived(!!data.license.features.auditLog);
+
+  const searchParams = createUrlSearchParamsStore();
+
+  let events = $state<AuditEvent[]>([]);
+  let nextCursor = $state<string | null>(null);
+  let cursorStack = $state<string[]>([]);
+  let loading = $state(false);
+  let expandedRow = $state<string | null>(null);
+  let instanceView = $state(false);
+
+  let actorInputValue = $state($searchParams.actor ?? "");
+
+  const LIMIT = 50;
+
+  const AUDIT_ACTIONS = [
+    "account.change_password",
+    "account.create_dashboard_api_key",
+    "account.delete_dashboard_api_key",
+    "account.delete_passkey",
+    "account.disable_2fa",
+    "account.enable_2fa",
+    "account.request_password_reset",
+    "account.sign_in",
+    "account.sign_in_sso",
+    "account.sign_out",
+    "account.sign_up",
+    "account.verify_email",
+    "aiApplication.create",
+    "aiApplication.delete",
+    "aiApplication.update",
+    "apiCall.delete",
+    "apiCall.reassign_application",
+    "apiCall.update_metadata",
+    "apiKey.create",
+    "apiKey.delete",
+    "apiKey.toggle_collect_data",
+    "apiKey.toggle_enabled",
+    "apiKey.update",
+    "compute.remove_node",
+    "instanceAdmin.add_user_to_org",
+    "instanceAdmin.ban_user",
+    "instanceAdmin.create_user",
+    "instanceAdmin.remove_user_from_org",
+    "instanceAdmin.reset_user_password",
+    "instanceAdmin.set_email_verified",
+    "instanceAdmin.set_sso_self_manage",
+    "instanceAdmin.unban_user",
+    "instanceAdmin.update_user_role",
+    "invitation.cancel",
+    "invitation.create",
+    "member.remove",
+    "member.update_role",
+    "modelDeployment.create",
+    "modelDeployment.delete",
+    "modelDeployment.retry",
+    "modelDeployment.toggle_enabled",
+    "modelDeployment.update",
+    "onboarding.cli",
+    "onboarding.setup",
+    "organization.create",
+    "organization.delete",
+    "organization.update",
+    "sso.delete_provider",
+    "sso.register_oidc",
+    "sso.register_saml",
+    "user.update_settings",
+  ] as const;
+
+  const RESOURCE_GROUPS: Record<string, string[]> = {};
+  for (const a of AUDIT_ACTIONS) {
+    const resource = a.split(".")[0]!;
+    if (!RESOURCE_GROUPS[resource]) {
+      RESOURCE_GROUPS[resource] = [];
+    }
+    RESOURCE_GROUPS[resource].push(a);
+  }
+
+  async function fetchEvents(cursor?: string) {
+    if (!hasFeature) {
+      return;
+    }
+    loading = true;
+    const result = await orpc.audit.list({
+      limit: LIMIT,
+      cursor: cursor || undefined,
+      action: $searchParams.action || undefined,
+      result: ($searchParams.result as "success" | "failure") || undefined,
+      actorId: $searchParams.actor || undefined,
+      from: $searchParams.from ? new Date($searchParams.from) : undefined,
+      to: $searchParams.to ? new Date($searchParams.to) : undefined,
+      includeInstanceEvents: instanceView,
+    });
+    loading = false;
+    if (result.error) {
+      toastState.add(result.error.message || "Failed to load audit events", "error");
+      return;
+    }
+    events = result.data.events;
+    nextCursor = result.data.nextCursor;
+  }
+
+  function applyFilters() {
+    cursorStack = [];
+    void fetchEvents();
+  }
+
+  function clearFilters() {
+    $searchParams.action = "";
+    $searchParams.result = "";
+    $searchParams.actor = "";
+    $searchParams.from = "";
+    $searchParams.to = "";
+    actorInputValue = "";
+    cursorStack = [];
+    void fetchEvents();
+  }
+
+  function goNext() {
+    if (!nextCursor) {
+      return;
+    }
+    const currentFirst = events[0]?.createdAt.toISOString();
+    if (currentFirst) {
+      cursorStack = [...cursorStack, currentFirst];
+    }
+    void fetchEvents(nextCursor);
+  }
+
+  function goPrev() {
+    if (cursorStack.length === 0) {
+      return;
+    }
+    const prev = cursorStack[cursorStack.length - 2];
+    cursorStack = cursorStack.slice(0, -1);
+    void fetchEvents(prev);
+  }
+
+  function toggleRow(id: string) {
+    expandedRow = expandedRow === id ? null : id;
+  }
+
+  let actorSearchTimeout: ReturnType<typeof setTimeout> | undefined;
+
+  function onActorInput(e: Event) {
+    actorInputValue = (e.target as HTMLInputElement).value;
+    clearTimeout(actorSearchTimeout);
+    actorSearchTimeout = setTimeout(() => {
+      $searchParams.actor = actorInputValue || "";
+      applyFilters();
+    }, 400);
+  }
+
+  function formatAction(action: string): string {
+    const [resource, verb] = action.split(".");
+    if (!verb) {
+      return action;
+    }
+    return `${resource}: ${verb.replace(/_/g, " ")}`;
+  }
+
+  function actorDisplay(event: AuditEvent): string {
+    if (event.actorLabel) {
+      return event.actorLabel;
+    }
+    if (event.actorId) {
+      return event.actorId.slice(0, 8) + "...";
+    }
+    return event.actorType;
+  }
+
+  async function handleExport(format: "ndjson" | "csv") {
+    const from = $searchParams.from ? new Date($searchParams.from) : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    const to = $searchParams.to ? new Date($searchParams.to) : undefined;
+
+    const result = await orpc.audit.export({ from, to, includeInstanceEvents: instanceView });
+    if (result.error) {
+      toastState.add(result.error.message || "Export failed", "error");
+      return;
+    }
+
+    const { events: rows, truncated } = result.data;
+
+    if (truncated) {
+      toastState.add("Export was capped at 10,000 rows. Narrow the date range for a complete export.", "warning");
+    }
+
+    let content: string;
+    let mimeType: string;
+    let extension: string;
+
+    if (format === "ndjson") {
+      content = rows.map((r: AuditEvent) => JSON.stringify(r)).join("\n");
+      mimeType = "application/x-ndjson";
+      extension = "jsonl";
+    } else {
+      const headers = ["id", "createdAt", "actorType", "actorId", "actorLabel", "action", "resource", "resourceId", "result", "ipAddress", "userAgent", "context"];
+      const csvRows = rows.map((r: AuditEvent) =>
+        headers.map((h) => {
+          const val = r[h as keyof AuditEvent];
+          if (val === null || val === undefined) {
+            return "";
+          }
+          if (val instanceof Date) {
+            return val.toISOString();
+          }
+          if (typeof val === "object") {
+            return `"${JSON.stringify(val).replace(/"/g, '""')}"`;
+          }
+          const s = String(val);
+          if (s.includes(",") || s.includes('"') || s.includes("\n")) {
+            return `"${s.replace(/"/g, '""')}"`;
+          }
+          return s;
+        }).join(","),
+      );
+      content = [headers.join(","), ...csvRows].join("\n");
+      mimeType = "text/csv";
+      extension = "csv";
+    }
+
+    const blob = new Blob([content], { type: mimeType });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `audit-export-${new Date().toISOString().slice(0, 10)}.${extension}`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  let exportMenuOpen = $state(false);
+
+  const hasActiveFilters = $derived(
+    !!($searchParams.action || $searchParams.result || $searchParams.actor || $searchParams.from || $searchParams.to),
+  );
+
+  onMount(() => {
+    void fetchEvents();
+    return () => clearTimeout(actorSearchTimeout);
+  });
+</script>
+
+<svelte:head>
+  <title>Audit Log</title>
+</svelte:head>
+
+<div class="container max-w-6xl px-6 py-8 compact:py-4 mx-auto">
+  <div class="mb-6 compact:mb-3 flex items-start justify-between">
+    <div>
+      <h1 class="text-2xl font-bold text-foreground">Audit Log</h1>
+      <p class="mt-1 text-sm text-muted-foreground">
+        {#if instanceView}
+          All events across the instance, including actions outside any organization.
+        {:else}
+          Security-relevant events for your organization.
+        {/if}
+      </p>
+    </div>
+    {#if data.isInstanceAdmin}
+      <label class="flex items-center gap-2 cursor-pointer">
+        <span class="text-sm text-muted-foreground">Instance view</span>
+        <Switch
+          checked={instanceView}
+          onCheckedChange={(v) => { instanceView = v; applyFilters(); }}
+        />
+      </label>
+    {/if}
+  </div>
+
+  {#if !hasFeature}
+    <Card.Root>
+      <Card.Content class="py-12 text-center">
+        <h2 class="text-lg font-semibold mb-2">Audit Log requires an Enterprise license</h2>
+        <p class="text-sm text-muted-foreground mb-4">
+          The audit log provides a tamper-evident record of all security-relevant actions
+          in your organization, with filtering, export, and SIEM integration.
+        </p>
+        <Button href="https://xinity.ai/xinity-pricing" target="_blank" rel="noopener noreferrer">
+          View Plans
+        </Button>
+      </Card.Content>
+    </Card.Root>
+  {:else}
+    <Card.Root>
+      <Card.Header>
+        <div class="flex items-center justify-between">
+          <div>
+            <Card.Title>Events</Card.Title>
+            <Card.Description>Browse and filter audit events</Card.Description>
+          </div>
+          <div class="relative">
+            <Button variant="outline" onclick={() => { exportMenuOpen = !exportMenuOpen; }}>
+              <Download class="w-4 h-4 mr-2" />
+              Export
+            </Button>
+            {#if exportMenuOpen}
+              <div class="absolute right-0 top-full mt-1 w-40 rounded-md border bg-popover p-1 shadow-md z-50">
+                <button
+                  class="w-full rounded-sm px-3 py-1.5 text-sm text-left hover:bg-accent hover:text-accent-foreground"
+                  onclick={() => { exportMenuOpen = false; handleExport("ndjson"); }}
+                >
+                  NDJSON (.jsonl)
+                </button>
+                <button
+                  class="w-full rounded-sm px-3 py-1.5 text-sm text-left hover:bg-accent hover:text-accent-foreground"
+                  onclick={() => { exportMenuOpen = false; handleExport("csv"); }}
+                >
+                  CSV (.csv)
+                </button>
+              </div>
+            {/if}
+          </div>
+        </div>
+
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-3 mt-4">
+          <Select.Root
+            type="single"
+            value={$searchParams.action}
+            onValueChange={(v) => { $searchParams.action = v ?? ""; applyFilters(); }}
+          >
+            <Select.Trigger class="w-full">
+              {$searchParams.action ? formatAction($searchParams.action) : "All actions"}
+            </Select.Trigger>
+            <Select.Content class="max-h-64">
+              <Select.Item value="" label="All actions" />
+              {#each Object.entries(RESOURCE_GROUPS) as [resource, actions]}
+                <Select.Group>
+                  <Select.GroupHeading>{resource}</Select.GroupHeading>
+                  {#each actions as action}
+                    <Select.Item value={action} label={formatAction(action)} />
+                  {/each}
+                </Select.Group>
+              {/each}
+            </Select.Content>
+          </Select.Root>
+
+          <Select.Root
+            type="single"
+            value={$searchParams.result}
+            onValueChange={(v) => { $searchParams.result = v ?? ""; applyFilters(); }}
+          >
+            <Select.Trigger class="w-full">
+              {$searchParams.result ? ($searchParams.result === "success" ? "Success" : "Failure") : "All results"}
+            </Select.Trigger>
+            <Select.Content>
+              <Select.Item value="" label="All results" />
+              <Select.Item value="success" label="Success" />
+              <Select.Item value="failure" label="Failure" />
+            </Select.Content>
+          </Select.Root>
+
+          <div class="relative">
+            <Search class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+            <Input
+              placeholder="Actor ID..."
+              value={actorInputValue}
+              oninput={onActorInput}
+              class="pl-9"
+            />
+          </div>
+
+          <Input
+            type="date"
+            value={$searchParams.from ?? ""}
+            oninput={(e) => { $searchParams.from = (e.target as HTMLInputElement).value; applyFilters(); }}
+            placeholder="From"
+          />
+
+          <div class="flex gap-2">
+            <Input
+              type="date"
+              value={$searchParams.to ?? ""}
+              oninput={(e) => { $searchParams.to = (e.target as HTMLInputElement).value; applyFilters(); }}
+              placeholder="To"
+              class="flex-1"
+            />
+            {#if hasActiveFilters}
+              <Button variant="ghost" size="sm" onclick={clearFilters} class="shrink-0">
+                Clear
+              </Button>
+            {/if}
+          </div>
+        </div>
+      </Card.Header>
+
+      <Card.Content>
+        {#if loading && events.length === 0}
+          <p class="text-center text-muted-foreground py-8">Loading...</p>
+        {:else if events.length === 0}
+          <p class="text-center text-muted-foreground py-8">No audit events found.</p>
+        {:else}
+          <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+              <thead>
+                <tr class="border-b text-left">
+                  <th class="py-2 pr-4 font-medium text-muted-foreground w-6"></th>
+                  <th class="py-2 pr-4 font-medium text-muted-foreground">Timestamp</th>
+                  <th class="py-2 pr-4 font-medium text-muted-foreground">Actor</th>
+                  <th class="py-2 pr-4 font-medium text-muted-foreground">Action</th>
+                  <th class="py-2 pr-4 font-medium text-muted-foreground">Resource</th>
+                  <th class="py-2 pr-4 font-medium text-muted-foreground">Result</th>
+                  <th class="py-2 font-medium text-muted-foreground">IP</th>
+                </tr>
+              </thead>
+              <tbody>
+                {#each events as event (event.id)}
+                  <tr class="border-b last:border-0 hover:bg-muted/50">
+                    <td class="py-3 pr-2">
+                      {#if event.context && Object.keys(event.context).length > 0}
+                        <button
+                          class="text-muted-foreground hover:text-foreground"
+                          onclick={() => toggleRow(event.id)}
+                          aria-label={expandedRow === event.id ? "Collapse details" : "Expand details"}
+                        >
+                          {#if expandedRow === event.id}
+                            <ChevronUp class="w-4 h-4" />
+                          {:else}
+                            <ChevronDown class="w-4 h-4" />
+                          {/if}
+                        </button>
+                      {/if}
+                    </td>
+                    <td class="py-3 pr-4 text-muted-foreground text-xs whitespace-nowrap">
+                      {humanDate(event.createdAt)}
+                    </td>
+                    <td class="py-3 pr-4">
+                      <div class="flex items-center gap-1.5">
+                        <Badge variant="outline" class="text-[10px] shrink-0">
+                          {event.actorType.replace("_", " ")}
+                        </Badge>
+                        <span class="truncate max-w-[160px]" title={event.actorLabel ?? event.actorId ?? ""}>
+                          {actorDisplay(event)}
+                        </span>
+                      </div>
+                    </td>
+                    <td class="py-3 pr-4 font-mono text-xs">
+                      {event.action}
+                    </td>
+                    <td class="py-3 pr-4">
+                      <span>{event.resource}</span>
+                      {#if event.resourceId}
+                        <span class="text-muted-foreground text-xs ml-1" title={event.resourceId}>
+                          ({event.resourceId.slice(0, 8)}...)
+                        </span>
+                      {/if}
+                    </td>
+                    <td class="py-3 pr-4">
+                      <Badge variant={event.result === "success" ? "outline" : "destructive"}>
+                        {event.result}
+                      </Badge>
+                    </td>
+                    <td class="py-3 text-muted-foreground text-xs">
+                      {event.ipAddress ?? ""}
+                    </td>
+                  </tr>
+                  {#if expandedRow === event.id && event.context}
+                    <tr class="border-b last:border-0">
+                      <td colspan="7" class="px-4 py-3 bg-muted/30">
+                        <pre class="text-xs font-mono whitespace-pre-wrap break-all">{JSON.stringify(event.context, null, 2)}</pre>
+                      </td>
+                    </tr>
+                  {/if}
+                {/each}
+              </tbody>
+            </table>
+          </div>
+
+          <div class="flex items-center justify-between mt-4 pt-4 border-t">
+            <span class="text-sm text-muted-foreground">
+              Page {cursorStack.length + 1}
+            </span>
+            <div class="flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={cursorStack.length === 0}
+                onclick={goPrev}
+              >
+                <ChevronLeft class="w-4 h-4" />
+                Previous
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={!nextCursor}
+                onclick={goNext}
+              >
+                Next
+                <ChevronRight class="w-4 h-4" />
+              </Button>
+            </div>
+          </div>
+        {/if}
+      </Card.Content>
+    </Card.Root>
+  {/if}
+</div>


### PR DESCRIPTION
## Description

Audit trail UI for enterprise-licensed instances. Org owners and admins can browse, filter, and export audit events. Instance admins can optionally include instance-level events (user creation, etc.).

Also fixes IP resolution behind reverse proxies: both oRPC and Better Auth audit paths now use the adapter's resolved client address instead of parsing XFF independently, and deployers can configure which header to trust.

## Type of change

New feature

## Testing

- Manual testing was done against a local instance behind Caddy (reverse proxy IP resolution, filtering, pagination, export). UI bugs found during testing (DrizzleQueryError on Date serialization, events disappearing on org switch, missing instance admin events) were fixed in a parallel session and are included in this branch.
- No test files were added or changed. The existing audit unit and e2e tests cover the procedure layer.

## Checklist

- [x] Tests pass locally (`bun test`), or no testable code was changed
- [x] New or changed behavior is covered by tests, or this change does not require tests
- [x] Documentation is updated, or no user-facing behavior or configuration was changed
- [x] There are no breaking changes, or they are marked with `!` in the commit type and described above
- [x] No security-sensitive changes (authentication, credentials, input handling), or they have been reviewed
- [x] No new dependencies were added, or they have been reviewed for license and maintenance status