### PR TITLE
fix(cli): allow unsetting config keys

### DIFF
--- a/docs/features/cli.md
+++ b/docs/features/cli.md
@@ -32,6 +32,8 @@ Call any dashboard API route from the command line. Routes are discovered dynami
 
 Set CLI-level config (API key, dashboard URL) or edit a component's environment through the menu editor. Component changes are reviewed as a diff and applied only after confirmation, followed by a service restart. CLI configuration is stored in `~/.config/xinity/config.json` (`$XDG_CONFIG_HOME` is honored when set).
 
+Submitting an empty value unsets a key unless it is required, and Escape leaves the value untouched. `xinity configure <key> ""` (or `--reset`) unsets CLI-level config non-interactively, and unsetting a component secret also deletes its file from the host's secrets directory unless another installed component still reads it.
+
 ### Self-update (`xinity update`)
 
 Downloads the latest release, verifies SHA-256, and atomically replaces the binary with rollback on failure. `--check` reports whether an update is available without installing.

--- a/packages/xinity-cli/src/commands/configure.ts
+++ b/packages/xinity-cli/src/commands/configure.ts
@@ -1,5 +1,5 @@
 import type { CommandModule } from "yargs";
-import { menuConfigureCli, loadConfig, saveConfig, updateConfig } from "../lib/config.ts";
+import { menuConfigureCli, clearConfigKey, updateConfig } from "../lib/config.ts";
 import { configureComponentFlow } from "../lib/up-plan.ts";
 import type { Component } from "../lib/component-meta.ts";
 import type { CliConfig } from "../lib/config.ts";
@@ -20,7 +20,7 @@ export const configureCommand: CommandModule = {
         default: "cli",
       })
       .positional("value", {
-        describe: "Value to assign to the config key",
+        describe: "Value to assign to the config key, empty string to unset it",
         type: "string",
       })
       .option("reset", {
@@ -36,10 +36,8 @@ export const configureCommand: CommandModule = {
     const targetHostArg = argv["target-host"] as string | undefined;
     const isConfigKey = (CLI_CONFIG_KEYS as readonly string[]).includes(key);
 
-    if (isConfigKey && reset) {
-      const config = loadConfig();
-      delete (config as Record<string, unknown>)[key];
-      saveConfig(config);
+    if (isConfigKey && (reset || value === "")) {
+      clearConfigKey(key as keyof CliConfig);
       return;
     }
 

--- a/packages/xinity-cli/src/lib/config.ts
+++ b/packages/xinity-cli/src/lib/config.ts
@@ -97,6 +97,13 @@ export function updateConfig(patch: Partial<CliConfig>): CliConfig {
   return config;
 }
 
+export function clearConfigKey(key: keyof CliConfig): CliConfig {
+  const config = loadConfig();
+  delete config[key];
+  saveConfig(config);
+  return config;
+}
+
 /** Format a CLI config value for display in the menu. */
 function displayCliValue(field: ConfigField, value: string | undefined): string {
   if (value) {
@@ -135,25 +142,17 @@ export async function menuConfigureCli(): Promise<void> {
 
     const field = CLI_FIELDS.find((f) => f.key === choice)!;
     const current = config[field.key];
+    const unsetHint = current ? pc.dim(" [Enter to unset]") : "";
 
-    if (field.isSecret) {
-      const keepHint = current ? pc.dim(" [Enter to keep current]") : "";
-      const value = await p.password({
-        message: `${field.label}${keepHint}`,
-      });
-      if (p.isCancel(value)) { p.cancel("Cancelled."); return; }
-      if (value) config[field.key] = value;
-      else if (!current) delete config[field.key];
-    } else {
-      const value = await p.text({
-        message: field.label,
+    const value = field.isSecret
+      ? await p.password({ message: `${field.label}${unsetHint}` })
+      : await p.text({
+        message: `${field.label}${unsetHint}`,
         placeholder: current ?? undefined,
-        defaultValue: current ?? undefined,
       });
-      if (p.isCancel(value)) { p.cancel("Cancelled."); return; }
-      if (value) config[field.key] = value;
-      else delete config[field.key];
-    }
+    if (p.isCancel(value)) continue;
+    if (value) config[field.key] = value;
+    else delete config[field.key];
   }
 
   saveConfig(config);

--- a/packages/xinity-cli/src/lib/env-prompt.ts
+++ b/packages/xinity-cli/src/lib/env-prompt.ts
@@ -360,8 +360,6 @@ export type MenuEditOptions = {
   attentionKeys?: Set<string>;
   /** Keys owned by another layer (e.g. stack shared settings): not shown, not editable; their seeded values pass through. */
   hiddenKeys?: Set<string>;
-  /** Values the edited layer inherits; expert fields still matching them stay behind the advanced toggle. */
-  inherited?: Record<string, string>;
   /** Message displayed above the menu. */
   message?: string;
 }
@@ -371,8 +369,7 @@ export type MenuEditOptions = {
  * persisting anything. Returns null if the user cancels.
  *
  * Required fields are marked and block saving while unset. Expert fields
- * are hidden behind an "advanced settings" toggle unless they carry a
- * value beyond the inherited baseline or need attention.
+ * live behind the "advanced settings" toggle, set or not.
  */
 export async function menuEditEnv(
   schema: z.ZodObject<any>,
@@ -382,7 +379,6 @@ export async function menuEditEnv(
   const fields = analyzeEnvSchema(schema);
   const attentionKeys = opts?.attentionKeys ?? new Set<string>();
   const hiddenKeys = opts?.hiddenKeys ?? new Set<string>();
-  const inherited = opts?.inherited ?? {};
   const editable = fields.filter((f) => !hiddenKeys.has(f.key));
   const values: Record<string, string | undefined> = { ...existing };
   let showExpert = false;
@@ -390,11 +386,8 @@ export async function menuEditEnv(
   // is exactly the one you usually want next.
   let cursor: string | undefined;
 
-  const isUnset = (f: EnvField) => values[f.key] === undefined || values[f.key] === "";
   const requiredUnset = (f: EnvField) => isRequiredUnset(f, values);
-  const isInherited = (f: EnvField) => inherited[f.key] !== undefined && values[f.key] === inherited[f.key];
-  const isVisible = (f: EnvField) =>
-    !f.isExpert || showExpert || (!isUnset(f) && !isInherited(f)) || requiredUnset(f) || attentionKeys.has(f.key);
+  const isVisible = (f: EnvField) => !f.isExpert || showExpert;
 
   while (true) {
     const hiddenCount = editable.filter((f) => !isVisible(f)).length;

--- a/packages/xinity-cli/src/lib/env-prompt.ts
+++ b/packages/xinity-cli/src/lib/env-prompt.ts
@@ -154,7 +154,7 @@ export type EnvChange = {
   after?: string;
 }
 
-export function withoutDerivedKeys(component: Component, config: Record<string, string>): Record<string, string> {
+function withoutDerivedKeys(component: Component, config: Record<string, string>): Record<string, string> {
   const derived = DERIVED_ENV_KEYS[component];
   if (!derived) {
     return config;
@@ -162,8 +162,11 @@ export function withoutDerivedKeys(component: Component, config: Record<string, 
   return Object.fromEntries(Object.entries(config).filter(([key]) => !derived.includes(key)));
 }
 
-/** What applying `after` would change relative to the values currently on the host. */
-export function diffEnv(before: EnvBundle, after: EnvBundle): EnvChange[] {
+/**
+ * What applying `after` would change relative to the values currently on the
+ * host.
+ */
+export function diffEnv(component: Component, before: EnvBundle, after: EnvBundle): EnvChange[] {
   const changes: EnvChange[] = [];
   const compare = (prev: Record<string, string>, next: Record<string, string>, isSecret: boolean) => {
     for (const [key, value] of Object.entries(next)) {
@@ -177,7 +180,7 @@ export function diffEnv(before: EnvBundle, after: EnvBundle): EnvChange[] {
       if (!(key in next)) changes.push({ key, kind: "removed", isSecret });
     }
   };
-  compare(before.config, after.config, false);
+  compare(withoutDerivedKeys(component, before.config), withoutDerivedKeys(component, after.config), false);
   compare(before.secrets, after.secrets, true);
   return changes;
 }
@@ -538,7 +541,7 @@ export async function collectEnv(
 
   const withChanges = (result: EnvBundle): CollectedEnv => ({
     ...result,
-    changes: diffEnv({ config: withoutDerivedKeys(component, existingConfig), secrets: existingSecrets }, result),
+    changes: diffEnv(component, { config: existingConfig, secrets: existingSecrets }, result),
   });
   const useExisting = () => withChanges(splitValuesByCategory(fields, existing));
 

--- a/packages/xinity-cli/src/lib/env-prompt.ts
+++ b/packages/xinity-cli/src/lib/env-prompt.ts
@@ -13,6 +13,7 @@ export type EnvField = {
   hasDefault: boolean;
   defaultValue?: unknown;
   isOptional: boolean;
+  isRequired: boolean;
   isSecret: boolean;
   isExpert: boolean;
   isPublic: boolean;
@@ -70,13 +71,16 @@ export function analyzeEnvSchema(
     const meta = readFieldMeta(zodField as z.ZodType);
     const enumValues = extractEnumValues(prop);
     const resolvedType = resolveJsonSchemaType(prop);
+    const hasDefault = "default" in prop;
+    const isOptional = !requiredKeys.has(key);
 
     fields.push({
       key,
       description: prop.description,
-      hasDefault: "default" in prop,
+      hasDefault,
       defaultValue: prop.default,
-      isOptional: !requiredKeys.has(key),
+      isOptional,
+      isRequired: !isOptional && !hasDefault,
       isSecret: meta.secret,
       isExpert: meta.expert,
       isPublic: meta.public,
@@ -92,7 +96,7 @@ export function analyzeEnvSchema(
 
 /** The single definition of "the config is invalid without this field". */
 export function isRequiredUnset(field: EnvField, values: Record<string, string | undefined>): boolean {
-  return !field.isOptional && !field.hasDefault && !values[field.key];
+  return field.isRequired && !values[field.key];
 }
 
 export function missingRequiredFields(fields: EnvField[], values: Record<string, string | undefined>): EnvField[] {
@@ -256,20 +260,17 @@ async function promptFieldsUnderHeading(
 /** Distinguishes an Escape (back out, change nothing) from a skipped/cleared field. */
 const FIELD_CANCELLED: unique symbol = Symbol("field-cancelled");
 
-/**
- * Prompt for a single field value. Returns undefined if skipped. When
- * `cancelable`, Escape returns FIELD_CANCELLED instead of exiting the CLI
- * (menu editors treat it as backing out to the menu).
- */
+const UNSET_OPTION = "__unset__";
+
 async function promptField(
   field: EnvField,
   existingValue?: string,
-  cancelable = false,
+  inMenuEditor = false,
 ): Promise<string | undefined | typeof FIELD_CANCELLED> {
   const resolve = async <T>(prompt: Promise<T | symbol>): Promise<T | typeof FIELD_CANCELLED> => {
     const value = await prompt;
     if (isCancel(value)) {
-      if (cancelable) return FIELD_CANCELLED;
+      if (inMenuEditor) return FIELD_CANCELLED;
       cancelAndExit();
     }
     return value as T;
@@ -278,26 +279,31 @@ async function promptField(
   const hint = field.description ? dim(` (${field.description})`) : "";
   const optTag = field.isOptional ? dim(" [optional]") : "";
   const existing = existingValue ?? (field.hasDefault ? String(field.defaultValue) : undefined);
+  // Only the menu editor can back out with Escape, so only there is an empty submit safe to read as "unset".
+  const unsetOnEmpty = inMenuEditor && !field.isRequired;
+  const emptyHint = existingValue === undefined
+    ? ""
+    : dim(unsetOnEmpty ? " [Enter to unset]" : " [Enter to keep current]");
+  const keepOnEmpty = unsetOnEmpty ? undefined : existing;
 
   // Secret → masked password input
   if (field.isSecret) {
-    const keepHint = existing ? dim(" [Enter to keep current]") : "";
     const value = await resolve(password({
-      message: `${field.key}${hint}${optTag}${keepHint}`,
+      message: `${field.key}${hint}${optTag}${emptyHint}`,
       validate: (val) => {
-        if (!val && !existing && !field.isOptional && !field.hasDefault) return "This field is required";
+        if (!val && !existing && field.isRequired) return "This field is required";
         return undefined;
       },
     }));
     if (value === FIELD_CANCELLED) return value;
-    return value || existing || undefined;
+    return value || keepOnEmpty || undefined;
   }
 
   // Enum → select
   if (field.enumValues) {
     const options = field.enumValues.map((v) => ({ value: v, label: v }));
-    if (field.isOptional) {
-      options.unshift({ value: "__skip__", label: dim("skip") });
+    if (!field.isRequired) {
+      options.unshift({ value: UNSET_OPTION, label: dim(inMenuEditor ? "unset" : "skip") });
     }
     const value = await resolve(select({
       message: `${field.key}${hint}${optTag}`,
@@ -305,7 +311,7 @@ async function promptField(
       initialValue: existing,
     }));
     if (value === FIELD_CANCELLED) return value;
-    return value === "__skip__" ? undefined : value;
+    return value === UNSET_OPTION ? undefined : value;
   }
 
   // Boolean → confirm
@@ -322,17 +328,17 @@ async function promptField(
 
   // Number or string → text input
   const value = await resolve(text({
-    message: `${field.key}${hint}${optTag}`,
+    message: `${field.key}${hint}${optTag}${emptyHint}`,
     placeholder: existing ?? undefined,
-    defaultValue: existing ?? undefined,
+    defaultValue: unsetOnEmpty ? undefined : existing ?? undefined,
     validate: (val) => {
-      if (!val && !existing && !field.isOptional && !field.hasDefault) return "This field is required";
+      if (!val && !existing && field.isRequired) return "This field is required";
       if (val && field.isNumber && Number.isNaN(Number(val))) return "Must be a number";
       return undefined;
     },
   }));
   if (value === FIELD_CANCELLED) return value;
-  return value || undefined;
+  return value || keepOnEmpty || undefined;
 }
 
 /** Format a field's current value for display in the menu. */
@@ -469,6 +475,36 @@ export async function readExistingEnvState(component: Component, host: Host): Pr
   return {
     existingConfig: envContent ? parseEnvString(envContent) : {},
     existingSecrets: secretsResult.secrets,
+  };
+}
+
+export type SecretFilePlan = {
+  remove: string[];
+  keptForOtherComponents: string[];
+}
+
+export async function secretKeysOfOtherComponents(component: Component, host: Host): Promise<Set<string>> {
+  const manifest = await readManifest(host);
+  const others = (Object.keys(ENV_SCHEMAS) as Component[])
+    .filter((c) => c !== component && manifest.components[c]);
+  return new Set(
+    others.flatMap((c) => categorizeFields(analyzeEnvSchema(ENV_SCHEMAS[c])).secretFields.map((f) => f.key)),
+  );
+}
+
+export async function planSecretFileRemoval(
+  component: Component,
+  changes: EnvChange[],
+  host: Host,
+): Promise<SecretFilePlan> {
+  const unset = changes.filter((c) => c.kind === "removed" && c.isSecret).map((c) => c.key);
+  if (unset.length === 0) {
+    return { remove: [], keptForOtherComponents: [] };
+  }
+  const heldElsewhere = await secretKeysOfOtherComponents(component, host);
+  return {
+    remove: unset.filter((key) => !heldElsewhere.has(key)),
+    keptForOtherComponents: unset.filter((key) => heldElsewhere.has(key)),
   };
 }
 

--- a/packages/xinity-cli/src/lib/install-remove.ts
+++ b/packages/xinity-cli/src/lib/install-remove.ts
@@ -1,7 +1,7 @@
 import { confirm, isCancel } from "./clack.ts";
 import { heading } from "./output.ts";
 import { readManifest, writeManifest } from "./manifest.ts";
-import { analyzeEnvSchema, categorizeFields } from "./env-prompt.ts";
+import { analyzeEnvSchema, categorizeFields, secretKeysOfOtherComponents } from "./env-prompt.ts";
 import { type Host, isUnitActiveOn } from "./host.ts";
 import { unitName } from "./systemd.ts";
 import { runSteps, runStepsCollapsed } from "./step-runner.ts";
@@ -94,15 +94,7 @@ export async function* removeComponent(opts: {
   const fields = analyzeEnvSchema(schema);
   const { secretFields } = categorizeFields(fields);
   if (secretFields.length > 0) {
-    const manifest = await readManifest(host);
-    const otherComponents = (Object.keys(ENV_SCHEMAS) as Component[])
-      .filter((c) => c !== component && manifest.components[c]);
-    const sharedKeys = new Set(
-      otherComponents.flatMap((c) => {
-        const { secretFields: sf } = categorizeFields(analyzeEnvSchema(ENV_SCHEMAS[c]));
-        return sf.map((f) => f.key);
-      }),
-    );
+    const sharedKeys = await secretKeysOfOtherComponents(component, host);
 
     const toDelete = secretFields.filter((f) => !sharedKeys.has(f.key));
     const kept = secretFields.filter((f) => sharedKeys.has(f.key));

--- a/packages/xinity-cli/src/lib/installer.ts
+++ b/packages/xinity-cli/src/lib/installer.ts
@@ -372,6 +372,7 @@ async function performRollback(component: Component, host: Host, progress: Progr
 async function applyConfigAndStart(
   component: Component,
   env: EnvBundle,
+  removeSecretKeys: string[],
   host: Host,
   isUpdate: boolean,
   onFailure: ServiceFailurePolicy,
@@ -382,7 +383,7 @@ async function applyConfigAndStart(
   const unit = unitName(component);
 
   progress.update("Writing configuration…");
-  const configResult = await writeEnvConfig(component, env.config, env.secrets, host);
+  const configResult = await writeEnvConfig(component, env.config, env.secrets, host, removeSecretKeys);
   if (configResult.success) {
     progress.update("Environment configured");
   } else {
@@ -503,7 +504,7 @@ export async function applyComponentAction(
     }
 
     const binaryChanged = action.kind !== "reconfigure";
-    const errors = await applyConfigAndStart(component, action.env, host, isUpdate, onFailure, progress, binaryChanged);
+    const errors = await applyConfigAndStart(component, action.env, action.secretFiles.remove, host, isUpdate, onFailure, progress, binaryChanged);
 
     const success = errors.length === 0;
 

--- a/packages/xinity-cli/src/lib/service.ts
+++ b/packages/xinity-cli/src/lib/service.ts
@@ -40,6 +40,11 @@ export function buildSecretsWriteCommand(secrets: Record<string, string>): strin
   return cmds.join(" && ");
 }
 
+export function buildSecretsRemoveCommand(keys: string[]): string | null {
+  if (keys.length === 0) return null;
+  return `rm -f ${keys.map((key) => `${SECRETS_DIR}/${key}`).join(" ")}`;
+}
+
 export function buildUnitWriteCommand(component: Component, secretKeys: string[]): string {
   const baseConfig = getComponentConfig(component);
   const config: UnitConfig = { ...baseConfig, secretKeys };
@@ -53,6 +58,7 @@ export async function writeEnvConfig(
   config: Record<string, string>,
   secrets: Record<string, string>,
   host: Host,
+  removeSecretKeys: string[] = [],
 ): Promise<ServiceResult> {
   let result = await host.withElevation(
     buildEnvWriteCommand(component, config),
@@ -65,6 +71,14 @@ export async function writeEnvConfig(
   const secretsCommand = buildSecretsWriteCommand(secrets);
   if (secretsCommand) {
     result = await host.withElevation(secretsCommand, "Write secrets");
+    if (!result.success) {
+      return { success: false, error: result.output };
+    }
+  }
+
+  const removeCommand = buildSecretsRemoveCommand(removeSecretKeys);
+  if (removeCommand) {
+    result = await host.withElevation(removeCommand, "Remove unset secrets");
     if (!result.success) {
       return { success: false, error: result.output };
     }

--- a/packages/xinity-cli/src/lib/stack-layers.ts
+++ b/packages/xinity-cli/src/lib/stack-layers.ts
@@ -31,7 +31,6 @@ export async function menuEditLayer(opts: {
   const result = await menuEditEnv(opts.schema, { ...opts.inherited, ...opts.own }, {
     attentionKeys: opts.attentionKeys,
     hiddenKeys: opts.hiddenKeys,
-    inherited: opts.inherited,
     message: opts.message,
   });
   if (result === null) {

--- a/packages/xinity-cli/src/lib/stack-plan.ts
+++ b/packages/xinity-cli/src/lib/stack-plan.ts
@@ -22,7 +22,7 @@ import { readManifest, saveStackMembership, type StackMembership } from "./manif
 import { describeMigrationStep, migrationScriptComment, runMigrations } from "./migrator.ts";
 import { connectHost } from "./remote-host.ts";
 import { type ComponentAction, describeComponentAction, buildComponentAction, reviewGate, scriptComponentSection } from "./up-plan.ts";
-import { analyzeEnvSchema, splitValuesByCategory, readExistingEnvState, diffEnv, missingRequiredFields } from "./env-prompt.ts";
+import { analyzeEnvSchema, splitValuesByCategory, readExistingEnvState, diffEnv, missingRequiredFields, planSecretFileRemoval } from "./env-prompt.ts";
 import {
   type StackDefinition, type StackHost, type FleetDefinition,
   resolveEnv, saveStack, getFleetForHost, hostLabel,
@@ -234,6 +234,7 @@ async function planHostComponent(
       localRepoPath: targetVersion.slice(6),
       env: envResult.env,
       envChanges: envResult.envChanges,
+      secretFiles: await planSecretFileRemoval(component, envResult.envChanges, host),
       hardReset: false,
       serviceRunning,
     };

--- a/packages/xinity-cli/src/lib/stack-plan.ts
+++ b/packages/xinity-cli/src/lib/stack-plan.ts
@@ -210,7 +210,7 @@ async function resolveHostEnv(
 
   return {
     env: splitValuesByCategory(fields, merged),
-    envChanges: diffEnv({ config: existingConfig, secrets: existingSecrets }, splitValuesByCategory(fields, merged)),
+    envChanges: diffEnv(component, { config: existingConfig, secrets: existingSecrets }, splitValuesByCategory(fields, merged)),
   };
 }
 

--- a/packages/xinity-cli/src/lib/up-plan.ts
+++ b/packages/xinity-cli/src/lib/up-plan.ts
@@ -628,7 +628,7 @@ export async function configureComponentFlow(component: Component, host: Host): 
     return;
   }
 
-  const changes = diffEnv({ config: state.existingConfig, secrets: state.existingSecrets }, result);
+  const changes = diffEnv(component, { config: state.existingConfig, secrets: state.existingSecrets }, result);
   if (changes.length === 0) {
     log.info("No changes.");
     outro("Done");

--- a/packages/xinity-cli/src/lib/up-plan.ts
+++ b/packages/xinity-cli/src/lib/up-plan.ts
@@ -18,10 +18,10 @@ import { parseEnvString } from "./env-file.ts";
 import { unitName } from "./systemd.ts";
 import { pickReleaseAsset, resolveDirectUrl, getProjectUrl, type Release } from "./github.ts";
 import { assetSizeMb, buildInstallBinaryCommand } from "./install-download.ts";
-import { buildEnvWriteCommand, buildSecretsWriteCommand, buildUnitWriteCommand, writeEnvConfig, writeSystemdUnit, restartService } from "./service.ts";
+import { buildEnvWriteCommand, buildSecretsWriteCommand, buildSecretsRemoveCommand, buildUnitWriteCommand, writeEnvConfig, writeSystemdUnit, restartService } from "./service.ts";
 import { runSteps, createProgress } from "./step-runner.ts";
 import { resolveVersion, applyComponentAction, type VersionResult } from "./installer.ts";
-import { collectEnv, menuEditEnv, readExistingEnvState, diffEnv, type EnvBundle, type EnvChange } from "./env-prompt.ts";
+import { collectEnv, menuEditEnv, readExistingEnvState, diffEnv, planSecretFileRemoval, type EnvBundle, type EnvChange, type SecretFilePlan } from "./env-prompt.ts";
 import { discoverConnectionUrl, describeMigrationStep, migrationScriptComment, runMigrations } from "./migrator.ts";
 import { describePostgresProvision, buildPostgresProvisionCommands, applyPostgresProvision, type PostgresProvision } from "./postgres-setup.ts";
 import { planRedis, applyRedisPlan, describeRedisPlan, buildRedisProvisionCommands, type RedisPlan } from "./redis-setup.ts";
@@ -41,6 +41,7 @@ export type ComponentAction = {
   assetSizeMb?: string;
   env: EnvBundle;
   envChanges: EnvChange[];
+  secretFiles: SecretFilePlan;
   hardReset: boolean;
   serviceRunning: boolean;
 }
@@ -80,9 +81,12 @@ export async function buildComponentAction(
   version: Extract<VersionResult, { status: "proceed" | "current" }>,
   host: Host,
 ): Promise<ComponentAction | null> {
+  const secretFiles = await planSecretFileRemoval(base.component, base.envChanges, host);
+
   if (version.status === "current") {
     return {
       ...base,
+      secretFiles,
       kind: base.envChanges.length > 0 ? "reconfigure" : "none",
       installedVersion: version.version,
       toVersion: version.version,
@@ -100,6 +104,7 @@ export async function buildComponentAction(
 
   return {
     ...base,
+    secretFiles,
     kind: version.isUpdate ? "update" : "install",
     installedVersion: version.installedVersion,
     toVersion: version.release.tagName,
@@ -138,6 +143,7 @@ async function planComponentAction(
       localRepoPath: opts.targetVersion.slice(6),
       env: collected,
       envChanges: collected.changes,
+      secretFiles: await planSecretFileRemoval(component, collected.changes, host),
     };
   }
 
@@ -276,9 +282,14 @@ export async function planUp(
 
 // ─── Review ─────────────────────────────────────────────────────────────────
 
-function envChangeLines(changes: EnvChange[]): string[] {
+function envChangeLines(changes: EnvChange[], secretFiles: SecretFilePlan): string[] {
   return changes.map((c) => {
-    if (c.kind === "removed") return `- ${c.key}`;
+    if (c.kind === "removed") {
+      const kept = secretFiles.keptForOtherComponents.includes(c.key)
+        ? dim(" (secret file kept, another component still uses it)")
+        : "";
+      return `- ${c.key}${kept}`;
+    }
     const value = c.isSecret ? "••••••" : c.after;
     if (c.kind === "added") return `+ ${c.key} = ${value}`;
     return c.isSecret ? `~ ${c.key} = ••••••` : `~ ${c.key} = ${c.before} → ${c.after}`;
@@ -293,7 +304,7 @@ function serviceLine(action: ComponentAction): string {
 export function describeComponentAction(action: ComponentAction): string[] {
   const { component, envChanges } = action;
   const configLines = envChanges.length > 0
-    ? [`config changes:`, ...envChangeLines(envChanges).map((l) => `  ${l}`)]
+    ? [`config changes:`, ...envChangeLines(envChanges, action.secretFiles).map((l) => `  ${l}`)]
     : ["configuration unchanged"];
 
   switch (action.kind) {
@@ -392,11 +403,18 @@ const SCRIPT_HEADER = [
   "",
 ];
 
-function scriptConfigSection(component: Component, env: EnvBundle, serviceRunning: boolean): string[] {
+function scriptConfigSection(
+  component: Component,
+  env: EnvBundle,
+  serviceRunning: boolean,
+  secretFiles: SecretFilePlan,
+): string[] {
   const secretsCommand = buildSecretsWriteCommand(env.secrets);
+  const removeCommand = buildSecretsRemoveCommand(secretFiles.remove);
   return [
     buildEnvWriteCommand(component, env.config),
     ...(secretsCommand ? [secretsCommand] : []),
+    ...(removeCommand ? [removeCommand] : []),
     buildUnitWriteCommand(component, Object.keys(env.secrets)),
     serviceRunning ? `systemctl restart ${unitName(component)}` : `systemctl enable --now ${unitName(component)}`,
   ];
@@ -410,7 +428,7 @@ export async function scriptComponentSection(action: ComponentAction): Promise<s
     return [`# ── ${component}: ${action.toVersion} already current, nothing to do ──`];
   }
   if (action.kind === "reconfigure") {
-    return [header, ...scriptConfigSection(component, action.env, action.serviceRunning)];
+    return [header, ...scriptConfigSection(component, action.env, action.serviceRunning, action.secretFiles)];
   }
   if (action.localRepoPath) {
     return [
@@ -427,7 +445,7 @@ export async function scriptComponentSection(action: ComponentAction): Promise<s
     `mkdir -p /tmp/xinity-script-install`,
     `curl -fsSL -o '${archivePath}' '${url}'`,
     buildInstallBinaryCommand(component, archivePath),
-    ...scriptConfigSection(component, action.env, action.serviceRunning),
+    ...scriptConfigSection(component, action.env, action.serviceRunning, action.secretFiles),
   ];
 }
 
@@ -618,10 +636,11 @@ export async function configureComponentFlow(component: Component, host: Host): 
   }
 
   const serviceRunning = await isUnitActiveOn(host, unitName(component));
+  const secretFiles = await planSecretFileRemoval(component, changes, host);
 
   note(
     [
-      ...envChangeLines(changes),
+      ...envChangeLines(changes, secretFiles),
       dim(serviceRunning
         ? `update systemd unit, restart ${unitName(component)}`
         : `update systemd unit (${unitName(component)} is not running, takes effect on next start)`),
@@ -630,12 +649,12 @@ export async function configureComponentFlow(component: Component, host: Host): 
   );
 
   const proceed = await reviewGate(async () =>
-    [...SCRIPT_HEADER, ...scriptConfigSection(component, result, serviceRunning)].join("\n"),
+    [...SCRIPT_HEADER, ...scriptConfigSection(component, result, serviceRunning, secretFiles)].join("\n"),
   );
   if (!proceed) return;
 
   const progress = createProgress("Applying configuration…");
-  const configResult = await writeEnvConfig(component, result.config, result.secrets, host);
+  const configResult = await writeEnvConfig(component, result.config, result.secrets, host, secretFiles.remove);
   if (configResult.success) {
     progress.update("Environment configured");
     await writeSystemdUnit(component, Object.keys(result.secrets), host);

--- a/packages/xinity-cli/tests/integration/configure.test.ts
+++ b/packages/xinity-cli/tests/integration/configure.test.ts
@@ -65,6 +65,22 @@ describe("configure command", () => {
     expect(readConfig().apiKey).toBeUndefined();
   });
 
+  test("configure <key> \"\" unsets the key", async () => {
+    await runCli({
+      args: ["configure", "dashboardUrl", "http://test.example.com"],
+      env: { HOME: tmp.path, XDG_CONFIG_HOME: join(tmp.path, ".config") },
+    });
+    expect(readConfig().dashboardUrl).toBe("http://test.example.com");
+
+    const result = await runCli({
+      args: ["configure", "dashboardUrl", ""],
+      env: { HOME: tmp.path, XDG_CONFIG_HOME: join(tmp.path, ".config") },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(readConfig().dashboardUrl).toBeUndefined();
+  });
+
   test("configure --reset preserves other keys", async () => {
     await runCli({
       args: ["configure", "apiKey", "key-1"],

--- a/packages/xinity-cli/tests/unit/env-prompt.test.ts
+++ b/packages/xinity-cli/tests/unit/env-prompt.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
 import { z } from "zod";
 import { secret } from "common-env";
-import { analyzeEnvSchema, categorizeFields } from "../../src/lib/env-prompt.ts";
+import {
+  analyzeEnvSchema, categorizeFields, planSecretFileRemoval,
+  type EnvChange,
+} from "../../src/lib/env-prompt.ts";
 import { readEnvFile, serializeEnvFile, readSecretFiles } from "../../src/lib/env-file.ts";
+import { buildSecretsRemoveCommand } from "../../src/lib/service.ts";
 import { createTempDir, type TempDir } from "../helpers/temp-config.ts";
+import { FakeHost } from "../helpers/fake-host.ts";
 
 describe("env-prompt", () => {
   describe("analyzeEnvSchema", () => {
@@ -36,6 +41,9 @@ describe("env-prompt", () => {
       const fields = analyzeEnvSchema(schema);
       expect(fields[0]!.hasDefault).toBe(true);
       expect(fields[0]!.defaultValue).toBe(3000);
+      // Listed as required in the JSON schema, but the default satisfies it.
+      expect(fields[0]!.isOptional).toBe(false);
+      expect(fields[0]!.isRequired).toBe(false);
     });
 
     test("detects number fields", () => {
@@ -105,6 +113,74 @@ describe("env-prompt", () => {
       expect(secretFields.map((f) => f.key)).toEqual(["DB_PASSWORD", "API_KEY"]);
     });
 
+  });
+
+  describe("isRequired", () => {
+    const fields = analyzeEnvSchema(z.object({
+      HOST: z.string(),
+      PORT: z.coerce.number().default(3000),
+      MAIL_URL: z.url().optional(),
+    }));
+    const field = (key: string) => fields.find((f) => f.key === key)!;
+
+    test("a field without a value or a default is required", () => {
+      expect(field("HOST").isRequired).toBe(true);
+    });
+
+    test("a field with a default is not required, it falls back to it", () => {
+      expect(field("PORT").isRequired).toBe(false);
+    });
+
+    test("an optional field is not required", () => {
+      expect(field("MAIL_URL").isRequired).toBe(false);
+    });
+  });
+
+  describe("planSecretFileRemoval", () => {
+    const unset = (key: string, isSecret = true): EnvChange => ({ key, kind: "removed", isSecret });
+
+    const hostWith = (...components: string[]) => new FakeHost({
+      files: {
+        "/opt/xinity/manifest.json": JSON.stringify({
+          components: Object.fromEntries(components.map((c) => [c, { version: "0.0.0" }])),
+        }),
+      },
+    });
+
+    test("deletes the file of a secret only this component declares", async () => {
+      const plan = await planSecretFileRemoval("dashboard", [unset("MAIL_URL")], hostWith("dashboard", "gateway"));
+
+      expect(plan).toEqual({ remove: ["MAIL_URL"], keptForOtherComponents: [] });
+    });
+
+    test("keeps a secret another installed component still reads", async () => {
+      const plan = await planSecretFileRemoval("gateway", [unset("METRICS_AUTH")], hostWith("gateway", "dashboard"));
+
+      expect(plan).toEqual({ remove: [], keptForOtherComponents: ["METRICS_AUTH"] });
+    });
+
+    test("deletes a shared secret once no other component is installed", async () => {
+      const plan = await planSecretFileRemoval("gateway", [unset("METRICS_AUTH")], hostWith("gateway"));
+
+      expect(plan).toEqual({ remove: ["METRICS_AUTH"], keptForOtherComponents: [] });
+    });
+
+    test("ignores unset config keys, which the env file rewrite already drops", async () => {
+      const plan = await planSecretFileRemoval("gateway", [unset("HOST", false)], hostWith("gateway"));
+
+      expect(plan).toEqual({ remove: [], keptForOtherComponents: [] });
+    });
+  });
+
+  describe("buildSecretsRemoveCommand", () => {
+    test("removes each key's file under the secrets dir", () => {
+      expect(buildSecretsRemoveCommand(["MAIL_URL", "LICENSE_KEY"]))
+        .toBe("rm -f /etc/xinity-ai/secrets/MAIL_URL /etc/xinity-ai/secrets/LICENSE_KEY");
+    });
+
+    test("returns null when nothing was unset", () => {
+      expect(buildSecretsRemoveCommand([])).toBeNull();
+    });
   });
 
   describe("readEnvFile", () => {

--- a/packages/xinity-cli/tests/unit/env-prompt.test.ts
+++ b/packages/xinity-cli/tests/unit/env-prompt.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, test, beforeEach, afterEach } from "bun:test";
 import { z } from "zod";
 import { secret } from "common-env";
 import {
-  analyzeEnvSchema, categorizeFields, planSecretFileRemoval,
-  type EnvChange,
+  analyzeEnvSchema, categorizeFields, diffEnv, planSecretFileRemoval,
+  type EnvBundle, type EnvChange,
 } from "../../src/lib/env-prompt.ts";
 import { readEnvFile, serializeEnvFile, readSecretFiles } from "../../src/lib/env-file.ts";
 import { buildSecretsRemoveCommand } from "../../src/lib/service.ts";
@@ -133,6 +133,34 @@ describe("env-prompt", () => {
 
     test("an optional field is not required", () => {
       expect(field("MAIL_URL").isRequired).toBe(false);
+    });
+  });
+
+  describe("diffEnv", () => {
+    const bundle = (config: Record<string, string>): EnvBundle => ({ config, secrets: {} });
+
+    test("reports added, changed and removed keys", () => {
+      const changes = diffEnv(
+        "gateway",
+        bundle({ HOST: "0.0.0.0", PORT: "3000" }),
+        bundle({ HOST: "127.0.0.1", LOG_LEVEL: "debug" }),
+      );
+
+      expect(changes).toEqual([
+        { key: "HOST", kind: "changed", isSecret: false, before: "0.0.0.0", after: "127.0.0.1" },
+        { key: "LOG_LEVEL", kind: "added", isSecret: false, after: "debug" },
+        { key: "PORT", kind: "removed", isSecret: false },
+      ]);
+    });
+
+    test("a key the writer derives is never reported as removed", () => {
+      const changes = diffEnv(
+        "dashboard",
+        bundle({ ORIGIN: "https://xinity.test", HTTP_OVERRIDE_ORIGIN: "https://xinity.test" }),
+        bundle({ ORIGIN: "https://xinity.test" }),
+      );
+
+      expect(changes).toEqual([]);
     });
   });
 

--- a/packages/xinity-cli/tests/unit/stack.test.ts
+++ b/packages/xinity-cli/tests/unit/stack.test.ts
@@ -169,7 +169,6 @@ describe("resolveEnv", () => {
 
   test("includes the component's auto defaults as the base layer", () => {
     const stack = makeStack();
-    expect(resolveEnv(stack, "daemon").STATE_DIR).toBe("/var/lib/xinity-ai-daemon");
     expect(resolveEnv(stack, "gateway").INFOSERVER_URL).toBe("https://sysinfo.xinity.ai");
   });
 


### PR DESCRIPTION
## Description

Three CLI config fixes.

Unsetting a key was impossible, because every prompt passed the current value as clack's `defaultValue`, so an empty submit returned it unchanged.

- An empty submit now unsets any key that is not required (neither `optional()` nor carrying a `default()`), in both the component env editor and the CLI config menu, while Escape still backs out with the value unchanged.
- `xinity configure <key> ""` unsets non-interactively, alongside the existing `--reset`.
- Unsetting a secret now deletes its file as well, unless another installed component declares that key, reusing the rule `install-remove.ts` already had. Without the delete, the value is read back from the shared secrets dir and the unset does not stick.
- The install wizard keeps its old behavior, since Escape there exits the CLI instead of backing out, which means an empty Enter has to keep the prefilled value.
- Booleans remain unsettable, because `confirm` has no empty state.

`HTTP_OVERRIDE_ORIGIN` was reported as removed, even though `applyEnvDerivations` re-adds it from `ORIGIN` on every write. `collectEnv` stripped `DERIVED_ENV_KEYS` before diffing but the other two `diffEnv` callers did not, so `diffEnv` now takes the component and filters those keys itself.

Expert settings showed up outside the advanced section, because `isVisible` revealed any expert field holding a value beyond the inherited baseline, and single-host `configure` has no inherited map. The rule is now `!f.isExpert || showExpert`, which also drops `isUnset`, `isInherited` and `MenuEditOptions.inherited`, since those existed only to serve the old clause.

## Type of change

Bug fix

## Testing

`bun test` passes in `packages/xinity-cli`. Tests were added for unsetting env keys, secret file retention, and env diffing.

## Checklist

- [x] Tests pass locally (`bun test`), or no testable code was changed
- [x] New or changed behavior is covered by tests, or this change does not require tests
- [x] Documentation is updated, or no user-facing behavior or configuration was changed
- [x] There are no breaking changes, or they are marked with `!` in the commit type and described above
- [x] No security-sensitive changes (authentication, credentials, input handling), or they have been reviewed
- [x] No new dependencies were added, or they have been reviewed for license and maintenance status
