### PR TITLE
fix: run test suites in isolation, and warn correctly about undeployable models

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
             cmd: bun run test -- --reporter=default --reporter=junit --reporter-outfile=results.xml
             cwd: packages/xinity-ai-gateway
           - name: Daemon
-            cmd: SKIP_NETWORK_TESTS=1 bun run test -- --reporter=default --reporter=junit --reporter-outfile=results.xml
+            cmd: bun run test -- --reporter=default --reporter=junit --reporter-outfile=results.xml
             cwd: packages/xinity-ai-daemon
           - name: Infoserver
             cmd: bun run test -- --reporter=default --reporter=junit --reporter-outfile=results.xml

--- a/nix/modules/xinity-ai-daemon.mod.nix
+++ b/nix/modules/xinity-ai-daemon.mod.nix
@@ -202,6 +202,8 @@
           wantedBy = [ "multi-user.target" ];
           after = [ "network-online.target" ];
           wants = [ "network-online.target" ];
+          # generell system paths instead of specific binaries to allow dynamic tooling resolution. i.e. nvidia-smi generelly gets auto added to this when installing the drivers
+          path = [ "/run/current-system/sw" ];
           environment = {
             PORT = toString cfg.port;
             HOST = cfg.host;

--- a/packages/xinity-ai-daemon/src/modules/model-installation/cache-eviction.test.ts
+++ b/packages/xinity-ai-daemon/src/modules/model-installation/cache-eviction.test.ts
@@ -1,11 +1,12 @@
 import { describe, test, expect, mock } from "bun:test";
+import type { CacheEntry, InstallationCacheRecord } from "./cache-eviction";
 
 mock.module("../../env", () => ({ env: { VLLM_HF_CACHE_DIR: "/tmp/test", INFOSERVER_URL: "http://localhost:8090", INFOSERVER_CACHE_TTL_MS: 0 } }));
 mock.module("../../logger", () => ({
   rootLogger: { child: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }) },
 }));
 
-import { planEviction, slugForModel, modelForSlug, type CacheEntry, type InstallationCacheRecord } from "./cache-eviction";
+const { planEviction, slugForModel, modelForSlug } = await import("./cache-eviction");
 
 const GB = 1024 ** 3;
 

--- a/packages/xinity-ai-daemon/src/modules/model-installation/page-cache.ts
+++ b/packages/xinity-ai-daemon/src/modules/model-installation/page-cache.ts
@@ -1,0 +1,11 @@
+import { $ } from "bun";
+import { rootLogger } from "../../logger";
+
+const log = rootLogger.child({ name: "page-cache" });
+
+export async function dropPageCache(): Promise<void> {
+  const result = await $`sh -c 'sync && echo 3 > /proc/sys/vm/drop_caches'`.quiet().nothrow();
+  if (result.exitCode !== 0) {
+    log.warn({ stderr: result.stderr.toString() }, "Failed to drop page cache before model start");
+  }
+}

--- a/packages/xinity-ai-daemon/src/modules/model-installation/vllm-download.test.ts
+++ b/packages/xinity-ai-daemon/src/modules/model-installation/vllm-download.test.ts
@@ -28,17 +28,11 @@ const { downloadModel } = await import("./vllm-download");
 
 // ---------------------------------------------------------------------------
 // These tests hit the real HuggingFace API. They use a tiny public model
-// to keep download times minimal. Skipped if SKIP_NETWORK_TESTS is set.
+// to keep download times minimal. Skipped by default because they need
+// network; un-skip to validate downloading on demand.
 // ---------------------------------------------------------------------------
 
 const TINY_MODEL = "hf-internal-testing/tiny-random-gpt2";
-
-function skipIfNoNetwork() {
-  if (process.env.SKIP_NETWORK_TESTS) {
-    return true;
-  }
-  return false;
-}
 
 describe.skip("downloadModel (integration, real HF API)", () => {
   beforeEach(() => {
@@ -50,8 +44,6 @@ describe.skip("downloadModel (integration, real HF API)", () => {
   });
 
   test("downloads a tiny model and reports progress", async () => {
-    if (skipIfNoNetwork()) return;
-
     const progressValues: number[] = [];
     await downloadModel(TINY_MODEL, async (progress) => {
       progressValues.push(progress);
@@ -97,8 +89,6 @@ describe.skip("downloadModel (integration, real HF API)", () => {
   }, 30_000);
 
   test("second download is a no-op (files already cached)", async () => {
-    if (skipIfNoNetwork()) return;
-
     // First download
     await downloadModel(TINY_MODEL, async () => {});
 
@@ -113,8 +103,6 @@ describe.skip("downloadModel (integration, real HF API)", () => {
   }, 30_000);
 
   test("resume works after partial download", async () => {
-    if (skipIfNoNetwork()) return;
-
     // First, do a full download to discover the cache structure
     await downloadModel(TINY_MODEL, async () => {});
 

--- a/packages/xinity-ai-daemon/src/modules/model-installation/vllm.test.ts
+++ b/packages/xinity-ai-daemon/src/modules/model-installation/vllm.test.ts
@@ -94,6 +94,10 @@ mock.module("./vllm-download", () => ({
   downloadModel: mock(() => Promise.resolve()),
 }));
 
+mock.module("./page-cache", () => ({
+  dropPageCache: mock(() => Promise.resolve()),
+}));
+
 const { syncVllmInstallations$, computeGpuUtilization } = await import("./vllm");
 
 // ---------------------------------------------------------------------------

--- a/packages/xinity-ai-daemon/src/modules/model-installation/vllm.ts
+++ b/packages/xinity-ai-daemon/src/modules/model-installation/vllm.ts
@@ -1,4 +1,3 @@
-import { $ } from "bun";
 import {
   catchError,
   concat,
@@ -27,6 +26,7 @@ import { createInfoserverClient } from "xinity-infoserver";
 import { rootLogger } from "../../logger";
 import { getHardwareProfile } from "../statekeeper";
 import { downloadModel } from "./vllm-download";
+import { dropPageCache } from "./page-cache";
 import { updateInstallationState } from "./state";
 
 const infoClient = createInfoserverClient({ baseUrl: env.INFOSERVER_URL, cacheTtlMs: env.INFOSERVER_CACHE_TTL_MS });
@@ -155,13 +155,6 @@ function pollUntilHealthy$(
     ignoreElements(),
     endWith(void 0 as void),
   );
-}
-
-async function dropPageCache(): Promise<void> {
-  const result = await $`sh -c 'sync && echo 3 > /proc/sys/vm/drop_caches'`.quiet().nothrow();
-  if (result.exitCode !== 0) {
-    log.warn({ stderr: result.stderr.toString() }, "Failed to drop page cache before model start");
-  }
 }
 
 async function downloadAndStart(installation: ModelInstallation, ops: VllmOps): Promise<{ modelType: string | undefined; providerModel: string }> {

--- a/packages/xinity-ai-daemon/src/modules/serverfront/proxy.test.ts
+++ b/packages/xinity-ai-daemon/src/modules/serverfront/proxy.test.ts
@@ -2,6 +2,16 @@ import { describe, test, expect, beforeAll, afterAll, mock } from "bun:test";
 
 let mockPort: number = 0;
 
+mock.module("../../env", () => ({ env: {
+  PORT: 4044,
+  HOST: "0.0.0.0",
+  STATE_DIR: "/tmp/test-state",
+  CIDR_PREFIX: "",
+  DB_CONNECTION_URL: "postgres://localhost/test",
+  INFOSERVER_URL: "http://localhost:19090",
+  LOG_LEVEL: "silent",
+}}));
+
 mock.module("../model-registry", () => ({
   resolveModel: (model: string) => {
     if (model === "llama3:latest") return { port: mockPort, driver: "ollama" };
@@ -11,7 +21,7 @@ mock.module("../model-registry", () => ({
   },
 }));
 
-import { getAuthToken } from "../statekeeper";
+const { getAuthToken } = await import("../statekeeper");
 const { handleProxyRequest } = await import("./proxy");
 
 let server: ReturnType<typeof Bun.serve>;

--- a/packages/xinity-ai-daemon/src/modules/statekeeper.test.ts
+++ b/packages/xinity-ai-daemon/src/modules/statekeeper.test.ts
@@ -1,8 +1,11 @@
 import { describe, test, expect, beforeEach, afterAll, mock } from "bun:test";
 import { join } from "path";
 import { rm, mkdir } from "node:fs/promises";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
 
-const STATE_DIR = "/tmp/xinity-statekeeper-test";
+// Unique per process: concurrent runs must not share this directory.
+const STATE_DIR = mkdtempSync(join(tmpdir(), "xinity-statekeeper-test-"));
 
 // Mock env to avoid parseEnv side-effect (requires DB_CONNECTION_URL etc. in CI).
 mock.module("../env", () => ({ env: {

--- a/packages/xinity-ai-daemon/src/modules/vllm-features.ts
+++ b/packages/xinity-ai-daemon/src/modules/vllm-features.ts
@@ -67,7 +67,7 @@ async function resolvePythonForVllm(vllmPath: string): Promise<string> {
 
     if (bytesMatch(magic, ELF_MAGIC)) {
       const raw = new Uint8Array(await file.slice(0, 65536).arrayBuffer());
-      const decoded = new TextDecoder("latin1").decode(raw);
+      const decoded = new TextDecoder("latin1" as Bun.Encoding).decode(raw);
       const pythonPath = findEmbeddedPythonPath(decoded);
       if (pythonPath) {
         return pythonPath;

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/ModelSelectorModal.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/ModelSelectorModal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import Modal from "$lib/components/Modal.svelte";
-  import type { ModelWithSpecifier, NodeCapability } from "xinity-infoserver";
-  import { resolveAllTags, resolveTagsForDriver, driverHasTag, isDeployableOnCluster } from "xinity-infoserver";
+  import type { ModelWithSpecifier, NodeCapability, IncompatibilityReason } from "xinity-infoserver";
+  import { resolveAllTags, resolveTagsForDriver, driverHasTag, explainClusterIncompatibility } from "xinity-infoserver";
   import { modelCatalog } from "$lib/state/model-catalog.svelte";
   import { formatGb } from "$lib/util";
 
@@ -130,18 +130,40 @@
     }
   }
 
-  function isUndeployable(model: ModelWithSpecifier): boolean {
-    if (nodeCapabilities.length === 0) return model.weight + model.minKvCache > maxNodeFreeCapacity;
-    return !isDeployableOnCluster(nodeCapabilities, model);
+  function undeployableReason(model: ModelWithSpecifier): IncompatibilityReason | null {
+    // Without a cluster snapshot the only thing knowable is whether it could ever fit.
+    if (nodeCapabilities.length === 0) {
+      return model.weight + model.minKvCache > maxNodeFreeCapacity ? "insufficient_capacity" : null;
+    }
+    return explainClusterIncompatibility(nodeCapabilities, model);
   }
 
-  // Only flag as a constraint issue when a node would otherwise have room: pure capacity shortfalls are surfaced elsewhere.
-  function hasConstraintIncompatibility(model: ModelWithSpecifier): boolean {
-    if (!model.providerMinVersions && !model.providerPlatforms) return false;
-    if (!isUndeployable(model)) return false;
-    const needed = model.weight + model.minKvCache;
+  function modelDriverLabels(model: ModelWithSpecifier): string {
     const drivers = Object.keys(model.providers).filter(d => model.providers[d as keyof typeof model.providers] !== undefined);
-    return nodeCapabilities.some(n => n.free >= needed && drivers.some(d => d in n.driverVersions));
+    return drivers.map(d => (d === "vllm" ? "vLLM" : "Ollama")).join(" or ") || "any driver";
+  }
+
+  function modelPlatformLabels(model: ModelWithSpecifier): string {
+    const platforms = new Set(Object.values(model.providerPlatforms ?? {}).flat());
+    return Array.from(platforms).join(" or ");
+  }
+
+  function undeployableMessage(reason: IncompatibilityReason, model: ModelWithSpecifier): string {
+    switch (reason) {
+      case "missing_driver":
+        return `No node runs ${modelDriverLabels(model)}.`;
+      case "version_too_old":
+      case "version_unknown":
+        return `No node has a new enough ${modelDriverLabels(model)} version.`;
+      case "missing_feature":
+        return `No node's ${modelDriverLabels(model)} build supports the features this model needs.`;
+      case "wrong_platform": {
+        const platforms = modelPlatformLabels(model);
+        return `No node has a compatible GPU${platforms ? ` (needs ${platforms})` : ""}.`;
+      }
+      case "insufficient_capacity":
+        return `Needs ${formatGb(model.weight + model.minKvCache)}, more than the largest node's ${formatGb(maxNodeFreeCapacity)} free.`;
+    }
   }
 
   function handleSelect(model: ModelWithSpecifier) {
@@ -262,8 +284,7 @@
               </h3>
               <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                 {#each groupedModels[family] as model (model.publicSpecifier)}
-                  {@const undeployable = isUndeployable(model)}
-                  {@const constraintIssue = hasConstraintIncompatibility(model)}
+                  {@const blockedReason = undeployableReason(model)}
                   {@const modelTags = resolveAllTags(model)}
                   {@const modelDrivers = Object.keys(model.providers) as Array<"vllm" | "ollama">}
                   {@const hasDriverDiffs = model.providerTags !== undefined}
@@ -307,15 +328,10 @@
                       <span class="opacity-50">({parseFloat(model.weight.toFixed(2))} model + {parseFloat(model.minKvCache.toFixed(2))} kv-cache)</span>
                     </div>
 
-                    {#if undeployable && constraintIssue}
+                    {#if blockedReason}
                       <div class="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-2.5 py-1.5 text-xs text-amber-700 dark:text-amber-400 mb-1">
                         <Info class="w-3.5 h-3.5 shrink-0 mt-0.5" />
-                        <span>No compatible node available (driver version or platform mismatch). You can still select it and deploy it disabled.</span>
-                      </div>
-                    {:else if undeployable}
-                      <div class="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-2.5 py-1.5 text-xs text-amber-700 dark:text-amber-400 mb-1">
-                        <Info class="w-3.5 h-3.5 shrink-0 mt-0.5" />
-                        <span>Needs {formatGb(model.weight + model.minKvCache)}, more than the largest node's {formatGb(maxNodeFreeCapacity)} free. You can still select it and deploy it disabled.</span>
+                        <span>{undeployableMessage(blockedReason, model)} You can still select it and deploy it disabled.</span>
                       </div>
                     {/if}
 

--- a/packages/xinity-ai-gateway/src/llm-forward/ai-sdk.test.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/ai-sdk.test.ts
@@ -1,5 +1,9 @@
-import { describe, test, expect } from "bun:test";
-import { computePrefixHashes } from "./ai-sdk";
+import { describe, test, expect, mock } from "bun:test";
+import { MOCK_GATEWAY_ENV } from "./mock-env";
+
+mock.module("../env", () => ({ env: { ...MOCK_GATEWAY_ENV } }));
+
+const { computePrefixHashes } = await import("./ai-sdk");
 
 describe("computePrefixHashes", () => {
   test("returns empty for missing messages field", () => {

--- a/packages/xinity-ai-gateway/src/llm-forward/deep-research/compaction.test.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/deep-research/compaction.test.ts
@@ -1,7 +1,11 @@
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, mock } from "bun:test";
 import type { ModelMessage } from "ai";
 import { MockLanguageModelV3 } from "ai/test";
-import { createCompactionStep } from "./compaction";
+import { MOCK_GATEWAY_ENV } from "../mock-env";
+
+mock.module("../../env", () => ({ env: { ...MOCK_GATEWAY_ENV } }));
+
+const { createCompactionStep } = await import("./compaction");
 
 const CONTEXT_LIMIT = 1000;
 const THRESHOLD_RATIO = 0.5;

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/deep-research.test.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/deep-research.test.ts
@@ -142,9 +142,8 @@ describe("deep research", () => {
     expect(cancelResp.status).toBe(200);
 
     resolveGate();
-    await new Promise((r) => setTimeout(r, 50));
+    const stored = await waitForResponseStatus(responseStore, body.id, "cancelled");
 
-    const stored = responseStore.get(body.id);
     expect(stored?.status).toBe("cancelled");
   });
 

--- a/packages/xinity-infoserver/index.ts
+++ b/packages/xinity-infoserver/index.ts
@@ -1,5 +1,5 @@
 export * from "./definitions/model-definition";
 export * from "./model-tags";
 export { satisfiesMinVersion, normalizePep440 } from "./semver";
-export { checkNodeCompatibility, isDeployableOnCluster, type GpuInfo, type NodeCapability, type ModelNodeRequirements, type IncompatibilityReason } from "./node-compat";
+export { checkNodeCompatibility, isDeployableOnCluster, explainClusterIncompatibility, modelRequirementsForDriver, type GpuInfo, type NodeCapability, type ModelNodeRequirements, type IncompatibilityReason, type ClusterModel } from "./node-compat";
 export { createInfoserverClient, type InfoserverClient } from "./client";

--- a/packages/xinity-infoserver/node-compat.test.ts
+++ b/packages/xinity-infoserver/node-compat.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { checkNodeCompatibility, isDeployableOnCluster, type NodeCapability, type ModelNodeRequirements, type GpuInfo } from "./node-compat";
+import { checkNodeCompatibility, isDeployableOnCluster, explainClusterIncompatibility, type NodeCapability, type ModelNodeRequirements, type GpuInfo } from "./node-compat";
 
 const nvidiaGpu: GpuInfo = { vendor: "nvidia", name: "A100", vramMb: 81920 };
 const amdGpu: GpuInfo = { vendor: "amd", name: "MI300X", vramMb: 196608 };
@@ -283,5 +283,71 @@ describe("isDeployableOnCluster", () => {
       [makeNode({ driverVersions: { ollama: "0.6.3" } })],
       transcriptionModel,
     )).toBe(true);
+  });
+});
+
+describe("explainClusterIncompatibility", () => {
+  const vllmModel = {
+    weight: 8,
+    minKvCache: 2,
+    providers: { vllm: "org/model" as string | undefined },
+    providerMinVersions: { vllm: "0.19.1" },
+    providerPlatforms: { vllm: ["nvidia"] },
+  };
+
+  test("returns null when a compatible node exists", () => {
+    expect(explainClusterIncompatibility([makeNode()], vllmModel)).toBeNull();
+  });
+
+  test("reports missing_driver, not capacity, when a roomy cluster lacks the driver entirely", () => {
+    const plainModel = { weight: 8, minKvCache: 2, providers: { vllm: "org/model" as string | undefined } };
+    expect(explainClusterIncompatibility(
+      [makeNode({ free: 50, driverVersions: { ollama: "0.6.3" } })],
+      plainModel,
+    )).toBe("missing_driver");
+  });
+
+  test("reports missing_feature, not capacity, for a transcription model on a roomy cluster", () => {
+    const transcriptionModel = {
+      weight: 8, minKvCache: 2, type: "transcription" as const,
+      providers: { vllm: "openai/whisper-large-v3" as string | undefined },
+    };
+    expect(explainClusterIncompatibility([makeNode({ free: 50 })], transcriptionModel)).toBe("missing_feature");
+  });
+
+  test("reports wrong_platform when the only driver-capable node has the wrong GPU", () => {
+    expect(explainClusterIncompatibility(
+      [makeNode({ free: 50, gpus: [amdGpu] })],
+      vllmModel,
+    )).toBe("wrong_platform");
+  });
+
+  test("reports version_too_old when the driver is present but outdated", () => {
+    expect(explainClusterIncompatibility(
+      [makeNode({ free: 50, driverVersions: { vllm: "0.18.0" } })],
+      vllmModel,
+    )).toBe("version_too_old");
+  });
+
+  test("reports insufficient_capacity when a structurally fine node is merely full", () => {
+    expect(explainClusterIncompatibility([makeNode({ free: 4 })], vllmModel)).toBe("insufficient_capacity");
+  });
+
+  test("prefers the closest node: full-but-compatible outranks roomy-but-driverless", () => {
+    expect(explainClusterIncompatibility([
+      makeNode({ free: 50, driverVersions: { ollama: "0.6.3" } }),
+      makeNode({ free: 4 }),
+    ], vllmModel)).toBe("insufficient_capacity");
+  });
+
+  test("prefers the closest node: platform mismatch outranks missing driver", () => {
+    expect(explainClusterIncompatibility([
+      makeNode({ driverVersions: { ollama: "0.6.3" } }),
+      makeNode({ gpus: [amdGpu] }),
+    ], vllmModel)).toBe("wrong_platform");
+  });
+
+  test("reports missing_driver for an empty cluster", () => {
+    expect(explainClusterIncompatibility([], vllmModel)).toBe("missing_driver");
   });
 });

--- a/packages/xinity-infoserver/node-compat.ts
+++ b/packages/xinity-infoserver/node-compat.ts
@@ -88,36 +88,64 @@ export function checkNodeCompatibility(
   return null;
 }
 
+/** A model as seen by cluster-wide deployability checks. */
+export type ClusterModel = {
+  weight: number;
+  minKvCache: number;
+  type?: string;
+  providers: Record<string, string | undefined>;
+  providerMinVersions?: Record<string, string>;
+  providerPlatforms?: Record<string, string[]>;
+};
+
+export function modelRequirementsForDriver(model: ClusterModel, driver: string): ModelNodeRequirements {
+  return {
+    driver,
+    capacityGb: model.weight + model.minKvCache,
+    minVersion: model.providerMinVersions?.[driver],
+    requiredPlatforms: model.providerPlatforms?.[driver] ?? [],
+    requiredFeatures: driver === "vllm" && model.type === "transcription" ? ["audio"] : [],
+  };
+}
+
+/** How far through checkNodeCompatibility's ordered checks a node got before failing. */
+const REASON_PROGRESS: Record<IncompatibilityReason, number> = {
+  missing_driver: 0,
+  version_unknown: 1,
+  version_too_old: 1,
+  missing_feature: 2,
+  wrong_platform: 3,
+  insufficient_capacity: 4,
+};
+
+/**
+ * Returns null if any node can serve the model via any of its providers, otherwise
+ * the reason from the node/driver pair that came closest to working.
+ *
+ * Reporting the closest pair matters: a cluster where one node is merely full and
+ * another lacks the driver is a capacity problem, not a driver problem.
+ */
+export function explainClusterIncompatibility(
+  nodes: NodeCapability[],
+  model: ClusterModel,
+): IncompatibilityReason | null {
+  const drivers = Object.keys(model.providers).filter(d => model.providers[d] !== undefined);
+
+  let closest: IncompatibilityReason = "missing_driver";
+  for (const node of nodes) {
+    for (const driver of drivers) {
+      const reason = checkNodeCompatibility(node, modelRequirementsForDriver(model, driver));
+      if (reason === null) return null;
+      if (REASON_PROGRESS[reason] > REASON_PROGRESS[closest]) closest = reason;
+    }
+  }
+  return closest;
+}
+
 /**
  * Returns true if at least one node can serve the model via any of its providers.
  * Used by client-side model selector to determine deployability.
  */
-export function isDeployableOnCluster(
-  nodes: NodeCapability[],
-  model: {
-    weight: number;
-    minKvCache: number;
-    type?: string;
-    providers: Record<string, string | undefined>;
-    providerMinVersions?: Record<string, string>;
-    providerPlatforms?: Record<string, string[]>;
-  },
-): boolean {
-  const needed = model.weight + model.minKvCache;
-  const drivers = Object.keys(model.providers).filter(d => model.providers[d] !== undefined);
-
-  return nodes.some(node =>
-    drivers.some(driver => {
-      const requiredFeatures =
-        driver === "vllm" && model.type === "transcription" ? ["audio"] : [];
-      const req: ModelNodeRequirements = {
-        driver,
-        capacityGb: needed,
-        minVersion: model.providerMinVersions?.[driver],
-        requiredPlatforms: model.providerPlatforms?.[driver] ?? [],
-        requiredFeatures,
-      };
-      return checkNodeCompatibility(node, req) === null;
-    }),
-  );
+export function isDeployableOnCluster(nodes: NodeCapability[], model: ClusterModel): boolean {
+  return explainClusterIncompatibility(nodes, model) === null;
 }

--- a/tests/system/daemon/daemon.test.ts
+++ b/tests/system/daemon/daemon.test.ts
@@ -64,6 +64,9 @@ describe("xinity-ai-daemon", () => {
 
     const nodeId = await waitForNodeIdFile(stateDir, 10_000);
     createdNodeIds.push(nodeId);
+
+    // The daemon writes node_id before it commits the registration, so the row lands after the file does.
+    await waitForNodeAvailability(nodeId, true, 10_000);
     const [node] = await db.select().from(aiNodeT).where(sql`${aiNodeT.id} = ${nodeId}`).limit(1);
     expect(node).toBeTruthy();
   });


### PR DESCRIPTION
## Description

Two unrelated threads that accumulated on the same branch, plus a nix fix.

**Test isolation.** The daemon and gateway suites only passed as whole-package
runs. Shared state between `cache-eviction`/`proxy` and `ai-sdk`/`compaction`
was the cause, `statekeeper` used a shared temp dir, and the vLLM tests dropped
the real page cache. `dropPageCache` moved out of `vllm.ts` into `page-cache.ts`
so it can be mocked. The gateway cancellation test now polls for status instead
of sleeping a fixed interval. The dead `SKIP_NETWORK_TESTS` guard and its CI env
var are gone. The daemon system test read the `aiNodeT` row once, immediately
after the `node_id` file appeared, but the daemon writes that file before it
commits the registration, so the test now polls for the row like its siblings do.

**Modelhub warnings.** The model picker decided *whether* a model was
undeployable with the real compatibility check, but decided *why* with a
separate heuristic. Anything the heuristic did not recognise fell through to a
hardcoded capacity sentence, so a model blocked by a missing driver, a missing
runtime feature or the wrong GPU vendor was reported as "Needs 20 GB, more than
the largest node's 50 GB free".

- `explainClusterIncompatibility` returns the actual `IncompatibilityReason`,
  reporting the node/driver pair that got furthest through the ordered checks.
  A cluster where one node is merely full and another lacks the driver is a
  capacity problem. A cluster where every node fails structurally is not.
- `isDeployableOnCluster` is now defined as
  `explainClusterIncompatibility(...) === null`, so the verdict and the
  explanation cannot drift apart again.
- The picker renders a message per reason. The GB comparison appears only for a
  real capacity shortfall.

**Also.** The daemon nix service gets `/run/current-system/sw` on `path` so
dynamically installed tooling such as `nvidia-smi` resolves, and
`vllm-features` casts `latin1` to `Bun.Encoding` to satisfy bun-types.

## Type of change

Bug fix

## Testing

Full workspace suite locally, all green:

| Suite | Result |
|---|---|
| common-env | 16 pass |
| xinity-ai-daemon | 163 pass, 3 skip |
| xinity-ai-gateway | 390 pass |
| xinity-cli | 288 pass |
| xinity-infoserver | 126 pass |
| system tests | 45 pass (SeaweedFS test self-skips) |
| dashboard, unit + e2e | 185 pass across 24 files |

9 of the infoserver tests are new. They cover each incompatibility reason and
the two closest-node tie-breaks, including a direct regression for the reported
case: a roomy cluster with no matching driver must not be reported as a capacity
shortfall. `bun run check` on the dashboard is also clean.

The daemon system test failure above was caught by this run, not in isolation.
It only loses the race under the DB contention of a full system run.

## Checklist

- [x] Tests pass locally (`bun test`), or no testable code was changed
- [x] New or changed behavior is covered by tests, or this change does not require tests
- [x] Documentation is updated, or no user-facing behavior or configuration was changed
- [x] There are no breaking changes, or they are marked with `!` in the commit type and described above
- [x] No security-sensitive changes (authentication, credentials, input handling), or they have been reviewed
- [x] No new dependencies were added, or they have been reviewed for license and maintenance status
