### PR TITLE
Fix/dead node installations

### DIFF
--- a/packages/xinity-ai-dashboard/scripts/simulate-compute.ts
+++ b/packages/xinity-ai-dashboard/scripts/simulate-compute.ts
@@ -8,6 +8,7 @@
  *   - Most nodes online and active
  *   - One node permanently offline throughout
  *   - One node starts offline and toggles every 3 minutes
+ *   - One node removed from the cluster while its installations survive
  *
  * Cleans up all created rows on exit so no stale state is left behind.
  *
@@ -54,6 +55,7 @@ type DemoMachine = {
   models: ModelSpec[];
   available: boolean;
   togglesOnOff?: true;
+  removed?: true;
 };
 
 const ASCENT_GPUS = [{ vendor: "nvidia", name: "NVIDIA GB10", vramMb: 0 }];
@@ -76,6 +78,7 @@ const SMALL_MACHINES: DemoMachine[] = [
   { host: "192.0.2.1", machineName: "Ascent GX10", gpus: ASCENT_GPUS, estCapacity: 110, baseUtilization: 43, models: ASCENT_MODELS, available: true },
   { host: "192.0.2.2", machineName: "Ascent GX10", gpus: ASCENT_GPUS, estCapacity: 110, baseUtilization: 51, models: ASCENT_MODELS, available: true },
   { host: "192.0.2.3", machineName: "Ascent GX10", gpus: ASCENT_GPUS, estCapacity: 110, baseUtilization: 59, models: ASCENT_MODELS, available: false },
+  { host: "192.0.2.4", machineName: "Ascent GX10", gpus: ASCENT_GPUS, estCapacity: 110, baseUtilization: 47, models: ASCENT_MODELS, available: true, removed: true },
   { host: "192.0.2.11", machineName: "RTX PRO 6000 Workstation", gpus: RTX_GPUS, estCapacity: 95, baseUtilization: 65, models: RTX_MODELS, available: true },
   { host: "192.0.2.12", machineName: "RTX PRO 6000 Workstation", gpus: RTX_GPUS, estCapacity: 95, baseUtilization: 75, models: RTX_MODELS, available: false, togglesOnOff: true },
   { host: "192.0.2.21", machineName: "H100 Inference Server", gpus: H100_GPUS, estCapacity: 79, baseUtilization: 28, models: [{ publicSpecifier: "llama-3.3-70b", driver: "vllm", estCapacity: 70 }], available: true },
@@ -109,6 +112,7 @@ function generateLargeMachines(): DemoMachine[] {
         },
       ],
       available: !offline,
+      ...(i === 20 ? { removed: true as const } : {}),
     });
   }
 
@@ -268,7 +272,7 @@ async function main() {
 
   // Create nodes and their model installations.
   const nodeIds: string[] = [];
-  const liveNodes: { id: string; phase: number; models: ModelSpec[]; machineName: string; togglesOnOff: boolean; initiallyOnline: boolean }[] = [];
+  const liveNodes: { id: string; phase: number; models: ModelSpec[]; machineName: string; togglesOnOff: boolean; initiallyOnline: boolean; removed: boolean }[] = [];
 
   for (const [index, machine] of machines.entries()) {
     const [node] = await db.insert(aiNodeT).values({
@@ -280,10 +284,11 @@ async function main() {
       gpus: machine.gpus,
       driverVersions: machine.models.some((m) => m.driver === "vllm") ? { vllm: "0.19.1" } : { ollama: "0.6.3" },
       machineName: machine.machineName,
+      deletedAt: machine.removed ? new Date() : null,
     }).returning();
 
     nodeIds.push(node!.id);
-    liveNodes.push({ id: node!.id, phase: index, models: machine.models, machineName: machine.machineName, togglesOnOff: machine.togglesOnOff ?? false, initiallyOnline: machine.available });
+    liveNodes.push({ id: node!.id, phase: index, models: machine.models, machineName: machine.machineName, togglesOnOff: machine.togglesOnOff ?? false, initiallyOnline: machine.available, removed: machine.removed ?? false });
 
     for (const model of machine.models) {
       const [installation] = await db.insert(modelInstallationT).values({
@@ -326,15 +331,17 @@ async function main() {
     await db.insert(usageEventT).values(events);
   }
 
-  const onlineNodes = liveNodes.filter((n) => n.initiallyOnline && !n.togglesOnOff);
+  const onlineNodes = liveNodes.filter((n) => n.initiallyOnline && !n.togglesOnOff && !n.removed);
   const toggleNode = liveNodes.find((n) => n.togglesOnOff);
   let toggleOnline = false;
   let lastToggle = Date.now();
 
-  const offlineLabel = liveNodes.filter((n) => !n.initiallyOnline && !n.togglesOnOff).map((n) => n.machineName).join(", ");
+  const offlineLabel = liveNodes.filter((n) => !n.initiallyOnline && !n.togglesOnOff && !n.removed).map((n) => n.machineName).join(", ");
+  const removedLabel = liveNodes.filter((n) => n.removed).map((n) => n.machineName).join(", ");
   console.log(`[${preset}] Created ${liveNodes.length} demo machines with ${BACKFILL_HOURS}h backfill.`);
   console.log(`  Offline (static): ${offlineLabel || "none"}`);
   console.log(`  Toggling (3 min): ${toggleNode?.machineName ?? "none"}`);
+  console.log(`  Removed, installations kept: ${removedLabel || "none"}`);
   console.log(`Simulating for ${minutes} minutes (Ctrl-C to stop and clean up)...`);
 
   async function cleanup() {

--- a/packages/xinity-ai-dashboard/scripts/simulate-compute.ts
+++ b/packages/xinity-ai-dashboard/scripts/simulate-compute.ts
@@ -43,7 +43,7 @@ type ModelSpec = {
   publicSpecifier: string;
   driver: "ollama" | "vllm";
   estCapacity: number;
-  lifecycleState?: "ready" | "downloading" | "installing" | "failed" | "scheduling";
+  lifecycleState?: "ready" | "downloading" | "installing" | "failed";
 };
 
 type DemoMachine = {

--- a/packages/xinity-ai-dashboard/src/lib/orpc/dtos/model.dto.ts
+++ b/packages/xinity-ai-dashboard/src/lib/orpc/dtos/model.dto.ts
@@ -34,5 +34,27 @@ export const DeploymentDto = CommonDto.extend({
   settings: DeploymentSettingsDto.optional(),
 });
 
+export const ReplicaStatusDto = z.object({
+  phase: z.enum(["ready", "downloading", "installing", "failed", "scheduling"]),
+  node: z.string().nullable(),
+  error: z.string().nullable(),
+});
+export type ReplicaStatus = z.infer<typeof ReplicaStatusDto>;
+
+export const DeploymentStatusDto = z.object({
+  phase: z.enum(["ready", "downloading", "installing", "failed", "scheduling", "not_in_catalog", "partial"]),
+  progress: z.number().nullable(),
+  error: z.string().nullable().optional(),
+  failureLogs: z.string().nullable().optional(),
+  replicas: ReplicaStatusDto.array().optional(),
+});
+export type StatusPhase = z.infer<typeof DeploymentStatusDto>["phase"];
+
+export const DeploymentWithStatusDto = DeploymentDto.extend({
+  status: DeploymentStatusDto.optional(),
+  /** Set while the model is only served by the deprecated catalog. Removed before 1.0.0. */
+  deprecatedModel: z.boolean().optional(),
+});
+export type DeploymentWithStatus = z.infer<typeof DeploymentWithStatusDto>;
 
 export { type Model, ModelSchema as ModelDto } from "xinity-infoserver";

--- a/packages/xinity-ai-dashboard/src/lib/server/lib/deployment-status.test.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/lib/deployment-status.test.ts
@@ -1,0 +1,127 @@
+import { describe, test, expect } from "bun:test";
+import { foldDeploymentStatusRows, type DeploymentStatusRow } from "./deployment-status";
+
+const DEPLOYMENT: DeploymentStatusRow["model_deployment"] = {
+  id: "dep-1",
+  organizationId: "org-1",
+  name: "My Deployment",
+  description: null,
+  enabled: true,
+  publicSpecifier: "qwen3.6-27b",
+  specifier: "qwen3.6-27b",
+  earlySpecifier: null,
+  replicas: 4,
+  canaryProgressUntil: null,
+  canaryProgressFrom: null,
+  canaryProgressWithFeedback: false,
+  progress: 100,
+  kvCacheSize: null,
+  earlyKvCacheSize: null,
+  preferredDriver: null,
+  settings: { version: 1 },
+  deletedAt: null,
+  createdAt: new Date("2026-01-01"),
+  updatedAt: new Date("2026-01-01"),
+};
+
+type State = NonNullable<DeploymentStatusRow["model_installation_state"]>;
+
+function row(overrides: Partial<DeploymentStatusRow> = {}): DeploymentStatusRow {
+  return {
+    model_deployment: DEPLOYMENT,
+    model_installation: { id: "inst-1" },
+    model_installation_state: state(),
+    ai_node: { machineName: "gx10-a", host: "192.0.2.1" },
+    ...overrides,
+  };
+}
+
+function state(overrides: Partial<State> = {}): State {
+  return { lifecycleState: "ready", progress: null, errorMessage: null, failureLogs: null, ...overrides };
+}
+
+/** One live, ready replica per id. */
+function replicas(count: number): DeploymentStatusRow[] {
+  return Array.from({ length: count }, (_, i) => row({
+    model_installation: { id: `inst-${i}` },
+    ai_node: { machineName: `gx10-${i}`, host: `192.0.2.${i + 1}` },
+  }));
+}
+
+describe("foldDeploymentStatusRows", () => {
+  test("reports one replica per installation row", () => {
+    const [deployment] = foldDeploymentStatusRows(replicas(3));
+    expect(deployment!.status!.replicas).toHaveLength(3);
+    expect(deployment!.status!.phase).toBe("ready");
+  });
+
+  test("ignores a replica whose node left the cluster, even while its state still reads ready", () => {
+    const [deployment] = foldDeploymentStatusRows([
+      ...replicas(2),
+      row({ model_installation: { id: "inst-gone" }, ai_node: null }),
+    ]);
+    expect(deployment!.status!.replicas).toHaveLength(2);
+    expect(deployment!.status!.phase).toBe("ready");
+  });
+
+  test("reports no status when every installation sits on a node that left the cluster", () => {
+    const [deployment] = foldDeploymentStatusRows([
+      row({ model_installation: { id: "inst-0" }, ai_node: null }),
+      row({ model_installation: { id: "inst-1" }, ai_node: null }),
+    ]);
+    expect(deployment!.status).toBeUndefined();
+    expect(deployment!.id).toBe("dep-1");
+  });
+
+  test("reports no status for a deployment with no installations at all", () => {
+    const [deployment] = foldDeploymentStatusRows([
+      row({ model_installation: null, model_installation_state: null, ai_node: null }),
+    ]);
+    expect(deployment!.status).toBeUndefined();
+  });
+
+  test("labels a replica by machine name, falling back to host", () => {
+    const [deployment] = foldDeploymentStatusRows([
+      row({ model_installation: { id: "inst-0" }, ai_node: { machineName: "gx10-a", host: "192.0.2.1" } }),
+      row({ model_installation: { id: "inst-1" }, ai_node: { machineName: null, host: "192.0.2.2" } }),
+    ]);
+    expect(deployment!.status!.replicas!.map(r => r.node)).toEqual(["gx10-a", "192.0.2.2"]);
+  });
+
+  test("treats an installation with no state row as scheduling", () => {
+    const [deployment] = foldDeploymentStatusRows([
+      row({ model_installation_state: null }),
+    ]);
+    expect(deployment!.status!.phase).toBe("scheduling");
+    expect(deployment!.status!.replicas).toEqual([{ phase: "scheduling", node: "gx10-a", error: null }]);
+  });
+
+  test("aggregates the worst phase across replicas", () => {
+    const [deployment] = foldDeploymentStatusRows([
+      row({ model_installation: { id: "inst-0" } }),
+      row({ model_installation: { id: "inst-1" }, model_installation_state: state({ lifecycleState: "downloading", progress: 42 }) }),
+    ]);
+    expect(deployment!.status!.phase).toBe("downloading");
+    expect(deployment!.status!.progress).toBe(42);
+  });
+
+  test("reports partial when some replicas failed and others are ready", () => {
+    const [deployment] = foldDeploymentStatusRows([
+      row({ model_installation: { id: "inst-0" } }),
+      row({ model_installation: { id: "inst-1" }, model_installation_state: state({ lifecycleState: "failed", errorMessage: "boom" }) }),
+    ]);
+    expect(deployment!.status!.phase).toBe("partial");
+    expect(deployment!.status!.error).toBe("boom");
+  });
+
+  test("keeps deployments separate", () => {
+    const other = { ...DEPLOYMENT, id: "dep-2", name: "Other" };
+    const result = foldDeploymentStatusRows([
+      ...replicas(2),
+      row({ model_deployment: other, model_installation: { id: "inst-x" } }),
+    ]);
+    expect(result).toHaveLength(2);
+    expect(result.find(d => d.id === "dep-1")!.status!.replicas).toHaveLength(2);
+    expect(result.find(d => d.id === "dep-2")!.status!.replicas).toHaveLength(1);
+  });
+});

--- a/packages/xinity-ai-dashboard/src/lib/server/lib/deployment-status.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/lib/deployment-status.ts
@@ -1,0 +1,70 @@
+import type { lifecycleStateEnum, ModelDeployment } from "common-db";
+import type { DeploymentWithStatus, ReplicaStatus, StatusPhase } from "$lib/orpc/dtos/model.dto";
+import { aggregatePhase, isProgressBearingPhase, toDisplayPhase, type PhaseInfo } from "./deployment-phase";
+
+type LifecycleState = typeof lifecycleStateEnum.enumValues[number];
+
+/** One row of the deployment status join, narrowed to the columns the fold reads. */
+export type DeploymentStatusRow = {
+  model_deployment: ModelDeployment;
+  model_installation: { id: string } | null;
+  model_installation_state: {
+    lifecycleState: LifecycleState;
+    progress: number | null;
+    errorMessage: string | null;
+    failureLogs: string | null;
+  } | null;
+  ai_node: { machineName: string | null; host: string } | null;
+};
+
+/**
+ * Folds the status join into one deployment per id, with a replica per installation.
+ *
+ * A row whose `ai_node` is null sits on a node that was removed or went offline, so it counts as
+ * no replica at all: its state row stopped updating when the daemon went away.
+ */
+export function foldDeploymentStatusRows(rows: DeploymentStatusRow[]): DeploymentWithStatus[] {
+  const deploymentMap = new Map<string, { deployment: ModelDeployment; phaseInfo?: PhaseInfo; replicas: ReplicaStatus[] }>();
+
+  for (const row of rows) {
+    const deployment = row.model_deployment;
+    let entry = deploymentMap.get(deployment.id);
+    if (!entry) {
+      entry = { deployment, replicas: [] };
+      deploymentMap.set(deployment.id, entry);
+    }
+
+    const installation = row.model_installation;
+    const state = row.model_installation_state;
+    const liveNode = row.ai_node;
+
+    if (!installation || !liveNode) continue;
+
+    const nodeLabel = liveNode.machineName ?? liveNode.host;
+
+    if (!state) {
+      entry.phaseInfo = aggregatePhase(entry.phaseInfo, "scheduling", null, null);
+      entry.replicas.push({ phase: "scheduling", node: nodeLabel, error: null });
+      continue;
+    }
+
+    const phase = state.lifecycleState;
+    const progress = isProgressBearingPhase(phase) ? (state.progress ?? null) : null;
+    entry.phaseInfo = aggregatePhase(entry.phaseInfo, phase, progress, state.errorMessage, state.failureLogs);
+    entry.replicas.push({ phase, node: nodeLabel, error: state.errorMessage });
+  }
+
+  return Array.from(deploymentMap.values()).map(({ deployment, phaseInfo, replicas }) => {
+    if (!phaseInfo) return deployment;
+    return {
+      ...deployment,
+      status: {
+        phase: toDisplayPhase(phaseInfo) as StatusPhase,
+        progress: phaseInfo.progress,
+        error: phaseInfo.error,
+        failureLogs: phaseInfo.failureLogs,
+        replicas: replicas.length > 0 ? replicas : undefined,
+      },
+    };
+  });
+}

--- a/packages/xinity-ai-dashboard/src/lib/server/lib/node-liveness.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/lib/node-liveness.ts
@@ -1,0 +1,7 @@
+import { sql, aiNodeT, modelInstallationT } from "common-db";
+
+/** sql part to be used in a where clause when querying ai_node, to only get ones that are live */
+export const nodeIsLive = sql`${aiNodeT.available} AND ${aiNodeT.deletedAt} IS NULL`;
+
+/** sql part to be used as the join condition between model_installation and ai_node, to only join live ones */
+export const installationOnLiveNode = sql`${aiNodeT.id} = ${modelInstallationT.nodeId} AND ${nodeIsLive}`;

--- a/packages/xinity-ai-dashboard/src/lib/server/lib/orchestration.mod.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/lib/orchestration.mod.ts
@@ -7,6 +7,7 @@ import { rootLogger } from "../logging";
 import { building } from "$app/environment";
 import { maxVramGb } from "$lib/server/license";
 import { serverEnv } from "$lib/server/serverenv";
+import { nodeIsLive } from "./node-liveness";
 
 const log = rootLogger.child({ name: "orchestration.mod" })
 
@@ -373,11 +374,7 @@ async function runSyncDeployedModels() {
   const requiredModels = await assembleModelRequirementTable();
   const [existing, availableServers]: [ModelInstallation[], AiNode[]] = await Promise.all([
     getDB().select().from(modelInstallationT).where(sql`${modelInstallationT.deletedAt} IS NULL`),
-    getDB().select().from(aiNodeT).where(sql`
-      ${aiNodeT.available}
-    AND
-      ${aiNodeT.deletedAt} IS NULL
-    `),
+    getDB().select().from(aiNodeT).where(nodeIsLive),
   ]);
 
   const availableServerIds = new Set(availableServers.map(s => s.id));

--- a/packages/xinity-ai-dashboard/src/lib/server/notifications/scheduler.test.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/notifications/scheduler.test.ts
@@ -12,6 +12,7 @@ function row(overrides: Partial<Row> = {}): Row {
     publicSpecifier: "qwen3.6-27b",
     desiredReplicas: 4,
     installationId: "inst-1",
+    liveNodeId: "node-1",
     lifecycleState: "ready",
     errorMessage: null,
     ...overrides,
@@ -20,7 +21,7 @@ function row(overrides: Partial<Row> = {}): Row {
 
 /** One installation row per id, all in the given phase. */
 function installations(count: number, lifecycleState = "ready"): Row[] {
-  return Array.from({ length: count }, (_, i) => row({ installationId: `inst-${i}`, lifecycleState }));
+  return Array.from({ length: count }, (_, i) => row({ installationId: `inst-${i}`, liveNodeId: `node-${i}`, lifecycleState }));
 }
 
 describe("foldDeploymentPhaseRows", () => {
@@ -85,6 +86,32 @@ describe("foldDeploymentPhaseRows", () => {
     ]).get("dep-1")!;
     expect(info.phase).toBe("scheduling");
     expect(info.observedReplicas).toBe(1);
+  });
+
+  test("ignores a replica whose node left the cluster, even while its state still reads ready", () => {
+    const info = foldDeploymentPhaseRows([
+      ...installations(2),
+      row({ installationId: "inst-gone", liveNodeId: null, lifecycleState: "ready" }),
+    ]).get("dep-1")!;
+    expect(info.observedReplicas).toBe(2);
+    expect(info.phase).toBe("ready");
+  });
+
+  test("reports pending when every installation sits on a node that left the cluster", () => {
+    const info = foldDeploymentPhaseRows([
+      row({ installationId: "inst-0", liveNodeId: null, lifecycleState: "ready" }),
+      row({ installationId: "inst-1", liveNodeId: null, lifecycleState: "ready" }),
+    ]).get("dep-1")!;
+    expect(info.observedReplicas).toBe(0);
+    expect(info.phase).toBe("pending");
+  });
+
+  test("drops the stale error of a replica whose node left the cluster", () => {
+    const info = foldDeploymentPhaseRows([
+      row({ installationId: "inst-gone", liveNodeId: null, lifecycleState: "failed", errorMessage: "boom" }),
+    ]).get("dep-1")!;
+    expect(info.error).toBeNull();
+    expect(info.phase).toBe("pending");
   });
 
   test("an all-ready but under-provisioned deployment reports ready with a shortfall", () => {

--- a/packages/xinity-ai-dashboard/src/lib/server/notifications/scheduler.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/notifications/scheduler.ts
@@ -279,26 +279,27 @@ async function checkNodeHealth() {
 
 async function checkCapacity() {
   try {
-    const nodes = await getDB()
-      .select({ id: aiNodeT.id, estCapacity: aiNodeT.estCapacity, available: aiNodeT.available })
-      .from(aiNodeT)
-      .where(sql`
-        ${aiNodeT.available}
-      AND
-        ${aiNodeT.deletedAt} IS NULL
-      `);
-
-    const installations = await getDB()
-      .select({ estCapacity: modelInstallationT.estCapacity })
-      .from(modelInstallationT)
-      .innerJoin(aiNodeT, sql`
-        ${aiNodeT.id} = ${modelInstallationT.nodeId}
-      AND
-        ${aiNodeT.available}
-      AND
-        ${aiNodeT.deletedAt} IS NULL
-      `)
-      .where(sql`${modelInstallationT.deletedAt} IS NULL`);
+    const [nodes, installations] = await Promise.all([
+      getDB()
+        .select({ estCapacity: aiNodeT.estCapacity })
+        .from(aiNodeT)
+        .where(sql`
+          ${aiNodeT.available}
+        AND
+          ${aiNodeT.deletedAt} IS NULL
+        `),
+      getDB()
+        .select({ estCapacity: modelInstallationT.estCapacity })
+        .from(modelInstallationT)
+        .innerJoin(aiNodeT, sql`
+          ${aiNodeT.id} = ${modelInstallationT.nodeId}
+        AND
+          ${aiNodeT.available}
+        AND
+          ${aiNodeT.deletedAt} IS NULL
+        `)
+        .where(sql`${modelInstallationT.deletedAt} IS NULL`),
+    ]);
 
     const totalCapacity = nodes.reduce((sum, n) => sum + n.estCapacity, 0);
     if (totalCapacity === 0) return;

--- a/packages/xinity-ai-dashboard/src/lib/server/notifications/scheduler.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/notifications/scheduler.ts
@@ -12,6 +12,7 @@ import {
 } from "common-db";
 import { serverEnv } from "$lib/server/serverenv";
 import { getDB } from "$lib/server/db";
+import { nodeIsLive, installationOnLiveNode } from "$lib/server/lib/node-liveness";
 import { rootLogger } from "$lib/server/logging";
 import { building } from "$app/environment";
 import { notifyOrgMembers } from "./notification.service";
@@ -176,13 +177,7 @@ async function getDeploymentPhases(): Promise<Map<string, DeploymentInfo>> {
       ${modelInstallationT.deletedAt} IS NULL
     `)
     .leftJoin(modelInstallationStateT, sql`${modelInstallationStateT.id} = ${modelInstallationT.id}`)
-    .leftJoin(aiNodeT, sql`
-      ${aiNodeT.id} = ${modelInstallationT.nodeId}
-    AND
-      ${aiNodeT.available}
-    AND
-      ${aiNodeT.deletedAt} IS NULL
-    `);
+    .leftJoin(aiNodeT, installationOnLiveNode);
 
   return foldDeploymentPhaseRows(rows);
 }
@@ -283,21 +278,11 @@ async function checkCapacity() {
       getDB()
         .select({ estCapacity: aiNodeT.estCapacity })
         .from(aiNodeT)
-        .where(sql`
-          ${aiNodeT.available}
-        AND
-          ${aiNodeT.deletedAt} IS NULL
-        `),
+        .where(nodeIsLive),
       getDB()
         .select({ estCapacity: modelInstallationT.estCapacity })
         .from(modelInstallationT)
-        .innerJoin(aiNodeT, sql`
-          ${aiNodeT.id} = ${modelInstallationT.nodeId}
-        AND
-          ${aiNodeT.available}
-        AND
-          ${aiNodeT.deletedAt} IS NULL
-        `)
+        .innerJoin(aiNodeT, installationOnLiveNode)
         .where(sql`${modelInstallationT.deletedAt} IS NULL`),
     ]);
 
@@ -400,12 +385,7 @@ async function checkWeeklyReport() {
     const oneWeekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60_000);
     const [orgs, nodeResult] = await Promise.all([
       getDB().select({ id: organizationT.id, name: organizationT.name }).from(organizationT),
-      getDB().select({ count: count() }).from(aiNodeT)
-        .where(sql`
-          ${aiNodeT.available}
-        AND
-          ${aiNodeT.deletedAt} IS NULL
-        `),
+      getDB().select({ count: count() }).from(aiNodeT).where(nodeIsLive),
     ]);
     const activeNodes = nodeResult[0]?.count ?? 0;
     const period = formatReportPeriod(oneWeekAgo, now);

--- a/packages/xinity-ai-dashboard/src/lib/server/notifications/scheduler.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/notifications/scheduler.ts
@@ -83,6 +83,7 @@ export type DeploymentPhaseRow = {
   publicSpecifier: string;
   desiredReplicas: number;
   installationId: string | null;
+  liveNodeId: string | null;
   lifecycleState: string | null;
   errorMessage: string | null;
 };
@@ -98,8 +99,10 @@ export function foldDeploymentPhaseRows(rows: DeploymentPhaseRow[]): Map<string,
 
   for (const row of rows) {
     const existing = accumulators.get(row.deploymentId);
-    const phase: DeploymentPhase = row.lifecycleState as DeploymentPhase ?? (row.installationId ? "scheduling" : "pending");
-    const observed = row.installationId ? 1 : 0;
+    const servedByLiveNode = row.installationId !== null && row.liveNodeId !== null;
+    const phase: DeploymentPhase = servedByLiveNode ? (row.lifecycleState as DeploymentPhase ?? "scheduling") : "pending";
+    const observed = servedByLiveNode ? 1 : 0;
+    const error = servedByLiveNode ? row.errorMessage : null;
 
     if (!existing) {
       accumulators.set(row.deploymentId, {
@@ -109,14 +112,14 @@ export function foldDeploymentPhaseRows(rows: DeploymentPhaseRow[]): Map<string,
         orgName: row.orgName ?? "",
         name: row.deploymentName,
         model: row.publicSpecifier,
-        error: row.errorMessage,
+        error,
         observedReplicas: observed,
         desiredReplicas: row.desiredReplicas,
       });
     } else {
       const agg = aggregatePhase(
         { phase: existing.phase, progress: null, error: existing.error, failureLogs: null, hasReady: existing.hasReady },
-        phase, null, row.errorMessage,
+        phase, null, error,
       );
       accumulators.set(row.deploymentId, {
         ...existing,
@@ -156,6 +159,7 @@ async function getDeploymentPhases(): Promise<Map<string, DeploymentInfo>> {
       publicSpecifier: modelDeploymentT.publicSpecifier,
       desiredReplicas: modelDeploymentT.replicas,
       installationId: modelInstallationT.id,
+      liveNodeId: aiNodeT.id,
       lifecycleState: modelInstallationStateT.lifecycleState,
       errorMessage: modelInstallationStateT.errorMessage,
     })
@@ -171,7 +175,14 @@ async function getDeploymentPhases(): Promise<Map<string, DeploymentInfo>> {
     AND
       ${modelInstallationT.deletedAt} IS NULL
     `)
-    .leftJoin(modelInstallationStateT, sql`${modelInstallationStateT.id} = ${modelInstallationT.id}`);
+    .leftJoin(modelInstallationStateT, sql`${modelInstallationStateT.id} = ${modelInstallationT.id}`)
+    .leftJoin(aiNodeT, sql`
+      ${aiNodeT.id} = ${modelInstallationT.nodeId}
+    AND
+      ${aiNodeT.available}
+    AND
+      ${aiNodeT.deletedAt} IS NULL
+    `);
 
   return foldDeploymentPhaseRows(rows);
 }

--- a/packages/xinity-ai-dashboard/src/lib/server/notifications/scheduler.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/notifications/scheduler.ts
@@ -289,8 +289,15 @@ async function checkCapacity() {
       `);
 
     const installations = await getDB()
-      .select({ nodeId: modelInstallationT.nodeId, estCapacity: modelInstallationT.estCapacity })
+      .select({ estCapacity: modelInstallationT.estCapacity })
       .from(modelInstallationT)
+      .innerJoin(aiNodeT, sql`
+        ${aiNodeT.id} = ${modelInstallationT.nodeId}
+      AND
+        ${aiNodeT.available}
+      AND
+        ${aiNodeT.deletedAt} IS NULL
+      `)
       .where(sql`${modelInstallationT.deletedAt} IS NULL`);
 
     const totalCapacity = nodes.reduce((sum, n) => sum + n.estCapacity, 0);

--- a/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/cluster.procedure.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/cluster.procedure.ts
@@ -1,6 +1,7 @@
 import { rootOs, withOrganization, requirePermission } from "../root";
 import { sql, aiNodeT, modelInstallationT } from "common-db";
 import { getDB } from "$lib/server/db";
+import { nodeIsLive } from "$lib/server/lib/node-liveness";
 import z from "zod";
 import type { NodeCapability } from "xinity-infoserver";
 
@@ -40,12 +41,7 @@ export async function buildClusterCapacity(): Promise<ClusterCapacity> {
       driverVersions: aiNodeT.driverVersions,
       driverFeatures: aiNodeT.driverFeatures,
       gpus: aiNodeT.gpus,
-    }).from(aiNodeT)
-      .where(sql`
-        ${aiNodeT.available}
-      AND
-        ${aiNodeT.deletedAt} IS NULL
-      `),
+    }).from(aiNodeT).where(nodeIsLive),
     getDB().select().from(modelInstallationT)
       .where(sql`${modelInstallationT.deletedAt} IS NULL`),
   ]);

--- a/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/deployment.procedure.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/deployment.procedure.ts
@@ -4,6 +4,7 @@ import { sql, modelDeploymentT, modelInstallationT, modelInstallationStateT, aiN
 import z from "zod";
 import { DeploymentDto } from "$lib/orpc/dtos/model.dto";
 import { getDB } from "$lib/server/db";
+import { installationOnLiveNode } from "$lib/server/lib/node-liveness";
 import { syncDeployedModels } from "$lib/server/lib/orchestration.mod";
 import { resolveSchedulable, resolvesOnlyAsLegacy } from "$lib/server/model-catalog";
 import { buildClusterCapacity } from "./cluster.procedure";
@@ -232,13 +233,7 @@ async function queryDeploymentsWithStatus(where: SQL | undefined): Promise<Deplo
       ${modelInstallationT.deletedAt} IS NULL
     `)
     .leftJoin(modelInstallationStateT, sql`${modelInstallationStateT.id} = ${modelInstallationT.id}`)
-    .leftJoin(aiNodeT, sql`
-      ${aiNodeT.id} = ${modelInstallationT.nodeId}
-    AND
-      ${aiNodeT.available}
-    AND
-      ${aiNodeT.deletedAt} IS NULL
-    `)
+    .leftJoin(aiNodeT, installationOnLiveNode)
     .where(where);
 
   const deploymentMap = new Map<string, { deployment: ModelDeployment; phaseInfo?: PhaseInfo; replicas: ReplicaStatus[] }>();

--- a/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/deployment.procedure.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/deployment.procedure.ts
@@ -232,7 +232,13 @@ async function queryDeploymentsWithStatus(where: SQL | undefined): Promise<Deplo
       ${modelInstallationT.deletedAt} IS NULL
     `)
     .leftJoin(modelInstallationStateT, sql`${modelInstallationStateT.id} = ${modelInstallationT.id}`)
-    .leftJoin(aiNodeT, sql`${aiNodeT.id} = ${modelInstallationT.nodeId}`)
+    .leftJoin(aiNodeT, sql`
+      ${aiNodeT.id} = ${modelInstallationT.nodeId}
+    AND
+      ${aiNodeT.available}
+    AND
+      ${aiNodeT.deletedAt} IS NULL
+    `)
     .where(where);
 
   const deploymentMap = new Map<string, { deployment: ModelDeployment; phaseInfo?: PhaseInfo; replicas: ReplicaStatus[] }>();
@@ -247,19 +253,22 @@ async function queryDeploymentsWithStatus(where: SQL | undefined): Promise<Deplo
 
     const installation = row.model_installation;
     const state = row.model_installation_state;
-    const node = row.ai_node;
+    const liveNode = row.ai_node;
 
-    if (installation && !state) {
+    if (!installation || !liveNode) continue;
+
+    const nodeLabel = liveNode.machineName ?? liveNode.host;
+
+    if (!state) {
       entry.phaseInfo = aggregatePhase(entry.phaseInfo, "scheduling", null, null);
-      entry.replicas.push({ phase: "scheduling", node: node?.machineName ?? node?.host ?? null, error: null });
+      entry.replicas.push({ phase: "scheduling", node: nodeLabel, error: null });
       continue;
     }
-    if (!state) continue;
 
     const phase = state.lifecycleState;
     const progress = isProgressBearingPhase(phase) ? (state.progress ?? null) : null;
     entry.phaseInfo = aggregatePhase(entry.phaseInfo, phase, progress, state.errorMessage, state.failureLogs);
-    entry.replicas.push({ phase, node: node?.machineName ?? node?.host ?? null, error: state.errorMessage });
+    entry.replicas.push({ phase, node: nodeLabel, error: state.errorMessage });
   }
 
   return Array.from(deploymentMap.values()).map(({ deployment, phaseInfo, replicas }) => {

--- a/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/deployment.procedure.ts
+++ b/packages/xinity-ai-dashboard/src/lib/server/orpc/procedures/deployment.procedure.ts
@@ -2,7 +2,7 @@ import { rootOs, withOrganization, requirePermission, auditMiddleware } from "..
 import { commonInputFilter } from "$lib/orpc/dtos/common.dto";
 import { sql, modelDeploymentT, modelInstallationT, modelInstallationStateT, aiNodeT, deploymentMatchesInstallation, type ModelDeployment, type SQL } from "common-db";
 import z from "zod";
-import { DeploymentDto } from "$lib/orpc/dtos/model.dto";
+import { DeploymentDto, DeploymentWithStatusDto, type DeploymentWithStatus } from "$lib/orpc/dtos/model.dto";
 import { getDB } from "$lib/server/db";
 import { installationOnLiveNode } from "$lib/server/lib/node-liveness";
 import { syncDeployedModels } from "$lib/server/lib/orchestration.mod";
@@ -10,7 +10,7 @@ import { resolveSchedulable, resolvesOnlyAsLegacy } from "$lib/server/model-cata
 import { buildClusterCapacity } from "./cluster.procedure";
 import { checkNodeCompatibility, type ModelNodeRequirements } from "xinity-infoserver";
 import { rootLogger } from "$lib/server/logging";
-import { aggregatePhase, isProgressBearingPhase, toDisplayPhase, type PhaseInfo } from "$lib/server/lib/deployment-phase";
+import { foldDeploymentStatusRows } from "$lib/server/lib/deployment-status";
 import { findOrgName } from "$lib/server/lib/org-queries";
 import { notifyOrgMembers } from "$lib/server/notifications/notification.service";
 import { NotificationType } from "$lib/server/notifications/events";
@@ -195,34 +195,10 @@ async function findActiveDeploymentInOrg(id: string, orgId: string): Promise<Mod
 // Shared status schema and query helper
 // ---------------------------------------------------------------------------
 
-const ReplicaStatusSchema = z.object({
-  phase: z.enum(["ready", "downloading", "installing", "failed", "scheduling"]),
-  node: z.string().nullable(),
-  error: z.string().nullable(),
-});
-
-const DeploymentStatusSchema = z.object({
-  phase: z.enum(["ready", "downloading", "installing", "failed", "scheduling", "not_in_catalog", "partial"]),
-  progress: z.number().nullable(),
-  error: z.string().nullable().optional(),
-  failureLogs: z.string().nullable().optional(),
-  replicas: ReplicaStatusSchema.array().optional(),
-});
-
-export const DeploymentWithStatusDto = DeploymentDto.extend({
-  status: DeploymentStatusSchema.optional(),
-  /** Set while the model is only served by the deprecated catalog. Removed before 1.0.0. */
-  deprecatedModel: z.boolean().optional(),
-});
-export type DeploymentWithStatus = z.infer<typeof DeploymentWithStatusDto>;
-type StatusPhase = z.infer<typeof DeploymentStatusSchema>["phase"];
-
 /**
  * Runs the status join query and aggregates installation phase info for the given deployments.
  * `where` should narrow to the specific deployment rows you want (org condition + optional id filter).
  */
-type ReplicaStatus = z.infer<typeof ReplicaStatusSchema>;
-
 async function queryDeploymentsWithStatus(where: SQL | undefined): Promise<DeploymentWithStatus[]> {
   const rows = await getDB()
     .select()
@@ -236,48 +212,7 @@ async function queryDeploymentsWithStatus(where: SQL | undefined): Promise<Deplo
     .leftJoin(aiNodeT, installationOnLiveNode)
     .where(where);
 
-  const deploymentMap = new Map<string, { deployment: ModelDeployment; phaseInfo?: PhaseInfo; replicas: ReplicaStatus[] }>();
-
-  for (const row of rows) {
-    const deployment = row.model_deployment;
-    let entry = deploymentMap.get(deployment.id);
-    if (!entry) {
-      entry = { deployment, replicas: [] };
-      deploymentMap.set(deployment.id, entry);
-    }
-
-    const installation = row.model_installation;
-    const state = row.model_installation_state;
-    const liveNode = row.ai_node;
-
-    if (!installation || !liveNode) continue;
-
-    const nodeLabel = liveNode.machineName ?? liveNode.host;
-
-    if (!state) {
-      entry.phaseInfo = aggregatePhase(entry.phaseInfo, "scheduling", null, null);
-      entry.replicas.push({ phase: "scheduling", node: nodeLabel, error: null });
-      continue;
-    }
-
-    const phase = state.lifecycleState;
-    const progress = isProgressBearingPhase(phase) ? (state.progress ?? null) : null;
-    entry.phaseInfo = aggregatePhase(entry.phaseInfo, phase, progress, state.errorMessage, state.failureLogs);
-    entry.replicas.push({ phase, node: nodeLabel, error: state.errorMessage });
-  }
-
-  return Array.from(deploymentMap.values()).map(({ deployment, phaseInfo, replicas }) => {
-    if (!phaseInfo) return deployment;
-    const phase = toDisplayPhase(phaseInfo);
-    const status = {
-      phase: phase as StatusPhase,
-      progress: phaseInfo.progress,
-      error: phaseInfo.error,
-      failureLogs: phaseInfo.failureLogs,
-      replicas: replicas.length > 0 ? replicas : undefined,
-    };
-    return { ...deployment, status };
-  });
+  return foldDeploymentStatusRows(rows);
 }
 
 async function lookupIsMissingFromCatalog(specifier: string | null): Promise<boolean> {

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/+layout.server.ts
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/+layout.server.ts
@@ -2,6 +2,7 @@ import { auth } from "$lib/server/auth-server";
 import { rootLogger } from "$lib/server/logging";
 import { serverEnv, isInstanceAdmin } from "$lib/server/serverenv";
 import { getDB } from "$lib/server/db";
+import { nodeIsLive } from "$lib/server/lib/node-liveness";
 import type { LayoutServerLoad } from "./$types";
 import { redirect, type Cookies } from "@sveltejs/kit";
 // path to root package version
@@ -159,11 +160,7 @@ async function fetchTotalAvailableVramGb(): Promise<number> {
     const [result] = await getDB()
       .select({ total: sql<number>`coalesce(sum(${aiNodeT.estCapacity}), 0)` })
       .from(aiNodeT)
-      .where(sql`
-        ${aiNodeT.available}
-      AND
-        ${aiNodeT.deletedAt} IS NULL
-      `);
+      .where(nodeIsLive);
     return result?.total ?? 0;
   } catch (err) {
     log.warn({ err }, "Failed to sum node VRAM");

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/+page.server.ts
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/+page.server.ts
@@ -2,7 +2,7 @@ import type { PageServerLoad } from "./$types";
 import { router } from "$lib/server/orpc/router";
 import { call } from "@orpc/server";
 import { buildClusterCapacity, type ClusterCapacity } from "$lib/server/orpc/procedures/cluster.procedure";
-import type { DeploymentWithStatus } from "$lib/server/orpc/procedures/deployment.procedure";
+import type { DeploymentWithStatus } from "$lib/orpc/dtos/model.dto";
 import type { ApplicationDto } from "$lib/orpc/dtos/application.dto";
 import { isRedirect, isHttpError } from "@sveltejs/kit";
 

--- a/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/+page.svelte
+++ b/packages/xinity-ai-dashboard/src/routes/(authenticated)/modelhub/+page.svelte
@@ -291,7 +291,7 @@
       {#each { length: slots.missing } as _}
         <span
           class="w-2.5 h-2.5 rounded-full {unscheduledSlotConfig.dot}"
-          title="Not scheduled: no node had capacity for this replica"
+          title="Not scheduled: no node was free to take this replica"
         ></span>
       {/each}
     {/snippet}
@@ -406,7 +406,7 @@
                 {#if !deployment.enabled}
                   {@render chip("bg-muted-foreground/50", "bg-muted text-muted-foreground", "Disabled")}
                 {:else if !deployment.status}
-                  {@render chip("bg-amber-400", "bg-amber-100 text-amber-700", "No node available", false, "The orchestrator could not place this model on any node. Common causes: no node has enough free VRAM for the model weight, or no available node has the required driver.")}
+                  {@render chip("bg-amber-400", "bg-amber-100 text-amber-700", "No node available", false, "The orchestrator could not place this model on any node. Common causes: no node has enough free VRAM for the model weight, or no available node has the required driver. A node that was removed or is powered off no longer counts.")}
                 {:else}
                   {@const cfg = phaseConfig[deployment.status.phase]}
                   {@const slots = replicaSlots(deployment.replicas, deployment.status.replicas)}
@@ -414,7 +414,7 @@
                   {#if slots.missing > 0}
                     <span
                       class="ml-2 text-xs text-amber-600 dark:text-amber-500 cursor-help"
-                      title="Only {slots.observed.length} of {deployment.replicas} requested replicas are placed. Common causes: no node has enough free VRAM for the model weight, or no available node has the required driver."
+                      title="Only {slots.observed.length} of {deployment.replicas} requested replicas are placed. Each replica needs its own node, so a cluster cannot run more replicas than it has nodes. Other causes: no node has enough free VRAM for the model weight, or no available node has the required driver."
                     >
                       {slots.observed.length}/{deployment.replicas} replicas
                     </span>

--- a/packages/xinity-ai-gateway/README.md
+++ b/packages/xinity-ai-gateway/README.md
@@ -58,7 +58,7 @@ When extending or modifying the OpenAI-compatible routes, update the hand-author
 | `RESPONSE_CACHE_TTL_SECONDS` | `3600` | Responses API Redis cache TTL |
 | `INFOSERVER_CACHE_TTL_MS` | `600000` | How long the local catalog snapshot is trusted before revalidating, in ms |
 | `METRICS_AUTH` | (unset) | Basic auth for `/metrics` (format: `user:pass`, comma-separated for multiple) |
-| `IDLE_TIMEOUT` | `255` | Server-level idle connection timeout in seconds |
+| `IDLE_TIMEOUT` | `255` | Server-level idle connection timeout in seconds (max 255, Bun's cap). Inference routes are exempt and bounded by `BACKEND_TIMEOUT_MS` instead, so a long generation is not cut off mid-request. |
 
 ### S3 (image storage)
 

--- a/packages/xinity-ai-gateway/src/gatewayServer.ts
+++ b/packages/xinity-ai-gateway/src/gatewayServer.ts
@@ -15,6 +15,7 @@ import { handleCreateResponseRequest, handleGetOrDeleteResponseRequest, handleCa
 import { handleRerank } from "./llm-forward/endpoints/handle-rerank";
 import { handleTranscription } from "./llm-forward/endpoints/handle-transcription";
 import { handleMetrics, withMetrics } from "./metrics";
+import { LONG_RUNNING_ROUTES, withoutConnectionTimeout, type RouteHandler } from "./serve-config";
 import { getTlsConfig } from "common-env";
 import { logMigrationFailureFatal } from "common-db";
 import { getSearchProvider } from "./llm-forward/tools/search-providers";
@@ -54,7 +55,7 @@ const handler = new OpenAPIHandler(serverRouter, {
 const tls = getTlsConfig(env);
 setSearchProvider(getSearchProvider(env));
 
-const meteredEndpoints: Array<[string, (req: Request) => Promise<Response> | Response]> = [
+const meteredEndpoints: Array<[string, RouteHandler]> = [
   ["/v1/chat/completions", handleChatCompletion],
   ["/v1/completions", handleCompletion],
   ["/v1/embeddings", handleEmbeddingGeneration],
@@ -68,7 +69,10 @@ const meteredEndpoints: Array<[string, (req: Request) => Promise<Response> | Res
 ];
 
 const meteredRoutes = Object.fromEntries(
-  meteredEndpoints.map(([path, handler]) => [path, withMetrics(path, handler)]),
+  meteredEndpoints.map(([path, handler]) => [
+    path,
+    withMetrics(path, LONG_RUNNING_ROUTES.has(path) ? withoutConnectionTimeout(handler) : handler),
+  ]),
 );
 
 const serveOptions = {

--- a/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-responses.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/endpoints/handle-responses.ts
@@ -5,6 +5,7 @@ import { deleteResponse, getResponse, getResponseMessages, saveResponse, type Re
 import { rootLogger } from "../../logger";
 import { processMessageImages, restoreMessageImages, imageStore } from "../../image-store";
 import { env } from "../../env";
+import { createIdleTimeout, type IdleTimeout } from "../backend-fetch";
 import { DEEP_RESEARCH_SYSTEM_PROMPT, createCompactionStep } from "../deep-research";
 import { hasSearchProvider } from "../tools/response-tools";
 import { CreateResponseBodySchema, type CreateResponseBody, type ResponseObject } from "../responses/schemas";
@@ -203,7 +204,7 @@ async function runInBackground(prepared: PreparedRequest, genParams: GenerationP
   return Response.json(baseResponse, { status: 202 });
 }
 
-async function runStreaming(prepared: PreparedRequest, genParams: GenerationParams): Promise<Response> {
+async function runStreaming(prepared: PreparedRequest, genParams: GenerationParams, idle?: IdleTimeout): Promise<Response> {
   const { auth, body, originalModel, responseId, createdAt, include, logFields, creation } = prepared;
 
   const toolCalls: ToolCallItem[] = [];
@@ -214,7 +215,9 @@ async function runStreaming(prepared: PreparedRequest, genParams: GenerationPara
     result: streamText(genParams),
     orgId: auth.orgId, responseId, messageItemId: `msg_${responseId}`, createdAt, originalModel, body,
     baseResponse, toolCalls, toolResults, include,
+    onChunk: idle?.reset,
     onFinished: (usage, text) => {
+      idle?.clear();
       logChatUsage({
         ...logFields,
         usage,
@@ -255,15 +258,21 @@ export async function handleCreateResponseRequest(req: Request): Promise<Respons
     }
 
     const { body, modelInfo, provider, messagesForLLM, activeTools, hasTools, outputConfig } = prepared;
-    const genParams = buildGenerationParams(
-      body, modelInfo, provider, toModelMessages(messagesForLLM), activeTools, hasTools, outputConfig, req.signal,
-    );
+    const messages = toModelMessages(messagesForLLM);
+    const paramsWith = (signal: AbortSignal) =>
+      buildGenerationParams(body, modelInfo, provider, messages, activeTools, hasTools, outputConfig, signal);
 
+    // Background generation outlives the request that started it, so it takes no request-scoped deadline.
     if (body.background) {
-      return runInBackground(prepared, genParams);
+      return runInBackground(prepared, paramsWith(req.signal));
     }
+
+    const idle = body.stream ? createIdleTimeout() : undefined;
+    const timeoutSignal = idle?.signal ?? AbortSignal.timeout(env.BACKEND_TIMEOUT_MS);
+    const genParams = paramsWith(AbortSignal.any([req.signal, timeoutSignal]));
+
     if (body.stream) {
-      return runStreaming(prepared, genParams);
+      return runStreaming(prepared, genParams, idle);
     }
     return runBlocking(prepared, genParams);
   } catch (error) {

--- a/packages/xinity-ai-gateway/src/llm-forward/responses/stream.ts
+++ b/packages/xinity-ai-gateway/src/llm-forward/responses/stream.ts
@@ -70,6 +70,8 @@ export type StreamResponseParams = {
   toolResults: ToolResultData[];
   include: IncludeValue[];
   onFinished: (usage: LanguageModelUsage, text: string) => void;
+  /** called on every stream part, so a caller's idle timeout can be reset */
+  onChunk?: () => void;
 }
 
 /**
@@ -79,7 +81,7 @@ export type StreamResponseParams = {
 export function createResponseStream(params: StreamResponseParams): ReadableStream {
   const {
     result, orgId, responseId, messageItemId, createdAt, originalModel, body,
-    baseResponse, toolCalls, toolResults, include, onFinished,
+    baseResponse, toolCalls, toolResults, include, onFinished, onChunk,
   } = params;
 
   return new ReadableStream({
@@ -121,6 +123,7 @@ export function createResponseStream(params: StreamResponseParams): ReadableStre
         emitResponseLifecycle(controller, "response.in_progress", baseResponse, seq);
 
         for await (const part of result.fullStream) {
+          onChunk?.();
           if (part.type === "reasoning-start") {
             closeReasoningBlock();
             openReasoningBlock();

--- a/packages/xinity-ai-gateway/src/metrics.ts
+++ b/packages/xinity-ai-gateway/src/metrics.ts
@@ -8,8 +8,10 @@ import {
   processMetrics,
   serializeMetrics,
 } from "common-env";
+import type { Server } from "bun";
 import { version } from "../../../package.json";
 import { env } from "./env";
+import type { RouteHandler } from "./serve-config";
 import { releaseCallbacks } from "./llm-forward/release-registry";
 import { isAbortError } from "./llm-forward/util";
 import { rootLogger } from "./logger";
@@ -203,9 +205,9 @@ export function recordBackendError(model: string, status: number): void {
 
 export function withMetrics(
   endpoint: string,
-  handler: (req: Request) => Promise<Response> | Response,
-): (req: Request) => Promise<Response> {
-  return async (req: Request) => {
+  handler: RouteHandler,
+): (req: Request, server: Server<unknown>) => Promise<Response> {
+  return async (req: Request, server: Server<unknown>) => {
     const labels = { endpoint };
     const httpLabels = { method: req.method, route: endpoint };
     http.started(httpLabels);
@@ -220,7 +222,7 @@ export function withMetrics(
 
     let deferred = false;
     try {
-      const res = await handler(req);
+      const res = await handler(req, server);
       status = res.status;
       if (res.status === 499) clientDisconnectsTotal.inc(labels);
 

--- a/packages/xinity-ai-gateway/src/serve-config.ts
+++ b/packages/xinity-ai-gateway/src/serve-config.ts
@@ -7,6 +7,7 @@ export const LONG_RUNNING_ROUTES = new Set([
   "/v1/chat/completions",
   "/v1/completions",
   "/v1/audio/transcriptions",
+  "/v1/responses",
 ]);
 
 /** lifts the connection timeout for one request; bun clamps per-request values to the 255s cap, so 0 is the only value that works */

--- a/packages/xinity-ai-gateway/src/serve-config.ts
+++ b/packages/xinity-ai-gateway/src/serve-config.ts
@@ -1,0 +1,18 @@
+import type { Server } from "bun";
+
+export type RouteHandler = (req: Request, server: Server<unknown>) => Promise<Response> | Response;
+
+/** paths whose backend generation can outrun bun's 255s connection cap, and are bounded by BACKEND_TIMEOUT_MS instead */
+export const LONG_RUNNING_ROUTES = new Set([
+  "/v1/chat/completions",
+  "/v1/completions",
+  "/v1/audio/transcriptions",
+]);
+
+/** lifts the connection timeout for one request; bun clamps per-request values to the 255s cap, so 0 is the only value that works */
+export function withoutConnectionTimeout(handler: RouteHandler): RouteHandler {
+  return (req, server) => {
+    server.timeout(req, 0);
+    return handler(req, server);
+  };
+}


### PR DESCRIPTION
## Description

Deployments counted replicas on nodes that had been removed or powered off. I.e. on a two-node instance where two other nodes were once registered, but now disabled one deployment reported 4 ready replicas.

Installation state rows are only written by a daemon reporting in, so a departed node keeps its last
`ready` forever. The availablility of the node itself though is recorded, the gateway is ready to react to that, and the dashboard displaying the replicas should too, but didn't.  
Both now filter at read time, so a powered-off node recovers on its own once it reconnects. Capacity warnings had the
same bug, where used capacity counted every installation but total capacity counted only live nodes.  

Separately integrated as part of this PR: Bun caps `idleTimeout` at 255s and it fired before the gateway's own 300s `BACKEND_TIMEOUT_MS` could apply for long running inference routes.  
These specific routes now lift the connection timeout per request and rely on the
application bound instead. `/v1/responses` had no such bound, so it got one.

## Type of change

Bug fix

## Testing

Added coverage for the replica bug on both affected read paths: `scheduler.test.ts`, and a new
`deployment-status.test.ts`.

The timeout change is not automated, because it only manifests past 255s and a test for it does not
belong in CI.  
Verified by hand against a live server at the production `idleTimeout: 255`. An
exempted route completed a 290s request, a non-exempt one was killed at 256s.

## Checklist

- [x] Tests pass locally (`bun test`), or no testable code was changed
- [x] New or changed behavior is covered by tests, or this change does not require tests
- [x] Documentation is updated, or no user-facing behavior or configuration was changed
- [x] There are no breaking changes, or they are marked with `!` in the commit type and described above
- [x] No security-sensitive changes (authentication, credentials, input handling), or they have been reviewed
- [x] No new dependencies were added, or they have been reviewed for license and maintenance status