### PR TITLE
chore!: bun 1.4.2 + one metric shape for every service

### DIFF
--- a/.github/workflows/models.yml
+++ b/.github/workflows/models.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3"
+          bun-version: "1.4"
       - run: bun install --frozen-lockfile
       # Loading the catalog the way the server does is the validation.
       - run: bun run server.ts --check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ concurrency:
 permissions: {}
 
 env:
-  BUN_VERSION: "1.4.0"
+  BUN_VERSION: "1.4.2"
 
 jobs:
   # Standalone binaries via `bun build --compile`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ concurrency:
 permissions: {}
 
 env:
-  BUN_VERSION: "1.3.14"
+  BUN_VERSION: "1.4.0"
 
 jobs:
   # Standalone binaries via `bun build --compile`.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.4.0"
+          bun-version: "1.4.2"
       - run: bun scripts/sync-dockerfile-manifests.ts --check
 
   nix-flake-check:
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.4.0"
+          bun-version: "1.4.2"
       - run: bun install --frozen-lockfile
       - name: Run tests
         run: ${{ matrix.suite.cmd }}
@@ -107,7 +107,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.4.0"
+          bun-version: "1.4.2"
       - run: bun install --frozen-lockfile
       - name: Run system tests
         run: bun run test:system -- --reporter=default --reporter=junit --reporter-outfile=results.xml
@@ -152,7 +152,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.4.0"
+          bun-version: "1.4.2"
       - run: bun install --frozen-lockfile
 
       - name: Install Playwright Chromium

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.14"
+          bun-version: "1.4.0"
       - run: bun scripts/sync-dockerfile-manifests.ts --check
 
   nix-flake-check:
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.14"
+          bun-version: "1.4.0"
       - run: bun install --frozen-lockfile
       - name: Run tests
         run: ${{ matrix.suite.cmd }}
@@ -107,7 +107,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.14"
+          bun-version: "1.4.0"
       - run: bun install --frozen-lockfile
       - name: Run system tests
         run: bun run test:system -- --reporter=default --reporter=junit --reporter-outfile=results.xml
@@ -152,7 +152,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.14"
+          bun-version: "1.4.0"
       - run: bun install --frozen-lockfile
 
       - name: Install Playwright Chromium

--- a/bun.lock
+++ b/bun.lock
@@ -204,7 +204,7 @@
     "samlify": "2.13.1",
   },
   "catalog": {
-    "@types/bun": "^1.4.0",
+    "@types/bun": "^1.4.1",
     "drizzle-orm": "^0.45.2",
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",

--- a/bun.lock
+++ b/bun.lock
@@ -205,7 +205,7 @@
     "samlify": "2.13.1",
   },
   "catalog": {
-    "@types/bun": "^1.3.14",
+    "@types/bun": "^1.4.0",
     "drizzle-orm": "^0.45.2",
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",
@@ -616,7 +616,7 @@
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.3.0", "", { "dependencies": { "@tailwindcss/node": "4.3.0", "@tailwindcss/oxide": "4.3.0", "tailwindcss": "4.3.0" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw=="],
 
-    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+    "@types/bun": ["@types/bun@1.4.1", "", { "dependencies": { "bun-types": "1.4.1" } }, "sha512-0AVGiTXGajf1rgKom3N+c5L7CBxuoyyv1i44M0nX4UDK0G/fnRAMiri93nHuVPIb429KKtAgj7HatVmmOjeQLA=="],
 
     "@types/cookie": ["@types/cookie@0.6.0", "", {}, "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="],
 
@@ -710,7 +710,7 @@
 
     "bumpp": ["bumpp@11.1.0", "", { "dependencies": { "args-tokenizer": "^0.3.0", "cac": "^7.0.0", "jsonc-parser": "^3.3.1", "package-manager-detector": "^1.6.0", "semver": "^7.7.4", "tinyexec": "^1.1.2", "tinyglobby": "^0.2.16", "unconfig": "^7.5.0", "yaml": "^2.8.4" }, "bin": { "bumpp": "bin/bumpp.mjs" } }, "sha512-jdwOGMyX8JIqpQ0N2RMRR87DHZaoJnUtui5lU9LqFfFK5JC0H8qY9uWqXoa+dEWt/K7rOmmsoyiZB8RBM7RPBQ=="],
 
-    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+    "bun-types": ["bun-types@1.4.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-loKuVrAFZKfEv+JvWkHRS9GW5IqLuLRjVXN9p+vZvBN86O5hf/pBZQ5hSoyipsrMmWObZBDvWnlmKvjKTM0PdA=="],
 
     "cac": ["cac@7.0.0", "", {}, "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -71,7 +71,6 @@
         "mjml": "^5.2.1",
         "nodemailer": "^9.0.5",
         "pino": "catalog:",
-        "prom-client": "^15.1.3",
         "uqr": "^0.1.3",
       },
       "devDependencies": {
@@ -694,8 +693,6 @@
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 
-    "bintrees": ["bintrees@1.0.2", "", {}, "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="],
-
     "bits-ui": ["bits-ui@2.18.1", "", { "dependencies": { "@floating-ui/core": "^1.7.1", "@floating-ui/dom": "^1.7.1", "esm-env": "^1.1.2", "runed": "^0.35.1", "svelte-toolbelt": "^0.10.6", "tabbable": "^6.2.0" }, "peerDependencies": { "@internationalized/date": "^3.8.1", "svelte": "^5.33.0" } }, "sha512-KkemzKFH4T3gt3H+P86JcnAWExjByv/6vlwjm/BoCwTPHu03yiCdxbghdJLvFReQTe0acCAiRcKfmixxD6XvlA=="],
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
@@ -1234,8 +1231,6 @@
 
     "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
 
-    "prom-client": ["prom-client@15.1.3", "", { "dependencies": { "@opentelemetry/api": "^1.4.0", "tdigest": "^0.1.1" } }, "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g=="],
-
     "proto-list": ["proto-list@1.2.4", "", {}, "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="],
 
     "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
@@ -1349,8 +1344,6 @@
     "tailwindcss": ["tailwindcss@4.3.0", "", {}, "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q=="],
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
-
-    "tdigest": ["tdigest@0.1.2", "", { "dependencies": { "bintrees": "1.0.2" } }, "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA=="],
 
     "thread-stream": ["thread-stream@4.0.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -7,3 +7,6 @@
 minimumReleaseAge = 86400
 # Packages allowed to bypass the age gate (none for now).
 minimumReleaseAgeExcludes = []
+
+[test]
+preload = ["./tests/system/preload.ts"]

--- a/deployment/monitoring/dashboards/xinity-gateway.json
+++ b/deployment/monitoring/dashboards/xinity-gateway.json
@@ -17,12 +17,12 @@
   "panels": [
     { "type": "row", "id": 1, "title": "Traffic", "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 } },
     {
-      "type": "timeseries", "id": 2, "title": "Request rate by endpoint",
+      "type": "timeseries", "id": 2, "title": "Request rate by route",
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
       "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 15, "showPoints": "never", "lineInterpolation": "smooth", "stacking": { "mode": "normal", "group": "A" } } }, "overrides": [] },
       "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "lastNotNull", "max"] }, "tooltip": { "mode": "multi", "sort": "desc" } },
-      "targets": [ { "refId": "A", "editorMode": "code", "expr": "sum by (endpoint) (rate(gateway_requests_total[$__rate_interval]))", "legendFormat": "{{endpoint}}", "range": true } ]
+      "targets": [ { "refId": "A", "editorMode": "code", "expr": "sum by (route) (rate(http_requests_total{job=\"xinity-gateway\"}[$__rate_interval]))", "legendFormat": "{{route}}", "range": true } ]
     },
     {
       "type": "timeseries", "id": 3, "title": "Requests by status",
@@ -30,34 +30,34 @@
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 1 },
       "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 15, "showPoints": "never", "lineInterpolation": "smooth", "stacking": { "mode": "normal", "group": "A" } } }, "overrides": [] },
       "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "lastNotNull", "max"] }, "tooltip": { "mode": "multi", "sort": "desc" } },
-      "targets": [ { "refId": "A", "editorMode": "code", "expr": "sum by (status) (rate(gateway_requests_total[$__rate_interval]))", "legendFormat": "{{status}}", "range": true } ]
+      "targets": [ { "refId": "A", "editorMode": "code", "expr": "sum by (status) (rate(http_requests_total{job=\"xinity-gateway\"}[$__rate_interval]))", "legendFormat": "{{status}}", "range": true } ]
     },
     {
-      "type": "timeseries", "id": 4, "title": "Error rate by endpoint",
+      "type": "timeseries", "id": 4, "title": "Error rate by route",
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "gridPos": { "h": 8, "w": 8, "x": 0, "y": 9 },
       "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never", "lineInterpolation": "smooth" } }, "overrides": [] },
       "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi", "sort": "desc" } },
-      "targets": [ { "refId": "A", "editorMode": "code", "expr": "sum by (endpoint) (rate(gateway_request_errors_total[$__rate_interval]))", "legendFormat": "{{endpoint}}", "range": true } ]
+      "targets": [ { "refId": "A", "editorMode": "code", "expr": "sum by (route) (rate(http_requests_total{job=\"xinity-gateway\",status=~\"[45]..\"}[$__rate_interval]))", "legendFormat": "{{route}}", "range": true } ]
     },
     {
-      "type": "timeseries", "id": 5, "title": "Request latency by endpoint",
+      "type": "timeseries", "id": 5, "title": "Request latency by route",
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "gridPos": { "h": 8, "w": 8, "x": 8, "y": 9 },
-      "fieldConfig": { "defaults": { "unit": "ms", "custom": { "drawStyle": "line", "fillOpacity": 0, "showPoints": "never", "lineInterpolation": "smooth" } }, "overrides": [] },
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 0, "showPoints": "never", "lineInterpolation": "smooth" } }, "overrides": [] },
       "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "targets": [
-        { "refId": "A", "editorMode": "code", "expr": "histogram_quantile(0.5, sum by (le, endpoint) (rate(gateway_request_duration_milliseconds_bucket[$__rate_interval])))", "legendFormat": "p50 {{endpoint}}", "range": true },
-        { "refId": "B", "editorMode": "code", "expr": "histogram_quantile(0.95, sum by (le, endpoint) (rate(gateway_request_duration_milliseconds_bucket[$__rate_interval])))", "legendFormat": "p95 {{endpoint}}", "range": true }
+        { "refId": "A", "editorMode": "code", "expr": "histogram_quantile(0.5, sum by (le, route) (rate(http_request_duration_seconds_bucket{job=\"xinity-gateway\"}[$__rate_interval])))", "legendFormat": "p50 {{route}}", "range": true },
+        { "refId": "B", "editorMode": "code", "expr": "histogram_quantile(0.95, sum by (le, route) (rate(http_request_duration_seconds_bucket{job=\"xinity-gateway\"}[$__rate_interval])))", "legendFormat": "p95 {{route}}", "range": true }
       ]
     },
     {
-      "type": "timeseries", "id": 6, "title": "Active requests by endpoint",
+      "type": "timeseries", "id": 6, "title": "Active requests by route",
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "gridPos": { "h": 8, "w": 8, "x": 16, "y": 9 },
       "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never", "lineInterpolation": "stepAfter" } }, "overrides": [] },
       "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi", "sort": "desc" } },
-      "targets": [ { "refId": "A", "editorMode": "code", "expr": "sum by (endpoint) (gateway_active_requests)", "legendFormat": "{{endpoint}}", "range": true } ]
+      "targets": [ { "refId": "A", "editorMode": "code", "expr": "sum by (route) (http_requests_in_flight{job=\"xinity-gateway\"})", "legendFormat": "{{route}}", "range": true } ]
     },
     {
       "type": "timeseries", "id": 7, "title": "Input tokens p95 by model",

--- a/deployment/monitoring/dashboards/xinity-overview.json
+++ b/deployment/monitoring/dashboards/xinity-overview.json
@@ -22,7 +22,7 @@
       "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
       "fieldConfig": { "defaults": { "unit": "reqps", "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] } }, "overrides": [] },
       "options": { "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "colorMode": "value", "graphMode": "area", "textMode": "auto", "justifyMode": "auto" },
-      "targets": [ { "refId": "A", "editorMode": "code", "expr": "sum(rate(gateway_requests_total[$__rate_interval]))", "range": true } ]
+      "targets": [ { "refId": "A", "editorMode": "code", "expr": "sum(rate(http_requests_total{job=\"xinity-gateway\"}[$__rate_interval]))", "range": true } ]
     },
     {
       "type": "stat", "id": 3, "title": "Gateway error rate",
@@ -30,7 +30,7 @@
       "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
       "fieldConfig": { "defaults": { "unit": "percent", "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 1 }, { "color": "red", "value": 5 } ] } }, "overrides": [] },
       "options": { "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "colorMode": "value", "graphMode": "area", "textMode": "auto", "justifyMode": "auto" },
-      "targets": [ { "refId": "A", "editorMode": "code", "expr": "100 * sum(rate(gateway_request_errors_total[$__rate_interval])) / clamp_min(sum(rate(gateway_requests_total[$__rate_interval])), 1)", "range": true } ]
+      "targets": [ { "refId": "A", "editorMode": "code", "expr": "100 * sum(rate(http_requests_total{job=\"xinity-gateway\",status=~\"[45]..\"}[$__rate_interval])) / clamp_min(sum(rate(http_requests_total{job=\"xinity-gateway\"}[$__rate_interval])), 1)", "range": true } ]
     },
     {
       "type": "stat", "id": 4, "title": "Active requests",
@@ -38,7 +38,7 @@
       "gridPos": { "h": 4, "w": 4, "x": 8, "y": 1 },
       "fieldConfig": { "defaults": { "unit": "short", "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] } }, "overrides": [] },
       "options": { "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "colorMode": "value", "graphMode": "area", "textMode": "auto", "justifyMode": "auto" },
-      "targets": [ { "refId": "A", "editorMode": "code", "expr": "sum(gateway_active_requests)", "range": true } ]
+      "targets": [ { "refId": "A", "editorMode": "code", "expr": "sum(http_requests_in_flight{job=\"xinity-gateway\"})", "range": true } ]
     },
     {
       "type": "stat", "id": 5, "title": "Daemons up",
@@ -96,15 +96,7 @@
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 14 },
       "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 0, "showPoints": "never", "lineInterpolation": "smooth" } }, "overrides": [] },
       "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi", "sort": "desc" } },
-      "targets": [ { "refId": "A", "editorMode": "code", "expr": "nodejs_eventloop_lag_p99_seconds{job=\"xinity-dashboard\"}", "legendFormat": "p99 lag", "range": true } ]
-    },
-    {
-      "type": "timeseries", "id": 15, "title": "Node.js heap used",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 14 },
-      "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never", "lineInterpolation": "smooth" } }, "overrides": [] },
-      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi", "sort": "desc" } },
-      "targets": [ { "refId": "A", "editorMode": "code", "expr": "nodejs_heap_size_used_bytes{job=\"xinity-dashboard\"}", "legendFormat": "heap used", "range": true } ]
+      "targets": [ { "refId": "A", "editorMode": "code", "expr": "histogram_quantile(0.99, sum by (le) (rate(process_event_loop_lag_seconds_bucket{job=\"xinity-dashboard\"}[$__rate_interval])))", "legendFormat": "p99 lag", "range": true } ]
     },
     { "type": "row", "id": 16, "title": "Control plane (tether)", "collapsed": false, "gridPos": { "h": 1, "w": 24, "x": 0, "y": 22 } },
     {

--- a/docs/features/monitoring.md
+++ b/docs/features/monitoring.md
@@ -8,6 +8,20 @@ For deployment-specific monitoring setup, see the [Docker deployment guide](../.
 
 Each of the gateway, dashboard, tether, and daemon exposes a `GET /metrics` endpoint in Prometheus text format, protected by HTTP Basic Auth via the `METRICS_AUTH` environment variable (format: `user:pass`, comma-separated for multiple credentials). On the gateway, tether, and daemon this is optional; when unset, the endpoint is open. On the dashboard, `METRICS_AUTH` is required.
 
+### Shared runtime metrics
+
+Every service above exports these alongside its own. They carry no service label, since Prometheus already attaches `job` and `instance` at scrape time.
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `<service>_build_info` | gauge | `version`, `bun_version` | Running build. The value is always 1, so it joins onto other series by `instance`. The daemon's also carries `node_id` and `machine_name`. |
+| `process_start_time_seconds` | gauge | | Process start as a unix timestamp. Uptime is `time() - process_start_time_seconds`, and a change means a restart. |
+| `process_cpu_seconds_total` | counter | `mode` (`user`, `system`) | CPU time consumed. Use `rate()` for utilization. |
+| `process_resident_memory_bytes` | gauge | | Resident set size. |
+| `process_event_loop_lag_seconds` | histogram | | Event loop delay, sampled every 100ms. The clearest signal for a process that is up and idle but not responding. |
+
+Event loop lag is a cumulative histogram, so pick the window at query time: `histogram_quantile(0.99, rate(process_event_loop_lag_seconds_bucket[5m]))`. Being cumulative, it aggregates across instances and is unaffected by how many Prometheus servers scrape the target.
+
 ### Gateway metrics
 
 | Metric | Type | Labels | Description |
@@ -42,9 +56,6 @@ Load-balancer decision metrics (see [Load Balancing](gateway.md#load-balancing))
 | Metric | Type | Labels | Description |
 |---|---|---|---|
 | `http_requests_total` | counter | `method`, `route` | Total HTTP requests |
-| (Node.js defaults) | various | | Process CPU, memory, event loop lag, heap, GC |
-
-The dashboard uses `prom-client` and collects default Node.js/Bun runtime metrics automatically.
 
 ### Tether metrics
 
@@ -62,7 +73,7 @@ A daemon connection is meant to last as long as the node is up, so the connectio
 
 ### Daemon metrics
 
-All daemon metrics carry a `node_id` label, plus `machine_name` when the node has a display name set. GPU metrics additionally carry `gpu` (index) and `uuid`.
+All `daemon_*` metrics carry a `node_id` label, plus `machine_name` when the node has a display name set. GPU metrics additionally carry `gpu` (index) and `uuid`.
 
 | Metric | Type | Description |
 |---|---|---|

--- a/docs/features/monitoring.md
+++ b/docs/features/monitoring.md
@@ -22,14 +22,29 @@ Every service above exports these alongside its own. They carry no service label
 
 Event loop lag is a cumulative histogram, so pick the window at query time: `histogram_quantile(0.99, rate(process_event_loop_lag_seconds_bucket[5m]))`. Being cumulative, it aggregates across instances and is unaffected by how many Prometheus servers scrape the target.
 
+### Shared HTTP metrics
+
+Every service serves these under the same names, so one query shape works across the fleet. Scope by `job`, or a query sums all four services together.
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `http_requests_total` | counter | `method`, `route`, `status` | Requests by method, matched route, and response status |
+| `http_request_duration_seconds` | histogram | `method`, `route` | Request duration in seconds |
+| `http_requests_in_flight` | gauge | `method`, `route` | Requests currently being served |
+
+`route` is always a bounded pattern, never a raw path: the dashboard reports SvelteKit's matched `route.id`, the daemon reports `/proxy/*` for proxied inference, and anything unmatched reports `<unmatched>`. A path matching no route can therefore never mint a new series.
+
+Error rate comes from `status`, so there is no separate errors counter:
+
+```
+sum(rate(http_requests_total{job="xinity-gateway",status=~"[45].."}[5m]))
+  / sum(rate(http_requests_total{job="xinity-gateway"}[5m]))
+```
+
 ### Gateway metrics
 
 | Metric | Type | Labels | Description |
 |---|---|---|---|
-| `gateway_requests_total` | counter | `endpoint`, `status` | Total requests by endpoint and HTTP status |
-| `gateway_request_errors_total` | counter | `endpoint` | Requests with status >= 400 |
-| `gateway_active_requests` | gauge | `endpoint` | In-flight requests |
-| `gateway_request_duration_milliseconds` | histogram | `endpoint` | Request latency |
 | `gateway_time_to_first_token_milliseconds` | histogram | `deployment` | Time to first token (streaming) |
 | `gateway_model_requests_total` | counter | `model`, `status`, `org_id` | Requests per model (success/failure) |
 | `gateway_client_disconnects_total` | counter | `endpoint` | Client disconnections during streaming |
@@ -53,9 +68,7 @@ Load-balancer decision metrics (see [Load Balancing](gateway.md#load-balancing))
 
 ### Dashboard metrics
 
-| Metric | Type | Labels | Description |
-|---|---|---|---|
-| `http_requests_total` | counter | `method`, `route` | Total HTTP requests |
+Only the shared runtime and HTTP metrics above.
 
 ### Tether metrics
 

--- a/flake.lock
+++ b/flake.lock
@@ -63,16 +63,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1773705440,
-        "narHash": "sha256-xB30bbAp0e7ogSEYyc126mAJMt4FRFh8wtm6ADE1xuM=",
+        "lastModified": 1787640266,
+        "narHash": "sha256-MrkfE5hF5xx4L/0h5NyJ3xQkKVftwSuKSkFSrvlTxGY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "48652e9d5aea46e555b3df87354280d4f29cd3a3",
+        "rev": "f4f698677b11021a8f84f452e23ae9ef2427bec3",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "A NixOS service for the xinity-ai-daemon";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-25.11";
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-26.05";
     flake-parts.url = "github:hercules-ci/flake-parts";
     flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
     bun2nix.url = "github:nix-community/bun2nix";

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
       "packages/*"
     ],
     "catalog": {
-      "@types/bun": "^1.3.14",
+      "@types/bun": "^1.4.0",
       "drizzle-orm": "^0.45.2",
       "pino": "^10.3.1",
       "pino-pretty": "^13.1.3",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
       "packages/*"
     ],
     "catalog": {
-      "@types/bun": "^1.4.0",
+      "@types/bun": "^1.4.1",
       "drizzle-orm": "^0.45.2",
       "pino": "^10.3.1",
       "pino-pretty": "^13.1.3",

--- a/packages/common-db/src/connection.ts
+++ b/packages/common-db/src/connection.ts
@@ -1,9 +1,7 @@
-// https://github.com/oven-sh/bun/issues/18214
-
+// postgres.js rather than Bun.SQL, whose pool opens `max` connections on the
+// first query instead of growing with load, so every service would claim its
+// ceiling at startup. Switch once https://github.com/oven-sh/bun/pull/30636 lands.
 import postgres from "postgres";
-// Until further notice we still need an additional pg driver, to allow LISTEN/NOTIFY to work.
-// As soon as this becomes available in the bun PG driver, we should switch to that instead
-// ISSUE: https://github.com/oven-sh/bun/issues/18214
 import { drizzle, type PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import type { Logger } from "drizzle-orm/logger";
 import { sql } from "drizzle-orm";

--- a/packages/common-env/src/http-metrics.ts
+++ b/packages/common-env/src/http-metrics.ts
@@ -1,0 +1,73 @@
+import { createCounter, createGauge, createHistogram, type Labels, type Metric } from "./metrics-format";
+
+/** Seconds, the base unit every off-the-shelf Prometheus rule assumes. */
+const DURATION_BUCKETS = [0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120];
+
+export type HttpLabels = { method: string; route: string };
+
+export type Handler = (req: Request) => Promise<Response> | Response;
+
+export type HttpMetrics = {
+  track<T>(labels: HttpLabels, run: () => T | Promise<T>, statusOf: (result: T) => number): Promise<T>;
+  /** `route` becomes the label, so pass a pattern rather than a concrete path. */
+  route(route: string, handler: Handler): (req: Request) => Promise<Response>;
+  started(labels: HttpLabels): void;
+  finished(labels: HttpLabels, status: number, seconds: number): void;
+  metrics: Metric[];
+};
+
+export function createHttpMetrics(): HttpMetrics {
+  const requestsTotal = createCounter(
+    "http_requests_total",
+    "Total HTTP requests by method, route, and response status.",
+  );
+
+  const inFlight = createGauge(
+    "http_requests_in_flight",
+    "HTTP requests currently being served.",
+  );
+
+  const duration = createHistogram(
+    "http_request_duration_seconds",
+    "HTTP request duration in seconds by method and route.",
+    DURATION_BUCKETS,
+  );
+
+  const started = (labels: HttpLabels): void => {
+    inFlight.inc(labels as Labels);
+  };
+
+  const finished = (labels: HttpLabels, status: number, seconds: number): void => {
+    inFlight.dec(labels as Labels);
+    duration.observe(labels as Labels, seconds);
+    requestsTotal.inc({ ...labels, status: String(status) });
+  };
+
+  const self: HttpMetrics = {
+    started,
+    finished,
+    route(route, handler) {
+      return (req) =>
+        self.track(
+          { method: req.method, route },
+          async () => handler(req),
+          (res) => res.status,
+        );
+    },
+    async track(labels, run, statusOf) {
+      started(labels);
+      const start = performance.now();
+      try {
+        const result = await run();
+        finished(labels, statusOf(result), (performance.now() - start) / 1000);
+        return result;
+      } catch (err) {
+        finished(labels, 500, (performance.now() - start) / 1000);
+        throw err;
+      }
+    },
+    metrics: [requestsTotal, inFlight, duration],
+  };
+
+  return self;
+}

--- a/packages/common-env/src/index.ts
+++ b/packages/common-env/src/index.ts
@@ -165,6 +165,7 @@ export * from "./deployment-settings";
 export * from "./metrics-auth";
 export * from "./metrics-format";
 export * from "./process-metrics";
+export * from "./http-metrics";
 export * from "./service-url";
 export * from "./tether-protocol";
 export * from "./content-hash";

--- a/packages/common-env/src/index.ts
+++ b/packages/common-env/src/index.ts
@@ -164,6 +164,7 @@ export function quoteShellArgv(argv: string[]): string {
 export * from "./deployment-settings";
 export * from "./metrics-auth";
 export * from "./metrics-format";
+export * from "./process-metrics";
 export * from "./service-url";
 export * from "./tether-protocol";
 export * from "./content-hash";

--- a/packages/common-env/src/metrics-format.ts
+++ b/packages/common-env/src/metrics-format.ts
@@ -7,10 +7,14 @@
 
 export type Labels = Record<string, string>;
 
+function escapeLabelValue(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n");
+}
+
 function labelKey(labels: Labels): string {
   return Object.entries(labels)
     .sort(([a], [b]) => a.localeCompare(b))
-    .map(([k, v]) => `${k}="${v}"`)
+    .map(([k, v]) => `${k}="${escapeLabelValue(v)}"`)
     .join(",");
 }
 
@@ -112,8 +116,9 @@ export function createHistogram(name: string, help: string, boundaries: number[]
           lines.push(`${name}_bucket{${prefix}le="${sorted[i]}"} ${cumulative}`);
         }
         lines.push(`${name}_bucket{${prefix}le="+Inf"} ${count}`);
-        lines.push(`${name}_sum{${lk}} ${sum}`);
-        lines.push(`${name}_count{${lk}} ${count}`);
+        const suffix = lk ? `{${lk}}` : "";
+        lines.push(`${name}_sum${suffix} ${sum}`);
+        lines.push(`${name}_count${suffix} ${count}`);
       }
       return lines.join("\n");
     },

--- a/packages/common-env/src/process-metrics.test.ts
+++ b/packages/common-env/src/process-metrics.test.ts
@@ -1,0 +1,73 @@
+import { describe, test, expect } from "bun:test";
+import { createBuildInfo, processMetrics } from "./process-metrics";
+import { serializeMetrics } from "./metrics-format";
+
+function sampleValue(body: string, name: string, labels = ""): number | undefined {
+  const prefix = labels ? `${name}{${labels}} ` : `${name} `;
+  const line = body.split("\n").find((l) => l.startsWith(prefix));
+  return line === undefined ? undefined : Number(line.slice(prefix.length));
+}
+
+describe("processMetrics", () => {
+  test("reports a start time in the past and a plausible resident size", () => {
+    const body = serializeMetrics(processMetrics());
+
+    const start = sampleValue(body, "process_start_time_seconds");
+    expect(start).toBeGreaterThan(1_600_000_000);
+    expect(start).toBeLessThanOrEqual(Date.now() / 1000);
+
+    // A Bun process that has loaded a test runner is never a few kB, and a
+    // reading above a terabyte would mean the units are wrong.
+    const rss = sampleValue(body, "process_resident_memory_bytes");
+    expect(rss).toBeGreaterThan(1_000_000);
+    expect(rss).toBeLessThan(1e12);
+  });
+
+  test("splits CPU time by mode and accumulates across scrapes", () => {
+    const first = serializeMetrics(processMetrics());
+    const user = sampleValue(first, "process_cpu_seconds_total", 'mode="user"');
+    const system = sampleValue(first, "process_cpu_seconds_total", 'mode="system"');
+    expect(user).toBeGreaterThan(0);
+    expect(system).toBeGreaterThanOrEqual(0);
+
+    let spin = 0;
+    for (let i = 0; i < 3_000_000; i++) {
+      spin += i;
+    }
+    expect(spin).toBeGreaterThan(0);
+
+    const second = serializeMetrics(processMetrics());
+    expect(sampleValue(second, "process_cpu_seconds_total", 'mode="user"')).toBeGreaterThan(user!);
+  });
+
+  test("accumulates event loop samples as a cumulative histogram", async () => {
+    processMetrics();
+    await new Promise((resolve) => setTimeout(resolve, 350));
+
+    const body = serializeMetrics(processMetrics());
+    const count = sampleValue(body, "process_event_loop_lag_seconds_count", "");
+    expect(count).toBeGreaterThan(0);
+    expect(sampleValue(body, "process_event_loop_lag_seconds_sum", "")).toBeGreaterThanOrEqual(0);
+  });
+
+  test("reading twice neither loses samples nor changes the answer", async () => {
+    await new Promise((resolve) => setTimeout(resolve, 250));
+
+    const first = serializeMetrics(processMetrics());
+    const second = serializeMetrics(processMetrics());
+
+    const countOf = (body: string) =>
+      sampleValue(body, "process_event_loop_lag_seconds_count", "")!;
+    expect(countOf(first)).toBeGreaterThan(0);
+    expect(countOf(second)).toBeGreaterThanOrEqual(countOf(first));
+  });
+});
+
+describe("createBuildInfo", () => {
+  test("carries its labels on a constant 1 and names the Bun version", () => {
+    const body = serializeMetrics([createBuildInfo("gateway_build_info", { version: "1.2.3" })]);
+
+    expect(body).toContain("# TYPE gateway_build_info gauge");
+    expect(body).toMatch(/gateway_build_info\{bun_version="[^"]+",version="1\.2\.3"\} 1/);
+  });
+});

--- a/packages/common-env/src/process-metrics.ts
+++ b/packages/common-env/src/process-metrics.ts
@@ -1,0 +1,63 @@
+import { createCounter, createGauge, createHistogram, type Labels, type Metric } from "./metrics-format";
+
+const MS_PER_SECOND = 1e3;
+const US_PER_SECOND = 1e6;
+const SAMPLE_INTERVAL_MS = 100;
+const LAG_BUCKETS = [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5];
+
+const startTimeSeconds = Date.now() / 1000;
+
+const eventLoopLag = createHistogram(
+  "process_event_loop_lag_seconds",
+  "Event loop delay, sampled continuously.",
+  LAG_BUCKETS,
+);
+
+let sampler: Timer | undefined;
+
+/** Started on first scrape so linking common-env costs no timer in a process that exports nothing. */
+function startEventLoopSampler(): void {
+  if (sampler) {
+    return;
+  }
+  let expected = performance.now() + SAMPLE_INTERVAL_MS;
+  sampler = setInterval(() => {
+    const now = performance.now();
+    eventLoopLag.observe({}, Math.max(0, now - expected) / MS_PER_SECOND);
+    expected = now + SAMPLE_INTERVAL_MS;
+  }, SAMPLE_INTERVAL_MS);
+  sampler.unref();
+}
+
+export function createBuildInfo(name: string, labels: Labels): Metric {
+  const info = createGauge(name, "Build identity of the running service. The value is always 1.");
+  info.set({ ...labels, bun_version: process.versions.bun ?? "unknown" }, 1);
+  return info;
+}
+
+export function processMetrics(): Metric[] {
+  startEventLoopSampler();
+
+  const cpu = process.cpuUsage();
+
+  const startTime = createGauge(
+    "process_start_time_seconds",
+    "Start time of the process since the unix epoch, in seconds.",
+  );
+  startTime.set({}, startTimeSeconds);
+
+  const cpuSeconds = createCounter(
+    "process_cpu_seconds_total",
+    "Total user and system CPU time spent, in seconds.",
+  );
+  cpuSeconds.inc({ mode: "user" }, cpu.user / US_PER_SECOND);
+  cpuSeconds.inc({ mode: "system" }, cpu.system / US_PER_SECOND);
+
+  const residentMemory = createGauge(
+    "process_resident_memory_bytes",
+    "Resident memory size, in bytes.",
+  );
+  residentMemory.set({}, process.memoryUsage.rss());
+
+  return [startTime, cpuSeconds, residentMemory, eventLoopLag];
+}

--- a/packages/xinity-ai-daemon/src/modules/serverfront/metrics.test.ts
+++ b/packages/xinity-ai-daemon/src/modules/serverfront/metrics.test.ts
@@ -76,7 +76,7 @@ describe("handleDaemonMetrics", () => {
     const res = await handleDaemonMetrics(makeReq());
     expect(res.status).toBe(200);
     const body = await res.text();
-    expect(body).toContain('daemon_up{node_id="test-node-uuid",machine_name="test-machine"} 1');
+    expect(body).toContain('daemon_up{machine_name="test-machine",node_id="test-node-uuid"} 1');
     expect(res.headers.get("content-type")).toContain("text/plain");
   });
 
@@ -89,7 +89,7 @@ describe("handleDaemonMetrics", () => {
     mockSnapshot.mockReturnValue(snapshot([gpu()]));
     const body = await (await handleDaemonMetrics(makeReq())).text();
 
-    const labels = 'node_id="test-node-uuid",machine_name="test-machine",gpu="0",uuid="GPU-aaaa"';
+    const labels = 'gpu="0",machine_name="test-machine",node_id="test-node-uuid",uuid="GPU-aaaa"';
     expect(body).toContain(`daemon_gpu_utilization_percent{${labels}} 73.5`);
     expect(body).toContain(`daemon_gpu_memory_utilization_percent{${labels}} 41`);
     expect(body).toContain(`daemon_gpu_memory_used_mb{${labels}} 32768`);
@@ -99,10 +99,16 @@ describe("handleDaemonMetrics", () => {
     expect(body).toContain(`daemon_gpu_power_limit_watts{${labels}} 700`);
     expect(body).toContain(`daemon_gpu_throttled{${labels}} 0`);
     expect(body).toContain(`daemon_gpu_energy_wh_total{${labels}} 8.12`);
-    expect(body).toContain(`daemon_gpu_info{${labels},name="NVIDIA H100 80GB HBM3",driver_version="560.35.03"} 1`);
-    expect(body).toContain(`daemon_gpu_ecc_errors_total{${labels},type="uncorrected"} 0`);
-    expect(body).toContain(`daemon_gpu_ecc_errors_total{${labels},type="corrected"} 2`);
-    expect(body).toContain('daemon_gpu_sample_failures_total{node_id="test-node-uuid",machine_name="test-machine"} 0');
+    expect(body).toContain(
+      'daemon_gpu_info{driver_version="560.35.03",gpu="0",machine_name="test-machine",name="NVIDIA H100 80GB HBM3",node_id="test-node-uuid",uuid="GPU-aaaa"} 1',
+    );
+    expect(body).toContain(
+      'daemon_gpu_ecc_errors_total{gpu="0",machine_name="test-machine",node_id="test-node-uuid",type="uncorrected",uuid="GPU-aaaa"} 0',
+    );
+    expect(body).toContain(
+      'daemon_gpu_ecc_errors_total{gpu="0",machine_name="test-machine",node_id="test-node-uuid",type="corrected",uuid="GPU-aaaa"} 2',
+    );
+    expect(body).toContain('daemon_gpu_sample_failures_total{machine_name="test-machine",node_id="test-node-uuid"} 0');
   });
 
   test("emits one HELP/TYPE header per family across multiple GPUs", async () => {
@@ -110,8 +116,8 @@ describe("handleDaemonMetrics", () => {
     const body = await (await handleDaemonMetrics(makeReq())).text();
 
     expect(body.match(/# TYPE daemon_gpu_utilization_percent gauge/g)).toHaveLength(1);
-    expect(body).toContain('gpu="0",uuid="GPU-a"');
-    expect(body).toContain('gpu="1",uuid="GPU-b"');
+    expect(body).toContain('gpu="0",machine_name="test-machine",node_id="test-node-uuid",uuid="GPU-a"');
+    expect(body).toContain('gpu="1",machine_name="test-machine",node_id="test-node-uuid",uuid="GPU-b"');
     expect(body).toContain("# TYPE daemon_gpu_energy_wh_total counter");
   });
 
@@ -136,6 +142,6 @@ describe("handleDaemonMetrics", () => {
   test("reports the sample-failure count", async () => {
     mockSnapshot.mockReturnValue(snapshot([], 4));
     const body = await (await handleDaemonMetrics(makeReq())).text();
-    expect(body).toContain('daemon_gpu_sample_failures_total{node_id="test-node-uuid",machine_name="test-machine"} 4');
+    expect(body).toContain('daemon_gpu_sample_failures_total{machine_name="test-machine",node_id="test-node-uuid"} 4');
   });
 });

--- a/packages/xinity-ai-daemon/src/modules/serverfront/metrics.ts
+++ b/packages/xinity-ai-daemon/src/modules/serverfront/metrics.ts
@@ -2,6 +2,7 @@ import {
   createBuildInfo,
   createCounter,
   createGauge,
+  createHttpMetrics,
   createMetricsAuth,
   processMetrics,
   serializeMetrics,
@@ -14,6 +15,8 @@ import { getMetricsSnapshot, type GpuSnapshot } from "../metrics-sampler";
 import { getNodeId, getMachineName } from "../statekeeper";
 
 const metricsAuth = createMetricsAuth(env.METRICS_AUTH);
+
+export const httpMetrics = createHttpMetrics();
 
 /** Round to a fixed precision and drop trailing zeros. */
 function round(value: number, dp: number): number {
@@ -39,7 +42,7 @@ function gpuGauge(
 }
 
 function metricsResponse(metrics: Metric[]): Response {
-  return new Response(serializeMetrics([...metrics, ...processMetrics()]), {
+  return new Response(serializeMetrics([...metrics, ...httpMetrics.metrics, ...processMetrics()]), {
     headers: { "Content-Type": "text/plain; version=0.0.4; charset=utf-8" },
   });
 }

--- a/packages/xinity-ai-daemon/src/modules/serverfront/metrics.ts
+++ b/packages/xinity-ai-daemon/src/modules/serverfront/metrics.ts
@@ -1,24 +1,23 @@
-import { createMetricsAuth } from "common-env";
+import {
+  createBuildInfo,
+  createCounter,
+  createGauge,
+  createMetricsAuth,
+  processMetrics,
+  serializeMetrics,
+  type Labels,
+  type Metric,
+} from "common-env";
+import { version } from "../../../../../package.json";
 import { env } from "../../env";
 import { getMetricsSnapshot, type GpuSnapshot } from "../metrics-sampler";
 import { getNodeId, getMachineName } from "../statekeeper";
 
 const metricsAuth = createMetricsAuth(env.METRICS_AUTH);
 
-/** Escape a Prometheus label value (backslash and double-quote). */
-function esc(value: string): string {
-  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-}
-
 /** Round to a fixed precision and drop trailing zeros. */
 function round(value: number, dp: number): number {
   return Number(value.toFixed(dp));
-}
-
-/** A metric family: one HELP/TYPE header followed by its sample lines, or "" when empty. */
-function family(name: string, help: string, type: "gauge" | "counter", lines: string[]): string {
-  if (lines.length === 0) return "";
-  return [`# HELP ${name} ${help}`, `# TYPE ${name} ${type}`, ...lines].join("\n");
 }
 
 /** A per-GPU gauge that skips GPUs whose value isn't reported. */
@@ -26,15 +25,23 @@ function gpuGauge(
   name: string,
   help: string,
   gpus: GpuSnapshot[],
-  labelsFor: (g: GpuSnapshot) => string,
+  labelsFor: (g: GpuSnapshot) => Labels,
   valueFor: (g: GpuSnapshot) => number | null,
-): string {
-  const lines: string[] = [];
+): Metric {
+  const gauge = createGauge(name, help);
   for (const g of gpus) {
     const value = valueFor(g);
-    if (value !== null) lines.push(`${name}{${labelsFor(g)}} ${value}`);
+    if (value !== null) {
+      gauge.set(labelsFor(g), value);
+    }
   }
-  return family(name, help, "gauge", lines);
+  return gauge;
+}
+
+function metricsResponse(metrics: Metric[]): Response {
+  return new Response(serializeMetrics([...metrics, ...processMetrics()]), {
+    headers: { "Content-Type": "text/plain; version=0.0.4; charset=utf-8" },
+  });
 }
 
 export async function handleDaemonMetrics(req: Request): Promise<Response> {
@@ -43,62 +50,76 @@ export async function handleDaemonMetrics(req: Request): Promise<Response> {
   }
 
   const authErr = metricsAuth.unauthorized(req.headers.get("authorization"));
-  if (authErr) return authErr;
-
-  const node = `node_id="${esc(await getNodeId())}",machine_name="${esc(getMachineName())}"`;
-
-  const snapshot = getMetricsSnapshot();
-
-  const blocks: string[] = [
-    family("daemon_up", "1 when the daemon process is running.", "gauge", [`daemon_up{${node}} 1`]),
-  ];
-
-  if (snapshot !== null) {
-    blocks.push(family(
-      "daemon_gpu_sample_failures_total",
-      "GPU telemetry polls that returned no usable data since daemon start.",
-      "counter",
-      [`daemon_gpu_sample_failures_total{${node}} ${snapshot.sampleFailures}`],
-    ));
-
-    const gpus = snapshot.gpus;
-    const labels = (g: GpuSnapshot) => `${node},gpu="${g.index}",uuid="${esc(g.uuid)}"`;
-
-    blocks.push(
-      family("daemon_gpu_info", "GPU identity; value is always 1.", "gauge",
-        gpus.map((g) => `daemon_gpu_info{${labels(g)},name="${esc(g.name)}",driver_version="${esc(g.driverVersion ?? "")}"} 1`)),
-
-      gpuGauge("daemon_gpu_utilization_percent", "GPU compute utilization (0-100).",
-        gpus, labels, (g) => round(g.utilizationPct, 2)),
-      gpuGauge("daemon_gpu_memory_utilization_percent", "GPU memory-controller utilization (0-100).",
-        gpus, labels, (g) => (g.memoryUtilizationPct === null ? null : round(g.memoryUtilizationPct, 2))),
-      gpuGauge("daemon_gpu_memory_used_mb", "GPU memory in use (MiB).",
-        gpus, labels, (g) => g.memoryUsedMb),
-      gpuGauge("daemon_gpu_memory_total_mb", "Total GPU memory (MiB).",
-        gpus, labels, (g) => g.memoryTotalMb),
-      gpuGauge("daemon_gpu_temperature_celsius", "GPU core temperature (°C).",
-        gpus, labels, (g) => g.temperatureC),
-      gpuGauge("daemon_gpu_power_draw_watts", "Measured GPU power draw (W).",
-        gpus, labels, (g) => (g.powerWatts === null ? null : round(g.powerWatts, 2))),
-      gpuGauge("daemon_gpu_power_limit_watts", "GPU power limit (W).",
-        gpus, labels, (g) => (g.powerLimitWatts === null ? null : round(g.powerLimitWatts, 2))),
-      gpuGauge("daemon_gpu_throttled", "1 when the GPU is currently throttling clocks.",
-        gpus, labels, (g) => (g.throttled === null ? null : g.throttled ? 1 : 0)),
-
-      family("daemon_gpu_ecc_errors_total", "GPU ECC error count by type.", "counter", [
-        ...gpus.filter((g) => g.eccUncorrected !== null)
-          .map((g) => `daemon_gpu_ecc_errors_total{${labels(g)},type="uncorrected"} ${g.eccUncorrected}`),
-        ...gpus.filter((g) => g.eccCorrected !== null)
-          .map((g) => `daemon_gpu_ecc_errors_total{${labels(g)},type="corrected"} ${g.eccCorrected}`),
-      ]),
-
-      family("daemon_gpu_energy_wh_total", "GPU energy consumed since daemon start (Wh).", "counter",
-        gpus.map((g) => `daemon_gpu_energy_wh_total{${labels(g)}} ${round(g.energyWh, 4)}`)),
-    );
+  if (authErr) {
+    return authErr;
   }
 
-  const body = blocks.filter(Boolean).join("\n\n") + "\n";
-  return new Response(body, {
-    headers: { "Content-Type": "text/plain; version=0.0.4; charset=utf-8" },
-  });
+  const node: Labels = { node_id: await getNodeId(), machine_name: getMachineName() };
+
+  const up = createGauge("daemon_up", "1 when the daemon process is running.");
+  up.set(node, 1);
+
+  const buildInfo = createBuildInfo("daemon_build_info", { ...node, version });
+
+  const snapshot = getMetricsSnapshot();
+  if (snapshot === null) {
+    return metricsResponse([up, buildInfo]);
+  }
+
+  const sampleFailures = createCounter(
+    "daemon_gpu_sample_failures_total",
+    "GPU telemetry polls that returned no usable data since daemon start.",
+  );
+  sampleFailures.inc(node, snapshot.sampleFailures);
+
+  const gpus = snapshot.gpus;
+  const labels = (g: GpuSnapshot): Labels => ({ ...node, gpu: String(g.index), uuid: g.uuid });
+
+  const info = createGauge("daemon_gpu_info", "GPU identity. The value is always 1.");
+  for (const g of gpus) {
+    info.set({ ...labels(g), name: g.name, driver_version: g.driverVersion ?? "" }, 1);
+  }
+
+  const eccErrors = createCounter("daemon_gpu_ecc_errors_total", "GPU ECC error count by type.");
+  for (const g of gpus) {
+    if (g.eccUncorrected !== null) {
+      eccErrors.inc({ ...labels(g), type: "uncorrected" }, g.eccUncorrected);
+    }
+    if (g.eccCorrected !== null) {
+      eccErrors.inc({ ...labels(g), type: "corrected" }, g.eccCorrected);
+    }
+  }
+
+  const energy = createCounter(
+    "daemon_gpu_energy_wh_total",
+    "GPU energy consumed since daemon start (Wh).",
+  );
+  for (const g of gpus) {
+    energy.inc(labels(g), round(g.energyWh, 4));
+  }
+
+  return metricsResponse([
+    up,
+    buildInfo,
+    sampleFailures,
+    info,
+    gpuGauge("daemon_gpu_utilization_percent", "GPU compute utilization (0-100).",
+      gpus, labels, (g) => round(g.utilizationPct, 2)),
+    gpuGauge("daemon_gpu_memory_utilization_percent", "GPU memory-controller utilization (0-100).",
+      gpus, labels, (g) => (g.memoryUtilizationPct === null ? null : round(g.memoryUtilizationPct, 2))),
+    gpuGauge("daemon_gpu_memory_used_mb", "GPU memory in use (MiB).",
+      gpus, labels, (g) => g.memoryUsedMb),
+    gpuGauge("daemon_gpu_memory_total_mb", "Total GPU memory (MiB).",
+      gpus, labels, (g) => g.memoryTotalMb),
+    gpuGauge("daemon_gpu_temperature_celsius", "GPU core temperature (°C).",
+      gpus, labels, (g) => g.temperatureC),
+    gpuGauge("daemon_gpu_power_draw_watts", "Measured GPU power draw (W).",
+      gpus, labels, (g) => (g.powerWatts === null ? null : round(g.powerWatts, 2))),
+    gpuGauge("daemon_gpu_power_limit_watts", "GPU power limit (W).",
+      gpus, labels, (g) => (g.powerLimitWatts === null ? null : round(g.powerLimitWatts, 2))),
+    gpuGauge("daemon_gpu_throttled", "1 when the GPU is currently throttling clocks.",
+      gpus, labels, (g) => (g.throttled === null ? null : g.throttled ? 1 : 0)),
+    eccErrors,
+    energy,
+  ]);
 }

--- a/packages/xinity-ai-daemon/src/modules/serverfront/webserver.ts
+++ b/packages/xinity-ai-daemon/src/modules/serverfront/webserver.ts
@@ -5,7 +5,7 @@ import { env } from "../../env";
 import { rootLogger } from "../../logger";
 import { createOpenapiSpec, createScalarPage } from "./openai";
 import { handleProxyRequest } from "./proxy";
-import { handleDaemonMetrics } from "./metrics";
+import { handleDaemonMetrics, httpMetrics } from "./metrics";
 
 export async function startServer() {
   const handler = new OpenAPIHandler(router, {
@@ -19,28 +19,26 @@ export async function startServer() {
     tls,
     idleTimeout: env.IDLE_TIMEOUT,
     routes: {
-      "/": () => createScalarPage(),
-      "/openapi.json": () => Response.json(spec),
+      "/": httpMetrics.route("/", () => createScalarPage()),
+      "/openapi.json": httpMetrics.route("/openapi.json", () => Response.json(spec)),
     },
     async fetch(req: Request) {
       const url = new URL(req.url);
       if (url.pathname === "/metrics") {
         return handleDaemonMetrics(req);
       }
+      // The proxy path carries a model name, so it is labelled by pattern.
       if (url.pathname.startsWith("/proxy/")) {
-        return handleProxyRequest(req, url);
+        return httpMetrics.route("/proxy/*", (r) => handleProxyRequest(r, url))(req);
       }
 
-      const { matched, response } = await handler.handle(req, {
-        prefix: "/",
-        context: { headers: req.headers },
-      });
-
-      if (matched) {
-        return response;
-      }
-
-      return new Response("Not found", { status: 404 });
+      return httpMetrics.route("/rpc", async (r) => {
+        const { matched, response } = await handler.handle(r, {
+          prefix: "/",
+          context: { headers: r.headers },
+        });
+        return matched ? response : new Response("Not found", { status: 404 });
+      })(req);
     },
   } as const;
 

--- a/packages/xinity-ai-dashboard/CLAUDE.md
+++ b/packages/xinity-ai-dashboard/CLAUDE.md
@@ -69,7 +69,7 @@ All server-only modules are in `src/lib/server/`:
 - `auth-server.ts`, Better Auth configuration
 - `email.ts`, nodemailer + MJML (Svelte component templates in `src/lib/components/mailTemplates/`)
 - `logging.ts`, Pino logger (browser logs POST to `/log`)
-- `metrics.ts`, Prometheus via prom-client (exposed at `/metrics`)
+- `metrics.ts`, Prometheus via `common-env` metric primitives (exposed at `/metrics`)
 - `serverenv.ts`, parses `env-schema.ts`'s Zod schema into the typed `serverEnv`
 
 ### Path Aliases

--- a/packages/xinity-ai-dashboard/Dockerfile
+++ b/packages/xinity-ai-dashboard/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG BUN_VERSION=1.4.0
+ARG BUN_VERSION=1.4.2
 
 # ---------- base (shared manifest layer) ----------
 # All workspace package.jsons must be present for bun install to resolve the lockfile.

--- a/packages/xinity-ai-dashboard/Dockerfile
+++ b/packages/xinity-ai-dashboard/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG BUN_VERSION=1.3.1
+ARG BUN_VERSION=1.4.0
 
 # ---------- base (shared manifest layer) ----------
 # All workspace package.jsons must be present for bun install to resolve the lockfile.

--- a/packages/xinity-ai-dashboard/README.md
+++ b/packages/xinity-ai-dashboard/README.md
@@ -17,7 +17,7 @@ SvelteKit admin dashboard for Xinity AI. Built with Vite + Bun, Tailwind CSS, an
 - ORPC client/server utilities (`src/lib/orpc`)
 - Auth helpers built on better-auth (`src/lib/auth.ts`, `src/lib/server/auth-server.ts`)
 - Email support via nodemailer + MJML (`src/lib/server/email.ts`)
-- Metrics via prom-client (`src/lib/server/metrics.ts`)
+- Metrics via `common-env` metric primitives (`src/lib/server/metrics.ts`)
 
 ## Development
 

--- a/packages/xinity-ai-dashboard/package.json
+++ b/packages/xinity-ai-dashboard/package.json
@@ -61,7 +61,6 @@
 		"mjml": "^5.2.1",
 		"nodemailer": "^9.0.5",
 		"pino": "catalog:",
-		"prom-client": "^15.1.3",
 		"uqr": "^0.1.3"
 	}
 }

--- a/packages/xinity-ai-dashboard/src/hooks.server.ts
+++ b/packages/xinity-ai-dashboard/src/hooks.server.ts
@@ -4,7 +4,7 @@ import type { Handle, HandleServerError } from "@sveltejs/kit";
 import { redirect } from "@sveltejs/kit";
 import { sequence } from "@sveltejs/kit/hooks";
 import { rootLogger } from "$lib/server/logging";
-import { httpRequestCountMetric } from "$lib/server/metrics";
+import { httpMetrics } from "$lib/server/metrics";
 import { auth } from "$lib/server/auth-server";
 import { svelteKitHandler } from "better-auth/svelte-kit";
 import { building } from "$app/environment";
@@ -90,14 +90,10 @@ const handleAuth: Handle = ({ event, resolve }) => {
   return svelteKitHandler({ event, resolve, auth, building });
 };
 
-const UUID_IN_PATH = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/g;
-
+/** `route.id`, not `url.pathname`: an unbounded label mints a series per stray URL. */
 const recordRequestMetric: Handle = ({ event, resolve }) => {
-  httpRequestCountMetric.inc({
-    method: event.request.method,
-    route: event.url.pathname.replace(UUID_IN_PATH, "[uuid]"),
-  });
-  return resolve(event);
+  const labels = { method: event.request.method, route: event.route.id ?? "<unmatched>" };
+  return httpMetrics.track(labels, () => resolve(event), (res) => res.status);
 };
 
 /**

--- a/packages/xinity-ai-dashboard/src/lib/server/audit/audit-forwarder.test.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/audit/audit-forwarder.test.ts
@@ -1,15 +1,17 @@
-import { describe, test, expect, beforeEach, mock } from "bun:test";
+import { describe, test, expect, beforeEach, afterAll, spyOn } from "bun:test";
 import type { AuditEvent } from "common-db";
-import type { AuditDelivery } from "./audit-loki";
+import * as auditLoki from "./audit-loki";
 
-mock.module("$lib/server/logging", () => ({
-  rootLogger: { child: () => ({ info: () => {}, warn: () => {}, error: () => {} }) },
-}));
+/**
+ * A spy rather than `mock.module`, which has no counterpart to undo it: the
+ * override would outlive this file and hand `audit-loki.test.ts` the stub in
+ * place of the module it exists to test.
+ */
+const deliverAuditEvents = spyOn(auditLoki, "deliverAuditEvents");
 
-const deliverAuditEvents = mock((_events: AuditEvent[], _target: unknown): Promise<AuditDelivery> =>
-  Promise.resolve({ delivered: true }),
-);
-mock.module("./audit-loki", () => ({ deliverAuditEvents }));
+afterAll(() => {
+  deliverAuditEvents.mockRestore();
+});
 
 const { lokiTargetFromEnv, forwardAuditEvent, flushAuditEvents } = await import("./audit-forwarder");
 

--- a/packages/xinity-ai-dashboard/src/lib/server/audit/audit-loki.test.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/audit/audit-loki.test.ts
@@ -1,6 +1,12 @@
-import { describe, test, expect, mock } from "bun:test";
+import { describe, test, expect, afterEach, mock } from "bun:test";
 import type { AuditEvent } from "common-db";
 import { buildPushPayload, deliverAuditEvents } from "./audit-loki";
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
 
 const event: AuditEvent = {
   id: "3f1d1c2e-0000-4000-8000-000000000001",

--- a/packages/xinity-ai-dashboard/src/lib/server/license/license.test.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/license/license.test.ts
@@ -1,5 +1,6 @@
-import { describe, test, expect, beforeEach, mock } from "bun:test";
+import { describe, test, expect, beforeEach, afterAll, mock, spyOn } from "bun:test";
 import crypto from "node:crypto";
+import * as deploymentId from "$lib/server/deployment-id";
 
 // Generate a dedicated test key pair independent of the production key.
 const testKeyPair = crypto.generateKeyPairSync("ed25519");
@@ -7,23 +8,22 @@ const testPublicKeyBase64 = testKeyPair.publicKey
   .export({ type: "spki", format: "der" })
   .toString("base64");
 
-// Mock the public key module so parseLicense verifies against our test key.
+/**
+ * The only export is a string constant, so there is nothing to spy on. Contained
+ * because license.ts is the sole importer and this suite is its sole loader.
+ */
 mock.module("./public-key", () => ({
   PUBLIC_KEY_BASE64: testPublicKeyBase64,
 }));
 
 // serverEnv is mocked for all suites in tests/preload.ts. Each block sets what it needs.
 
-// Mock logger to suppress output during tests.
-mock.module("$lib/server/logging", () => ({
-  rootLogger: { child: () => ({ info: () => {}, warn: () => {}, error: () => {} }) },
-}));
-
-// Mock the deployment-id module so we can control the local instance ID.
 const deploymentIdMock = { id: null as string | null };
-mock.module("$lib/server/deployment-id", () => ({
-  getDeploymentId: () => deploymentIdMock.id,
-}));
+const getDeploymentId = spyOn(deploymentId, "getDeploymentId").mockImplementation(() => deploymentIdMock.id);
+
+afterAll(() => {
+  getDeploymentId.mockRestore();
+});
 
 // Now import the module under test (after mocks are in place).
 const { parseLicense, resetLicenseCache, isLicenseEffective, hasFeature, maxVramGb, tierName, licenseeName, isExpired, isInGracePeriod, hasOriginMismatch, hasInstanceMismatch, getLicenseSummary } = await import("./license");

--- a/packages/xinity-ai-dashboard/src/lib/server/metrics.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/metrics.ts
@@ -1,6 +1,6 @@
 import {
   createBuildInfo,
-  createCounter,
+  createHttpMetrics,
   createMetricsAuth,
   processMetrics,
   serializeMetrics,
@@ -14,13 +14,10 @@ export function isMetricsAuthorized(request: Request): boolean {
   return metricsAuth.isAuthorized(request.headers.get("authorization"));
 }
 
-export const httpRequestCountMetric = createCounter(
-  "http_requests_total",
-  "Total number of HTTP requests",
-);
+export const httpMetrics = createHttpMetrics();
 
 const buildInfo = createBuildInfo("dashboard_build_info", { version });
 
 export function renderMetrics(): string {
-  return serializeMetrics([buildInfo, httpRequestCountMetric, ...processMetrics()]);
+  return serializeMetrics([buildInfo, ...httpMetrics.metrics, ...processMetrics()]);
 }

--- a/packages/xinity-ai-dashboard/src/lib/server/metrics.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/metrics.ts
@@ -1,9 +1,11 @@
-/**
- * Prometheus metrics registry and common counters.
- * Imported by server hooks/routes that report request activity.
- */
-import * as promClient from "prom-client";
-import { createMetricsAuth } from "common-env";
+import {
+  createBuildInfo,
+  createCounter,
+  createMetricsAuth,
+  processMetrics,
+  serializeMetrics,
+} from "common-env";
+import { version } from "../../../../../package.json";
 import { serverEnv } from "$lib/server/serverenv";
 
 const metricsAuth = createMetricsAuth(serverEnv.METRICS_AUTH);
@@ -12,16 +14,13 @@ export function isMetricsAuthorized(request: Request): boolean {
   return metricsAuth.isAuthorized(request.headers.get("authorization"));
 }
 
-export const metricRegister = new promClient.Registry();
+export const httpRequestCountMetric = createCounter(
+  "http_requests_total",
+  "Total number of HTTP requests",
+);
 
-/**
- * Global HTTP request counter labeled by method and normalized route.
- */
-export const httpRequestCountMetric = new promClient.Counter({
-  name: "http_requests_total",
-  help: "Total number of HTTP requests",
-  labelNames: ["method", "route"] as const,
-  registers: [metricRegister],
-});
+const buildInfo = createBuildInfo("dashboard_build_info", { version });
 
-promClient.collectDefaultMetrics({ register: metricRegister });
+export function renderMetrics(): string {
+  return serializeMetrics([buildInfo, httpRequestCountMetric, ...processMetrics()]);
+}

--- a/packages/xinity-ai-dashboard/src/lib/server/notifications/scheduler.test.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/notifications/scheduler.test.ts
@@ -1,9 +1,4 @@
-import { describe, test, expect, mock } from "bun:test";
-
-mock.module("$lib/server/logging", () => ({
-  rootLogger: { child: () => ({ info: () => {}, warn: () => {}, error: () => {} }) },
-}));
-mock.module("$lib/server/db", () => ({ getDB: () => { throw new Error("db unused in these tests"); } }));
+import { describe, test, expect } from "bun:test";
 
 const { foldDeploymentPhaseRows } = await import("./scheduler");
 type Row = Parameters<typeof foldDeploymentPhaseRows>[0][number];

--- a/packages/xinity-ai-dashboard/src/lib/server/orpc/audit.test.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/orpc/audit.test.ts
@@ -1,22 +1,26 @@
-import { describe, test, expect, beforeEach, mock } from "bun:test";
+import { describe, test, expect, beforeEach, afterAll, mock } from "bun:test";
 import type { AuditContext, AuditTag } from "./audit";
 
 const insertValues = mock((row: unknown) => ({
   returning: () => Promise.resolve([{ id: "audit-event-id", createdAt: new Date(), ...(row as object) }]),
 }));
-mock.module("$lib/server/db", () => ({
-  getDB: () => ({ insert: () => ({ values: insertValues }) }),
-}));
 
-mock.module("$lib/server/logging", () => ({
-  rootLogger: { child: () => ({ info: () => {}, warn: () => {}, error: () => {} }) },
-}));
-
+/** Importing the real module boots Better Auth against a live database. */
 mock.module("$lib/server/auth-server", () => ({
   auth: { api: {} },
 }));
 
-// serverEnv and isInstanceAdmin are mocked for all suites in tests/preload.ts.
+// serverEnv, isInstanceAdmin, logging and db are mocked for all suites in tests/preload.ts.
+
+const { dbHandle } = require("$lib/server/db") as { dbHandle: { getDB: () => unknown; reset: () => void } };
+
+beforeEach(() => {
+  dbHandle.getDB = () => ({ insert: () => ({ values: insertValues }) });
+});
+
+afterAll(() => {
+  dbHandle.reset();
+});
 
 const { runWithAudit, emitAuthAuditEvent } = await import("./audit");
 const { rootOs, auditMiddleware } = await import("./root");

--- a/packages/xinity-ai-dashboard/src/lib/server/shutdown.test.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/shutdown.test.ts
@@ -1,8 +1,4 @@
-import { describe, test, expect, beforeEach, mock } from "bun:test";
-
-mock.module("$lib/server/logging", () => ({
-  rootLogger: { child: () => ({ info: () => {}, warn: () => {}, error: () => {} }) },
-}));
+import { describe, test, expect, beforeEach } from "bun:test";
 
 const { onShutdown, runShutdownTasks, resetShutdownTasks } = await import("./shutdown");
 

--- a/packages/xinity-ai-dashboard/src/routes/metrics/+server.ts
+++ b/packages/xinity-ai-dashboard/src/routes/metrics/+server.ts
@@ -1,17 +1,12 @@
-/**
- * Prometheus metrics endpoint with optional basic auth.
- */
 import type { RequestHandler } from "./$types";
-import { metricRegister, isMetricsAuthorized } from "$lib/server/metrics";
+import { renderMetrics, isMetricsAuthorized } from "$lib/server/metrics";
 import { error } from "@sveltejs/kit";
 
-/** Serves metrics in Prometheus text format. */
-export const GET: RequestHandler = async ({ request }) => {
+export const GET: RequestHandler = ({ request }) => {
   if (!isMetricsAuthorized(request)) {
     error(401);
   }
-  const metrics = await metricRegister.metrics();
-  return new Response(metrics, {
-    headers: { "Content-Type": metricRegister.contentType },
+  return new Response(renderMetrics(), {
+    headers: { "Content-Type": "text/plain; version=0.0.4; charset=utf-8" },
   });
 };

--- a/packages/xinity-ai-dashboard/tests/preload.ts
+++ b/packages/xinity-ai-dashboard/tests/preload.ts
@@ -33,3 +33,28 @@ mock.module("$lib/server/license", () => ({
   getLicenseSummary: () => ({ tier: "free", licensee: null, features: {} }),
   licensedFeatures,
 }));
+
+mock.module("$lib/server/logging", () => ({
+  rootLogger: { child: () => ({ info: () => {}, warn: () => {}, error: () => {} }) },
+}));
+
+/**
+ * Importing the real module opens a connection pool, so the double lives here.
+ * Suites that need rows assign `dbHandle.getDB` and call `dbHandle.reset` when
+ * done, which keeps one file's stub from standing in for another's.
+ */
+const rejectDBUse = () => {
+  throw new Error("no database under the test preload: assign dbHandle.getDB in the suite that needs one");
+};
+
+const dbHandle: { getDB: () => unknown; reset: () => void } = {
+  getDB: rejectDBUse,
+  reset: () => {
+    dbHandle.getDB = rejectDBUse;
+  },
+};
+
+mock.module("$lib/server/db", () => ({
+  getDB: () => dbHandle.getDB(),
+  dbHandle,
+}));

--- a/packages/xinity-ai-gateway/Dockerfile
+++ b/packages/xinity-ai-gateway/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG BUN_VERSION=1.4.0
+ARG BUN_VERSION=1.4.2
 
 # ---------- base (shared manifest layer) ----------
 # All workspace package.jsons must be present for bun install to resolve the lockfile.

--- a/packages/xinity-ai-gateway/Dockerfile
+++ b/packages/xinity-ai-gateway/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG BUN_VERSION=1.3.1
+ARG BUN_VERSION=1.4.0
 
 # ---------- base (shared manifest layer) ----------
 # All workspace package.jsons must be present for bun install to resolve the lockfile.

--- a/packages/xinity-ai-gateway/src/metrics.ts
+++ b/packages/xinity-ai-gateway/src/metrics.ts
@@ -3,6 +3,7 @@ import {
   createCounter,
   createGauge,
   createHistogram,
+  createHttpMetrics,
   createMetricsAuth,
   processMetrics,
   serializeMetrics,
@@ -15,28 +16,7 @@ import { rootLogger } from "./logger";
 
 const metricsAuth = createMetricsAuth(env.METRICS_AUTH);
 
-export const requestsTotal = createCounter(
-  "gateway_requests_total",
-  "Total HTTP requests by endpoint and status code",
-);
-
-export const requestErrorsTotal = createCounter(
-  "gateway_request_errors_total",
-  "Total failed requests by endpoint",
-);
-
-export const activeRequests = createGauge(
-  "gateway_active_requests",
-  "Currently in-flight requests by endpoint",
-);
-
-const DURATION_BUCKETS = [50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000, 60000, 120000];
-
-export const requestDuration = createHistogram(
-  "gateway_request_duration_milliseconds",
-  "Request duration in milliseconds by endpoint",
-  DURATION_BUCKETS,
-);
+const http = createHttpMetrics();
 
 const TTFT_BUCKETS = [50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000];
 
@@ -130,10 +110,7 @@ const buildInfo = createBuildInfo("gateway_build_info", { version });
 
 const allMetrics = [
   buildInfo,
-  requestsTotal,
-  requestErrorsTotal,
-  activeRequests,
-  requestDuration,
+  ...http.metrics,
   timeToFirstToken,
   modelRequestsTotal,
   clientDisconnectsTotal,
@@ -230,12 +207,13 @@ export function withMetrics(
 ): (req: Request) => Promise<Response> {
   return async (req: Request) => {
     const labels = { endpoint };
-    activeRequests.inc(labels);
-    const start = Date.now();
+    const httpLabels = { method: req.method, route: endpoint };
+    http.started(httpLabels);
+    const start = performance.now();
 
+    let status = 500;
     const cleanup = () => {
-      activeRequests.dec(labels);
-      requestDuration.observe(labels, Date.now() - start);
+      http.finished(httpLabels, status, (performance.now() - start) / 1000);
       releaseCallbacks.get(req)?.();
       releaseCallbacks.delete(req);
     };
@@ -243,8 +221,7 @@ export function withMetrics(
     let deferred = false;
     try {
       const res = await handler(req);
-      requestsTotal.inc({ endpoint, status: String(res.status) });
-      if (res.status >= 400) requestErrorsTotal.inc(labels);
+      status = res.status;
       if (res.status === 499) clientDisconnectsTotal.inc(labels);
 
       // For streaming responses, defer cleanup until the stream finishes
@@ -267,10 +244,6 @@ export function withMetrics(
       }
 
       return res;
-    } catch (err) {
-      requestErrorsTotal.inc(labels);
-      requestsTotal.inc({ endpoint, status: "500" });
-      throw err;
     } finally {
       if (!deferred) cleanup();
     }

--- a/packages/xinity-ai-gateway/src/metrics.ts
+++ b/packages/xinity-ai-gateway/src/metrics.ts
@@ -1,4 +1,13 @@
-import { createCounter, createGauge, createHistogram, createMetricsAuth, serializeMetrics } from "common-env";
+import {
+  createBuildInfo,
+  createCounter,
+  createGauge,
+  createHistogram,
+  createMetricsAuth,
+  processMetrics,
+  serializeMetrics,
+} from "common-env";
+import { version } from "../../../package.json";
 import { env } from "./env";
 import { releaseCallbacks } from "./llm-forward/release-registry";
 import { isAbortError } from "./llm-forward/util";
@@ -117,7 +126,10 @@ export const lbRedisFallbackTotal = createCounter(
   "Total load-balancer Redis failures that fell back to random selection, by strategy",
 );
 
+const buildInfo = createBuildInfo("gateway_build_info", { version });
+
 const allMetrics = [
+  buildInfo,
   requestsTotal,
   requestErrorsTotal,
   activeRequests,
@@ -269,7 +281,7 @@ export function handleMetrics(req: Request): Response {
   const authErr = metricsAuth.unauthorized(req.headers.get("authorization"));
   if (authErr) return authErr;
 
-  return new Response(serializeMetrics(allMetrics), {
+  return new Response(serializeMetrics([...allMetrics, ...processMetrics()]), {
     headers: { "Content-Type": "text/plain; version=0.0.4; charset=utf-8" },
   });
 }

--- a/packages/xinity-infoserver/Dockerfile
+++ b/packages/xinity-infoserver/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG BUN_VERSION=1.4.0
+ARG BUN_VERSION=1.4.2
 
 # ---------- base (shared manifest layer) ----------
 # All workspace package.jsons must be present for bun install to resolve the lockfile.

--- a/packages/xinity-infoserver/Dockerfile
+++ b/packages/xinity-infoserver/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG BUN_VERSION=1.3.1
+ARG BUN_VERSION=1.4.0
 
 # ---------- base (shared manifest layer) ----------
 # All workspace package.jsons must be present for bun install to resolve the lockfile.

--- a/packages/xinity-tether/src/index.ts
+++ b/packages/xinity-tether/src/index.ts
@@ -10,7 +10,7 @@ import { addConnection, removeConnection, pushDesiredState, runKeepaliveLoop, se
 import { buildDesiredState } from "./desired-state";
 import { createNotifyBus } from "./notify-bus";
 import { writeRegistration, queueInstallationStates, flushAndStop } from "./status-writer";
-import { handleMetrics, incRequestRejections } from "./metrics";
+import { handleMetrics, httpMetrics, incRequestRejections } from "./metrics";
 import { buildListenTarget } from "./serve-config";
 
 const log = rootLogger;
@@ -139,14 +139,12 @@ const server = Bun.serve({
   ...serveTarget,
   tls,
   routes: {
-    "/health": () => Response.json({ ok: true }),
+    "/health": httpMetrics.route("/health", () => Response.json({ ok: true })),
     "/metrics": handleMetrics,
-    "/api/v1/stream": handleSSEStream,
-    "/api/v1/status": handleStatus,
+    "/api/v1/stream": httpMetrics.route("/api/v1/stream", handleSSEStream),
+    "/api/v1/status": httpMetrics.route("/api/v1/status", handleStatus),
   },
-  fetch() {
-    return new Response("Not Found", { status: 404 });
-  },
+  fetch: httpMetrics.route("<unmatched>", () => new Response("Not Found", { status: 404 })),
 });
 
 log.info({ ...serveTarget, tls: !!tls }, `Tether started (${tls ? "https" : "http"})`);

--- a/packages/xinity-tether/src/metrics.ts
+++ b/packages/xinity-tether/src/metrics.ts
@@ -3,6 +3,7 @@ import {
   createCounter,
   createGauge,
   createHistogram,
+  createHttpMetrics,
   createMetricsAuth,
   processMetrics,
   serializeMetrics,
@@ -87,7 +88,10 @@ desiredStatePushesTotal.inc({}, 0);
 
 const buildInfo = createBuildInfo("tether_build_info", { version });
 
+export const httpMetrics = createHttpMetrics();
+
 const allMetrics = [
+  ...httpMetrics.metrics,
   buildInfo,
   connectedNodes,
   sseConnectionsTotal,

--- a/packages/xinity-tether/src/metrics.ts
+++ b/packages/xinity-tether/src/metrics.ts
@@ -1,4 +1,13 @@
-import { createCounter, createGauge, createHistogram, createMetricsAuth, serializeMetrics } from "common-env";
+import {
+  createBuildInfo,
+  createCounter,
+  createGauge,
+  createHistogram,
+  createMetricsAuth,
+  processMetrics,
+  serializeMetrics,
+} from "common-env";
+import { version } from "../../../package.json";
 import { env } from "./env";
 
 const metricsAuth = createMetricsAuth(env.METRICS_AUTH);
@@ -76,7 +85,10 @@ connectedNodes.set({}, 0);
 sseConnectionsTotal.inc({}, 0);
 desiredStatePushesTotal.inc({}, 0);
 
+const buildInfo = createBuildInfo("tether_build_info", { version });
+
 const allMetrics = [
+  buildInfo,
   connectedNodes,
   sseConnectionsTotal,
   connectionDuration,
@@ -94,7 +106,7 @@ export function handleMetrics(req: Request): Response {
     return authErr;
   }
 
-  return new Response(serializeMetrics(allMetrics), {
+  return new Response(serializeMetrics([...allMetrics, ...processMetrics()]), {
     headers: { "Content-Type": "text/plain; version=0.0.4; charset=utf-8" },
   });
 }

--- a/tests/system/gateway/gateway-test-helpers.ts
+++ b/tests/system/gateway/gateway-test-helpers.ts
@@ -119,8 +119,14 @@ export async function stopGateway(): Promise<void> {
   }
   const exited = gatewayProcess.exited;
   gatewayProcess.kill();
-  const timeout = Bun.sleep(2000)
-  await Promise.race([exited.then(() => undefined), timeout]);
+  const timedOut = await Promise.race([
+    exited.then(() => false),
+    Bun.sleep(2000).then(() => true),
+  ]);
+  if (timedOut) {
+    gatewayProcess.kill("SIGKILL");
+    await exited;
+  }
   gatewayProcess = null;
   gatewayReady = null;
 }

--- a/tests/system/preload.ts
+++ b/tests/system/preload.ts
@@ -1,0 +1,13 @@
+import { afterAll } from "bun:test";
+import { stopGateway } from "./gateway/gateway-test-helpers";
+import { stopInfoServer } from "./infoserver/infoserver-test-helpers";
+
+/**
+ * The gateway and info server are shared across test files, so no single file's
+ * `afterAll` owns them: whichever runs last would decide whether they survive
+ * the run. A preload hook is scoped to the whole run, so this always happens.
+ */
+afterAll(async () => {
+  await stopGateway();
+  await stopInfoServer();
+});


### PR DESCRIPTION
## Description

This PR finishes the metrics consolidation started with `common-env`, and bumps Bun to 1.4.2.

The dashboard was still using `prom-client` and the daemon still assembled exposition format by hand, so both now use the shared primitives and `prom-client` is removed. All four services that expose `/metrics` gain a common runtime set covering CPU, resident memory, start time, event loop lag and `build_info`, along with a common HTTP set that replaces four divergent ones. A single alert rule set now covers the fleet rather than one per service. The daemon previously reported no request metrics at all, and tether reported only the requests it refused.

There are some breaking changes with limited surface. The gateway's four request metrics are renamed to their `http_*` equivalents, and its duration histogram now measures seconds rather than milliseconds, so a query against the old names returns nothing instead of failing. Because all four services now publish these names, queries must select on `job` to isolate one service. The dashboards shipped in this repository are updated accordingly.

Two related fixes come with it. The dashboard labelled each request with its URL path and masked only UUIDs, so any other unmatched path created a permanent series; it now uses SvelteKit's matched `route.id`, which the route tree bounds. Separately, `metrics-format.ts` interpolated label values without escaping them, which the daemon had been compensating for locally.

The comment in `connection.ts` about adopting `Bun.SQL` now cites [oven-sh/bun#30636](https://github.com/oven-sh/bun/pull/30636), where the pool opens `max` connections on the first query, because the LISTEN/NOTIFY gap it previously named has since been closed.

## Type of change

Refactor + CI / build / tooling

## Testing

Every suite passes on Bun 1.4.2, including the dashboard end-to-end tests, against a database created fresh through `docker compose down -v`. All nine build and compile scripts complete.

## Checklist

- [x] Tests pass locally (`bun test`), or no testable code was changed
- [x] New or changed behavior is covered by tests, or this change does not require tests
- [x] Documentation is updated, or no user-facing behavior or configuration was changed
- [x] There are no breaking changes, or they are marked with `!` in the commit type and described above
- [x] No security-sensitive changes (authentication, credentials, input handling), or they have been reviewed
- [x] No new dependencies were added, or they have been reviewed for license and maintenance status
